### PR TITLE
Optimize the json parser a bit by avoiding dynamic string creation

### DIFF
--- a/include/dynd/types/base_struct_type.hpp
+++ b/include/dynd/types/base_struct_type.hpp
@@ -43,6 +43,8 @@ public:
      *           of the given name.
      */
     virtual intptr_t get_field_index(const std::string& field_name) const = 0;
+    intptr_t get_field_index(const char *field_index_begin,
+                             const char *field_index_end) const;
 
     size_t get_elwise_property_index(const std::string& property_name) const;
     ndt::type get_elwise_property_type(size_t elwise_property_index,

--- a/src/dynd/types/base_struct_type.cpp
+++ b/src/dynd/types/base_struct_type.cpp
@@ -15,6 +15,23 @@ using namespace dynd;
 base_struct_type::~base_struct_type() {
 }
 
+intptr_t base_struct_type::get_field_index(const char *field_index_begin,
+                                           const char *field_index_end) const
+{
+    size_t size = field_index_end - field_index_begin;
+    size_t field_count = get_field_count();
+    const string *field_names = get_field_names();
+    for (size_t i = 0; i != field_count; ++i) {
+        if (field_names[i].size() == size) {
+            if (memcmp(field_names[i].data(), field_index_begin, size) == 0) {
+                return i;
+            }
+        }
+    }
+
+    return -1;
+}
+
 size_t base_struct_type::get_elwise_property_index(const std::string& property_name) const
 {
     size_t field_count = get_field_count();


### PR DESCRIPTION
This change took parsing of a test 44MB json file from 1.2 seconds to
0.8 seconds.
