### PR TITLE
Reduce the strictness of T -> bool checking, define always as x != 0

### DIFF
--- a/src/dynd/kernels/single_assigner_builtin.hpp
+++ b/src/dynd/kernels/single_assigner_builtin.hpp
@@ -91,7 +91,7 @@ struct single_assigner_builtin_base<double, dynd_complex<src_real_type>, real_ki
 };
 
 
-// Anything -> boolean with no checking
+// Anything -> boolean always means (Anything != 0), does not do overflow, etc checking
 template<class src_type, type_kind_t src_kind>
 struct single_assigner_builtin_base<dynd_bool, src_type, bool_kind, src_kind, assign_error_none>
 {
@@ -101,36 +101,16 @@ struct single_assigner_builtin_base<dynd_bool, src_type, bool_kind, src_kind, as
         *dst = (*src != src_type(0));
     }
 };
-
-// Anything -> boolean with overflow checking
 template<class src_type, type_kind_t src_kind>
 struct single_assigner_builtin_base<dynd_bool, src_type, bool_kind, src_kind, assign_error_overflow>
-{
-    static void assign(dynd_bool *dst, const src_type *src, ckernel_prefix *DYND_UNUSED(extra)) {
-        src_type s = *src;
-
-        DYND_TRACE_ASSIGNMENT((bool)(s != src_type(0)), dynd_bool, s, src_type);
-
-        if (s == src_type(0)) {
-            *dst = false;
-        } else if (s == src_type(1)) {
-            *dst = true;
-        } else {
-            std::stringstream ss;
-            ss << "overflow while assigning " << ndt::make_type<src_type>() << " value ";
-            ss << s << " to " << ndt::make_type<dynd_bool>();
-            throw std::overflow_error(ss.str());
-        }
-    }
-};
-
-// Anything -> boolean with other error checking
+    : public single_assigner_builtin_base<dynd_bool, src_type, bool_kind, src_kind, assign_error_none> {};
 template<class src_type, type_kind_t src_kind>
 struct single_assigner_builtin_base<dynd_bool, src_type, bool_kind, src_kind, assign_error_fractional>
-    : public single_assigner_builtin_base<dynd_bool, src_type, bool_kind, src_kind, assign_error_overflow> {};
+    : public single_assigner_builtin_base<dynd_bool, src_type, bool_kind, src_kind, assign_error_none> {};
 template<class src_type, type_kind_t src_kind>
 struct single_assigner_builtin_base<dynd_bool, src_type, bool_kind, src_kind, assign_error_inexact>
-    : public single_assigner_builtin_base<dynd_bool, src_type, bool_kind, src_kind, assign_error_overflow> {};
+    : public single_assigner_builtin_base<dynd_bool, src_type, bool_kind, src_kind, assign_error_none> {};
+
 
 // Boolean -> anything with other error checking
 template<class dst_type, type_kind_t dst_kind>

