### PR TITLE
Change datetime parsing of abstract tz to ignore the input's tz

### DIFF
--- a/include/dynd/types/datetime_parser.hpp
+++ b/include/dynd/types/datetime_parser.hpp
@@ -19,7 +19,6 @@ struct datetime_struct;
  *
  * \param begin  The start of the UTF-8 buffer to parse.
  * \param end  One past the last character of the buffer to parse.
- * \param out_dt  The datetime to fill.
  * \param ambig  Order to use for ambiguous cases like "01/02/03"
  *               or "01/02/1995".
  * \param century_window  Number describing how to handle dates with
@@ -28,12 +27,18 @@ struct datetime_struct;
  *                        Values 1000 and higher mean to use a fixed window
  *                        starting at the year given. The value 0 means to
  *                        disallow two digit years.
+ * \param out_dt  The datetime to fill.
+ * \param out_tz_begin  If a timezone is parsed, this is set to the beginning of
+ *                      matched timezone.
+ * \param out_tz_end  If a timezone is parsed, this is set to the end of
+ *                    matched timezone.
  *
  * \returns  True if the parse is successful, false otherwise.
  */
 bool string_to_datetime(const char *begin, const char *end,
-                        datetime_struct &out_dt, date_parse_order_t ambig,
-                        int century_window, assign_error_mode errmode);
+                        date_parse_order_t ambig, int century_window,
+                        assign_error_mode errmode, datetime_struct &out_dt,
+                        const char *&out_tz_begin, const char *&out_tz_end);
 
 namespace parse {
 
@@ -43,7 +48,6 @@ namespace parse {
      * \param begin  The start of a range of UTF-8 characters. This is modified
      *               to point immediately after the parsed datetime if true is returned.
      * \param end  The end of a range of UTF-8 characters.
-     * \param out_dt  The datetime to fill.
      * \param ambig  Order to use for ambiguous cases like "01/02/03"
      *               or "01/02/1995".
      * \param century_window  Number describing how to handle dates with
@@ -52,12 +56,18 @@ namespace parse {
      *                        Values 1000 and higher mean to use a fixed window
      *                        starting at the year given. The value 0 means to
      *                        disallow two digit years.
+     * \param out_dt  The datetime to fill.
+     * \param out_tz_begin  If a timezone is parsed, this is set to the beginning of
+     *                      matched timezone.
+     * \param out_tz_end  If a timezone is parsed, this is set to the end of
+     *                    matched timezone.
      *
      * \returns  True if a datetime was parsed successfully, false otherwise.
      */
     bool parse_datetime(const char *&begin, const char *end,
-                        datetime_struct &out_dt, date_parse_order_t ambig,
-                        int century_window);
+                        date_parse_order_t ambig, int century_window,
+                        datetime_struct &out_dt, const char *&out_tz_begin,
+                        const char *&out_tz_end);
 
 } // namespace parse
 

--- a/include/dynd/types/datetime_util.hpp
+++ b/include/dynd/types/datetime_util.hpp
@@ -93,20 +93,25 @@ struct datetime_struct {
      * \param errmode  The error mode to use for how strict to be when converting
      *                 values. In mode assign_error_none, tries to do a "best interpretation"
      *                 conversion.
+     *
+     * \returns  The time zone, if any, found in the string
      */
-    inline void
+    inline std::string
     set_from_str(const std::string &s,
                  date_parse_order_t ambig = date_parse_no_ambig,
                  int century_window = 70,
                  assign_error_mode errmode = assign_error_fractional)
     {
+        const char *tz_begin = NULL, *tz_end = NULL;
         set_from_str(s.data(), s.data() + s.size(), ambig, century_window,
-                     errmode);
+                     errmode, tz_begin, tz_end);
+        return std::string(tz_begin, tz_end);
     }
 
     void set_from_str(const char *begin, const char *end,
                       date_parse_order_t ambig, int century_window,
-                      assign_error_mode errmode);
+                      assign_error_mode errmode, const char *&out_tz_begin,
+                      const char *&out_tz_end);
 
     /**
      * Returns an ndt::type corresponding to the datetime_struct structure.

--- a/include/dynd/types/time_parser.hpp
+++ b/include/dynd/types/time_parser.hpp
@@ -18,15 +18,54 @@ struct time_hmst;
  * \param begin  The start of the UTF-8 buffer to parse.
  * \param end  One past the last character of the buffer to parse.
  * \param out_hmst  The time to fill.
+ * \param out_tz_begin  If a timezone is parsed, this is set to the beginning of
+ *                      matched timezone.
+ * \param out_tz_end  If a timezone is parsed, this is set to the end of
+ *                    matched timezone.
  *
  * \returns  True if the parse is successful, false otherwise.
  */