--- a/tests/array/test_array_assign.cpp
+++ b/tests/array/test_array_assign.cpp
@@ -28,33 +28,39 @@ TYPED_TEST_P(ArrayAssign, ScalarAssignment_Bool) {
 
     // assignment to a bool scalar
     a = nd::empty(TestFixture::First::MakeType(ndt::make_type<dynd_bool>()));
-    const dynd_bool *ptr_b = (const dynd_bool *)a.get_ndo()->m_data_pointer;
+    const dynd_bool *ptr_a = (const dynd_bool *)a.get_ndo()->m_data_pointer;
     a.val_assign(TestFixture::Second::To(true));
-    EXPECT_TRUE(TestFixture::First::Dereference(ptr_b));
+    EXPECT_TRUE(TestFixture::First::Dereference(ptr_a));
     a.val_assign(TestFixture::Second::To(false));
-    EXPECT_FALSE(TestFixture::First::Dereference(ptr_b));
+    EXPECT_FALSE(TestFixture::First::Dereference(ptr_a));
     a.val_assign(TestFixture::Second::To(1));
-    EXPECT_TRUE(TestFixture::First::Dereference(ptr_b));
+    EXPECT_TRUE(TestFixture::First::Dereference(ptr_a));
     a.val_assign(TestFixture::Second::To(0));
-    EXPECT_FALSE(TestFixture::First::Dereference(ptr_b));
+    EXPECT_FALSE(TestFixture::First::Dereference(ptr_a));
     a.val_assign(TestFixture::Second::To(1.0));
-    EXPECT_TRUE(TestFixture::First::Dereference(ptr_b));
+    EXPECT_TRUE(TestFixture::First::Dereference(ptr_a));
     a.val_assign(TestFixture::Second::To(0.0));
-    EXPECT_FALSE(TestFixture::First::Dereference(ptr_b));
+    EXPECT_FALSE(TestFixture::First::Dereference(ptr_a));
     a.val_assign(TestFixture::Second::To(1.5), assign_error_none);
-    EXPECT_TRUE(TestFixture::First::Dereference(ptr_b));
+    EXPECT_TRUE(TestFixture::First::Dereference(ptr_a));
     a.val_assign(TestFixture::Second::To(-3.5f), assign_error_none);
-    EXPECT_TRUE(TestFixture::First::Dereference(ptr_b));
+    EXPECT_TRUE(TestFixture::First::Dereference(ptr_a));
     a.val_assign(TestFixture::Second::To(22), assign_error_none);
-    EXPECT_TRUE(TestFixture::First::Dereference(ptr_b));
-    if (!TestFixture::First::IsTypeID(cuda_device_type_id) && !TestFixture::Second::IsTypeID(cuda_device_type_id)) {
-        EXPECT_THROW(a.val_assign(TestFixture::Second::To(2)), runtime_error);
-        EXPECT_THROW(a.val_assign(TestFixture::Second::To(-1)), runtime_error);
-        EXPECT_THROW(a.val_assign(TestFixture::Second::To(1.5)), runtime_error);
-        EXPECT_THROW(a.val_assign(TestFixture::Second::To(1.5), assign_error_overflow), runtime_error);
-        EXPECT_THROW(a.val_assign(TestFixture::Second::To(1.5), assign_error_fractional), runtime_error);
-        EXPECT_THROW(a.val_assign(TestFixture::Second::To(1.5), assign_error_inexact), runtime_error);
-    }
+    EXPECT_TRUE(TestFixture::First::Dereference(ptr_a));
+    // As a special rule, any conversion to bool is defined as x != 0
+    // even in the more strict assignment error modes
+    a.val_assign(TestFixture::Second::To(2));
+    EXPECT_TRUE(TestFixture::First::Dereference(ptr_a));
+    a.val_assign(TestFixture::Second::To(-1));
+    EXPECT_TRUE(TestFixture::First::Dereference(ptr_a));
+    a.val_assign(TestFixture::Second::To(1.5));
+    EXPECT_TRUE(TestFixture::First::Dereference(ptr_a));
+    a.val_assign(TestFixture::Second::To(1.5), assign_error_overflow);
+    EXPECT_TRUE(TestFixture::First::Dereference(ptr_a));
+    a.val_assign(TestFixture::Second::To(1.5), assign_error_fractional);
+    EXPECT_TRUE(TestFixture::First::Dereference(ptr_a));
+    a.val_assign(TestFixture::Second::To(1.5), assign_error_inexact);
+    EXPECT_TRUE(TestFixture::First::Dereference(ptr_a));
 }
 
 TYPED_TEST_P(ArrayAssign, ScalarAssignment_Int8) {

--- a/tests/types/test_type_assign.cpp
+++ b/tests/types/test_type_assign.cpp
@@ -191,7 +191,7 @@ TEST(DTypeAssign, FixedSizeTests_Int8) {
 #define ONE_TEST(tid, v, m) \
             typed_data_assign(ndt::type(tid), NULL, (char *)&v, s_dt, NULL, s_ptr); \
             EXPECT_EQ(m, v)
-    EXPECT_THROW(typed_data_assign(ndt::type(bool_type_id), NULL, (char *)&v_b, s_dt, NULL, s_ptr), runtime_error);
+    ONE_TEST(bool_type_id, v_b, true);
     ONE_TEST(int16_type_id, v_i16, 127);
     ONE_TEST(int32_type_id, v_i32, 127);
     ONE_TEST(int64_type_id, v_i64, 127);
@@ -205,14 +205,17 @@ TEST(DTypeAssign, FixedSizeTests_Int8) {
     ONE_TEST(complex_float64_type_id, v_cf64, dynd_complex<double>(127));
 #undef ONE_TEST
 
-    // Test int8 -> bool variants
+    // As a special rule, conversion of int8 -> bool always means (value != 0)
     v_i8 = -33;
-    EXPECT_THROW(typed_data_assign(ndt::type(bool_type_id), NULL, (char *)&v_b, s_dt, NULL, s_ptr), runtime_error);
+    typed_data_assign(ndt::type(bool_type_id), NULL, (char *)&v_b, s_dt, NULL, s_ptr);
+    EXPECT_TRUE(v_b);
     v_i8 = -1;
-    EXPECT_THROW(typed_data_assign(ndt::type(bool_type_id), NULL, (char *)&v_b, s_dt, NULL, s_ptr), runtime_error);
+    typed_data_assign(ndt::type(bool_type_id), NULL, (char *)&v_b, s_dt, NULL, s_ptr);
+    EXPECT_TRUE(v_b);
     EXPECT_THROW(typed_data_assign(ndt::type(uint8_type_id), NULL, (char *)&v_u8, s_dt, NULL, s_ptr), runtime_error);
     v_i8 = 2;
-    EXPECT_THROW(typed_data_assign(ndt::type(bool_type_id), NULL, (char *)&v_b, s_dt, NULL, s_ptr), runtime_error);
+    typed_data_assign(ndt::type(bool_type_id), NULL, (char *)&v_b, s_dt, NULL, s_ptr);
+    EXPECT_TRUE(v_b);
     v_i8 = 0;
     typed_data_assign(ndt::type(bool_type_id), NULL, (char *)&v_b, s_dt, NULL, s_ptr);
     EXPECT_FALSE(v_b);
@@ -250,7 +253,7 @@ TEST(DTypeAssign, FixedSizeTests_Float64) {
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), (char *)&v, s_dt, s_ptr, assign_error_overflow), runtime_error);
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), (char *)&v, s_dt, s_ptr, assign_error_fractional), runtime_error);
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), (char *)&v, s_dt, s_ptr, assign_error_inexact), runtime_error)
-    ONE_TEST_THROW(bool_type_id, v_b);
+    ONE_TEST(bool_type_id, v_b, true);
     ONE_TEST_THROW(int8_type_id, v_i8);
     ONE_TEST_THROW(int16_type_id, v_i16);
     ONE_TEST_THROW(int32_type_id, v_i32);
@@ -381,7 +384,7 @@ TEST(DTypeAssign, FixedSizeTests_Complex_Float32) {
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), &v, s_dt, s_ptr, assign_error_overflow), runtime_error);
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), &v, s_dt, s_ptr, assign_error_fractional), runtime_error);
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), &v, s_dt, s_ptr, assign_error_inexact), runtime_error)
-    ONE_TEST_THROW(bool_type_id, v_b);
+    ONE_TEST(bool_type_id, v_b, true);
     ONE_TEST(int8_type_id, v_i8, 2);
     ONE_TEST(int16_type_id, v_i16, 2);
     ONE_TEST(int32_type_id, v_i32, 2);
@@ -407,7 +410,7 @@ TEST(DTypeAssign, FixedSizeTests_Complex_Float32) {
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), &v, s_dt, s_ptr, assign_error_overflow), runtime_error);
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), &v, s_dt, s_ptr, assign_error_fractional), runtime_error);
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), &v, s_dt, s_ptr, assign_error_inexact), runtime_error)
-    ONE_TEST_THROW(bool_type_id, v_b);
+    ONE_TEST(bool_type_id, v_b, true);
     ONE_TEST(int8_type_id, v_i8, -1);
     ONE_TEST(int16_type_id, v_i16, -1);
     ONE_TEST(int32_type_id, v_i32, -1);
@@ -433,7 +436,7 @@ TEST(DTypeAssign, FixedSizeTests_Complex_Float32) {
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), &v, s_dt, s_ptr, assign_error_overflow), runtime_error);
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), &v, s_dt, s_ptr, assign_error_fractional), runtime_error);
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), &v, s_dt, s_ptr, assign_error_inexact), runtime_error)
-    ONE_TEST_THROW(bool_type_id, v_b);
+    ONE_TEST(bool_type_id, v_b, true);
     ONE_TEST_THROW(int8_type_id, v_i8);
     ONE_TEST_THROW(int16_type_id, v_i16);
     ONE_TEST_THROW(int32_type_id, v_i32);
@@ -459,7 +462,7 @@ TEST(DTypeAssign, FixedSizeTests_Complex_Float32) {
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), &v, s_dt, s_ptr, assign_error_overflow), runtime_error);
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), &v, s_dt, s_ptr, assign_error_fractional), runtime_error);
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), &v, s_dt, s_ptr, assign_error_inexact), runtime_error)
-    ONE_TEST_THROW(bool_type_id, v_b);
+    ONE_TEST(bool_type_id, v_b, true);
     ONE_TEST_THROW(int8_type_id, v_i8);
     ONE_TEST_THROW(int16_type_id, v_i16);
     ONE_TEST_THROW(int32_type_id, v_i32);