-bool string_to_time(const char *begin, const char *end, time_hmst &out_hmst);
+bool string_to_time(const char *begin, const char *end, time_hmst &out_hmst,
+                    const char *&out_tz_begin, const char *&out_tz_end);
 
 namespace parse {
 
     /**
-     * Parses a time
+     * Parses a time zone specifier.
+     *
+     * \param begin  The start of a range of UTF-8 characters. This is modified
+     *               to point immediately after the parsed time if true is returned.
+     * \param end  The end of a range of UTF-8 characters.
+     *
+     * \param out_tz_begin  If a timezone is parsed, this is set to the beginning of
+     *                      matched timezone.
+     * \param out_tz_end  If a timezone is parsed, this is set to the end of
+     *                    matched timezone.
+     *
+     * \returns  True if a time zone was parsed successfully, false otherwise.
+     */
+    bool parse_timezone(const char *&begin, const char *end,
+                        const char *&out_tz_begin, const char *&out_tz_end);
+
+    /**
+     * Parses a time, possibly including a time zone
+     *
+     * \param begin  The start of a range of UTF-8 characters. This is modified
+     *               to point immediately after the parsed time if true is returned.
+     * \param end  The end of a range of UTF-8 characters.
+     * \param out_hmst  The time to fill.
+     * \param out_tz_begin  If a timezone is parsed, this is set to the beginning of
+     *                      matched timezone.
+     * \param out_tz_end  If a timezone is parsed, this is set to the end of
+     *                    matched timezone.
+     *
+     * \returns  True if a time was parsed successfully, false otherwise.
+     */
+    bool parse_time(const char *&begin, const char *end, time_hmst &out_hmst,
+                    const char *&out_tz_begin, const char *&out_tz_end);
+
+    /**
+     * Parses a time without a time zone.
      *
      * \param begin  The start of a range of UTF-8 characters. This is modified
      *               to point immediately after the parsed time if true is returned.
@@ -35,7 +74,8 @@ namespace parse {
      *
      * \returns  True if a time was parsed successfully, false otherwise.
      */
-    bool parse_time(const char *&begin, const char *end, time_hmst &out_hmst);
+    bool parse_time_no_tz(const char *&begin, const char *end,
+                          time_hmst &out_hmst);
 
     /**
      * Without skipping whitespace, parses an AM/PM indicator string and modifies

--- a/include/dynd/types/time_util.hpp
+++ b/include/dynd/types/time_util.hpp
@@ -90,14 +90,19 @@ struct time_hmst {
     inline void set_to_na() {
         hour = -128;
     }
-    void set_from_str(const char *begin, const char *end);
+    void set_from_str(const char *begin, const char *end,
+                      const char *&out_tz_begin, const char *&out_tz_end);
     /**
      * Sets the hmst from a string.
      *
      * \param s  Date string.
+     *
+     * \returns  The time zone, if any, found in the string
      */
-    inline void set_from_str(const std::string& s) {
-        set_from_str(s.data(), s.data() + s.size());
+    inline std::string set_from_str(const std::string& s) {
+        const char *tz_begin = NULL, *tz_end = NULL;
+        set_from_str(s.data(), s.data() + s.size(), tz_begin, tz_end);
+        return std::string(tz_begin, tz_end);
     }
 
 

--- a/src/dynd/types/datetime_util.cpp
+++ b/src/dynd/types/datetime_util.cpp
@@ -23,10 +23,12 @@ std::string datetime_struct::to_str() const
 
 void datetime_struct::set_from_str(const char *begin, const char *end,
                                    date_parse_order_t ambig, int century_window,
-                                   assign_error_mode errmode)
+                                   assign_error_mode errmode,
+                                   const char *&out_tz_begin,
+                                   const char *&out_tz_end)
 {
-    if (!string_to_datetime(begin, end, *this, ambig,
-                            century_window, errmode)) {
+    if (!string_to_datetime(begin, end, ambig, century_window, errmode, *this,
+                            out_tz_begin, out_tz_end)) {
         stringstream ss;
         ss << "Unable to parse ";
         print_escaped_utf8_string(ss, begin, end);

--- a/src/dynd/types/time_util.cpp
+++ b/src/dynd/types/time_util.cpp
@@ -74,9 +74,10 @@ void time_hmst::set_from_ticks(int64_t ticks)
     }
 }
 
-void time_hmst::set_from_str(const char *begin, const char *end)
+void time_hmst::set_from_str(const char *begin, const char *end,
+                             const char *&out_tz_begin, const char *&out_tz_end)
 {
-    if (!string_to_time(begin, end, *this)) {
+    if (!string_to_time(begin, end, *this, out_tz_begin, out_tz_end)) {
         stringstream ss;
         ss << "Unable to parse ";
         print_escaped_utf8_string(ss, begin, end);

--- a/tests/types/test_datetime_type.cpp
+++ b/tests/types/test_datetime_type.cpp
@@ -74,10 +74,12 @@ TEST(DateTimeDType, ValueCreationAbstract) {
     EXPECT_EQ((((1600-1970)*365 - (1972-1600)/4 + 3 + 366) * 1440LL) * 60 * 10000000LL,
                     nd::array("1601-01-01T00").ucast(d).view_scalars(di).as<int64_t>());
 
-    // Parsing Zulu timezone as abstract raises an error
-    EXPECT_THROW(nd::array("2000-01-01T03:00Z").ucast(d).eval(), invalid_argument);
-    // Parsing specified timezone as abstract raises an error
-    EXPECT_THROW(nd::array("2000-01-01T03:00+0300").ucast(d).eval(), invalid_argument);
+    // Parsing Zulu timezone as abstract works ok (throws away time zone)
+    EXPECT_EQ("2000-01-01T03:00",
+              nd::array("2000-01-01T03:00Z").ucast(d).eval().as<string>());
+    // Parsing specified timezone as abstract works ok (throws away time zone)
+    EXPECT_EQ("2000-01-01T03:00",
+              nd::array("2000-01-01T03:00+0300").ucast(d).eval().as<string>());
 
     // Parsing Zulu timezone as abstract with no error checking works though
 //    EXPECT_EQ((((1600-1970)*365 - (1972-1600)/4 + 3) * 1440LL + 15 * 60 + 45) * 60 * 10000000LL,


### PR DESCRIPTION
Previously this would error, now the time zone information is thrown away:

```
In [1]: from dynd import nd, ndt

In [2]: nd.array('2010-03-04T16:32+07:00', ndt.datetime)
Out[2]: nd.array(2010-03-04T16:32, type="datetime")

In [3]: nd.array('2010-03-04T16:32Z', ndt.datetime)
Out[3]: nd.array(2010-03-04T16:32, type="datetime")
```