@@ -485,7 +488,7 @@ TEST(DTypeAssign, FixedSizeTests_Complex_Float32) {
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), &v, s_dt, s_ptr, assign_error_overflow), runtime_error);
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), &v, s_dt, s_ptr, assign_error_fractional), runtime_error);
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), &v, s_dt, s_ptr, assign_error_inexact), runtime_error)
-    ONE_TEST_THROW(bool_type_id, v_b);
+    ONE_TEST(bool_type_id, v_b, true);
     ONE_TEST_THROW(int8_type_id, v_i8);
     ONE_TEST_THROW(int16_type_id, v_i16);
     ONE_TEST_THROW(int32_type_id, v_i32);
@@ -576,7 +579,7 @@ TEST(DTypeAssign, FixedSizeTests_Complex_Float64) {
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), (char *)&v, s_dt, s_ptr, assign_error_overflow), runtime_error);
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), (char *)&v, s_dt, s_ptr, assign_error_fractional), runtime_error);
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), (char *)&v, s_dt, s_ptr, assign_error_inexact), runtime_error)
-    ONE_TEST_THROW(bool_type_id, v_b);
+    ONE_TEST(bool_type_id, v_b, true);
     ONE_TEST(int8_type_id, v_i8, 2);
     ONE_TEST(int16_type_id, v_i16, 2);
     ONE_TEST(int32_type_id, v_i32, 2);
@@ -602,7 +605,7 @@ TEST(DTypeAssign, FixedSizeTests_Complex_Float64) {
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), (char *)&v, s_dt, s_ptr, assign_error_overflow), runtime_error);
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), (char *)&v, s_dt, s_ptr, assign_error_fractional), runtime_error);
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), (char *)&v, s_dt, s_ptr, assign_error_inexact), runtime_error)
-    ONE_TEST_THROW(bool_type_id, v_b);
+    ONE_TEST(bool_type_id, v_b, true);
     ONE_TEST(int8_type_id, v_i8, -1);
     ONE_TEST(int16_type_id, v_i16, -1);
     ONE_TEST(int32_type_id, v_i32, -1);
@@ -628,7 +631,7 @@ TEST(DTypeAssign, FixedSizeTests_Complex_Float64) {
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), (char *)&v, s_dt, s_ptr, assign_error_overflow), runtime_error);
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), (char *)&v, s_dt, s_ptr, assign_error_fractional), runtime_error);
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), (char *)&v, s_dt, s_ptr, assign_error_inexact), runtime_error)
-    ONE_TEST_THROW(bool_type_id, v_b);
+    ONE_TEST(bool_type_id, v_b, true);
     ONE_TEST_THROW(int8_type_id, v_i8);
     ONE_TEST_THROW(int16_type_id, v_i16);
     ONE_TEST_THROW(int32_type_id, v_i32);
@@ -654,7 +657,7 @@ TEST(DTypeAssign, FixedSizeTests_Complex_Float64) {
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), (char *)&v, s_dt, s_ptr, assign_error_overflow), runtime_error);
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), (char *)&v, s_dt, s_ptr, assign_error_fractional), runtime_error);
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), (char *)&v, s_dt, s_ptr, assign_error_inexact), runtime_error)
-    ONE_TEST_THROW(bool_type_id, v_b);
+    ONE_TEST(bool_type_id, v_b, true);
     ONE_TEST_THROW(int8_type_id, v_i8);
     ONE_TEST_THROW(int16_type_id, v_i16);
     ONE_TEST_THROW(int32_type_id, v_i32);
@@ -680,7 +683,7 @@ TEST(DTypeAssign, FixedSizeTests_Complex_Float64) {
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), (char *)&v, s_dt, s_ptr, assign_error_overflow), runtime_error);
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), (char *)&v, s_dt, s_ptr, assign_error_fractional), runtime_error);
 //            EXPECT_THROW(typed_data_assign(ndt::type(tid), (char *)&v, s_dt, s_ptr, assign_error_inexact), runtime_error)
-    ONE_TEST_THROW(bool_type_id, v_b);
+    ONE_TEST(bool_type_id, v_b, true);
     ONE_TEST_THROW(int8_type_id, v_i8);
     ONE_TEST_THROW(int16_type_id, v_i16);
     ONE_TEST_THROW(int32_type_id, v_i32);


### PR DESCRIPTION
This is to mirror a change in Blaze/DataShape where we are allowing
T -> bool implicit conversions, but disallowing bool -> T for T
different from bool.
