### PR TITLE
Change the interface/default idiom of ckernel creation slightly

### DIFF
--- a/include/dynd/func/elwise_callrefres.hpp
+++ b/include/dynd/func/elwise_callrefres.hpp
@@ -68,11 +68,11 @@ namespace detail {
                     const char *const *DYND_UNUSED(src_arrmeta), kernel_request_t kernreq, \
                     const eval::eval_context *DYND_UNUSED(ectx)) \
         { \
-            extra_type *e = ckb->get_at<extra_type>(ckb_offset); \
-            e->base.template set_expr_function<extra_type>((kernel_request_t)kernreq); \
+            extra_type *e = ckb->alloc_ck_leaf<extra_type>(ckb_offset); \
+            e->base.template set_expr_function<extra_type>(kernreq); \
             e->obj = *af_self->get_data_as<const T *>(); \
 \
-            return ckb_offset + sizeof(extra_type); \
+            return ckb_offset; \
         } \
     };
 

--- a/include/dynd/func/elwise_callretres.hpp
+++ b/include/dynd/func/elwise_callretres.hpp
@@ -68,11 +68,11 @@ namespace detail {
                     const char *const *DYND_UNUSED(src_arrmeta), kernel_request_t kernreq, \
                     const eval::eval_context *DYND_UNUSED(ectx)) \
         { \
-            extra_type *e = ckb->get_at<extra_type>(ckb_offset); \
-            e->base.template set_expr_function<extra_type>((kernel_request_t)kernreq); \
+            extra_type *e = ckb->alloc_ck_leaf<extra_type>(ckb_offset); \
+            e->base.template set_expr_function<extra_type>(kernreq); \
             e->obj = *af_self->get_data_as<const T *>(); \
 \
-            return ckb_offset + sizeof(extra_type); \
+            return ckb_offset; \
         } \
     };
 

--- a/include/dynd/func/elwise_funcrefres.hpp
+++ b/include/dynd/func/elwise_funcrefres.hpp
@@ -68,11 +68,11 @@ namespace detail {
                     const char *const *DYND_UNUSED(src_arrmeta), kernel_request_t kernreq, \
                     const eval::eval_context *DYND_UNUSED(ectx)) \
         { \
-            extra_type *e = ckb->get_at<extra_type>(ckb_offset); \
-            e->base.template set_expr_function<extra_type>((kernel_request_t)kernreq); \
+            extra_type *e = ckb->alloc_ck_leaf<extra_type>(ckb_offset); \
+            e->base.template set_expr_function<extra_type>(kernreq); \
             e->func = *af_self->get_data_as<func_type>(); \
 \
-            return ckb_offset + sizeof(extra_type); \
+            return ckb_offset; \
         } \
     };
 

--- a/include/dynd/func/elwise_funcretres.hpp
+++ b/include/dynd/func/elwise_funcretres.hpp
@@ -68,11 +68,11 @@ namespace detail {
                     const char *const *DYND_UNUSED(src_arrmeta), kernel_request_t kernreq, \
                     const eval::eval_context *DYND_UNUSED(ectx)) \
         { \
-            extra_type *e = ckb->get_at<extra_type>(ckb_offset); \
-            e->base.template set_expr_function<extra_type>((kernel_request_t)kernreq); \
+            extra_type *e = ckb->alloc_ck_leaf<extra_type>(ckb_offset); \
+            e->base.template set_expr_function<extra_type>(kernreq); \
             e->func = *af_self->get_data_as<func_type>(); \
 \
-            return ckb_offset + sizeof(extra_type); \
+            return ckb_offset; \
         } \
     };
 

--- a/include/dynd/func/elwise_methrefres.hpp
+++ b/include/dynd/func/elwise_methrefres.hpp
@@ -70,14 +70,14 @@ namespace detail {
                     const char *const *DYND_UNUSED(src_arrmeta), kernel_request_t kernreq, \
                     const eval::eval_context *DYND_UNUSED(ectx)) \
         { \
-            extra_type *e = ckb->get_at<extra_type>(ckb_offset); \
-            e->base.template set_expr_function<extra_type>((kernel_request_t)kernreq); \
+            extra_type *e = ckb->alloc_ck_leaf<extra_type>(ckb_offset); \
+            e->base.template set_expr_function<extra_type>(kernreq); \
             std::pair<const T *, func_type *> *obj_func = \
                 *af_self->get_data_as<std::pair<const T *, func_type *> *>(); \
             e->obj = obj_func->first; \
             e->func = obj_func->second; \
 \
-            return ckb_offset + sizeof(extra_type); \
+            return ckb_offset; \
         } \
     };
 

--- a/include/dynd/func/elwise_methretres.hpp
+++ b/include/dynd/func/elwise_methretres.hpp
@@ -70,14 +70,14 @@ namespace detail {
                     const char *const *DYND_UNUSED(src_arrmeta), kernel_request_t kernreq, \
                     const eval::eval_context *DYND_UNUSED(ectx)) \
         { \
-            extra_type *e = ckb->get_at<extra_type>(ckb_offset); \
-            e->base.template set_expr_function<extra_type>((kernel_request_t)kernreq); \
+            extra_type *e = ckb->alloc_ck_leaf<extra_type>(ckb_offset); \
+            e->base.template set_expr_function<extra_type>(kernreq); \
             std::pair<const T *, func_type *> *obj_func = \
                 *af_self->get_data_as<std::pair<const T *, func_type *> *>(); \
             e->obj = obj_func->first; \
             e->func = obj_func->second; \
 \
-            return ckb_offset + sizeof(extra_type); \
+            return ckb_offset; \
         } \
     };
 

--- a/include/dynd/kernels/assignment_kernels.hpp
+++ b/include/dynd/kernels/assignment_kernels.hpp
@@ -185,7 +185,7 @@ namespace kernels {
  * \returns  The offset within 'ckb' immediately after the
  *           created kernel.
  */
-size_t make_assignment_kernel(ckernel_builder *ckb, size_t ckb_offset,
+size_t make_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                               const ndt::type &dst_tp, const char *dst_arrmeta,
                               const ndt::type &src_tp, const char *src_arrmeta,
                               kernel_request_t kernreq,
@@ -202,7 +202,7 @@ size_t make_assignment_kernel(ckernel_builder *ckb, size_t ckb_offset,
  * \param kernreq  What kind of kernel must be placed in 'ckb'.
  */
 size_t make_pod_typed_data_assignment_kernel(ckernel_builder *ckb,
-                                             size_t ckb_offset,
+                                             intptr_t ckb_offset,
                                              size_t data_size,
                                              size_t data_alignment,
                                              kernel_request_t kernreq);
@@ -219,7 +219,7 @@ size_t make_pod_typed_data_assignment_kernel(ckernel_builder *ckb,
  * \param errmode  The error mode to use for assignments.
  */
 size_t make_builtin_type_assignment_kernel(
-    ckernel_builder *ckb, size_t ckb_offset, type_id_t dst_type_id,
+    ckernel_builder *ckb, intptr_t ckb_offset, type_id_t dst_type_id,
     type_id_t src_type_id, kernel_request_t kernreq, assign_error_mode errmode);
 
 /**
@@ -234,7 +234,7 @@ size_t make_builtin_type_assignment_kernel(
  *      // Proceed to create 'single' kernel...
  */
 size_t make_kernreq_to_single_kernel_adapter(ckernel_builder *ckb,
-                                             size_t ckb_offset, int nsrc,
+                                             intptr_t ckb_offset, int nsrc,
                                              kernel_request_t kernreq);
 
 namespace kernels {
@@ -303,7 +303,7 @@ struct strided_assign_ck : public kernels::unary_ck<strided_assign_ck> {
  *           created kernel.
  */
 size_t make_cuda_assignment_kernel(
-                ckernel_builder *ckb, size_t ckb_offset,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 const ndt::type& dst_tp, const char *dst_arrmeta,
                 const ndt::type& src_tp, const char *src_arrmeta,
                 kernel_request_t kernreq,
@@ -322,7 +322,7 @@ size_t make_cuda_assignment_kernel(
  * \param kernreq  What kind of kernel must be placed in 'ckb'.
  */
 size_t make_cuda_pod_typed_data_assignment_kernel(
-                ckernel_builder *ckb, size_t ckb_offset,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 bool dst_device, bool src_device,
                 size_t data_size, size_t data_alignment,
                 kernel_request_t kernreq);
@@ -341,7 +341,7 @@ size_t make_cuda_pod_typed_data_assignment_kernel(
  * \param errmode  The error mode to use for assignments.
  */
 size_t make_cuda_builtin_type_assignment_kernel(
-                ckernel_builder *ckb, size_t ckb_offset,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 bool dst_device, type_id_t dst_type_id,
                 bool src_device, type_id_t src_type_id,
                 kernel_request_t kernreq, assign_error_mode errmode);

--- a/include/dynd/kernels/bytes_assignment_kernels.hpp
+++ b/include/dynd/kernels/bytes_assignment_kernels.hpp
@@ -15,7 +15,7 @@ namespace dynd {
  * Makes a kernel which copies blockref bytes.
  */
 size_t make_blockref_bytes_assignment_kernel(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 size_t dst_alignment, const char *dst_arrmeta,
                 size_t src_alignment, const char *src_arrmeta,
                 kernel_request_t kernreq, const eval::eval_context *ectx);
@@ -24,7 +24,7 @@ size_t make_blockref_bytes_assignment_kernel(
  * Makes a kernel which copies fixed-size bytes to bytes.
  */
 size_t make_fixedbytes_to_blockref_bytes_assignment_kernel(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 size_t dst_alignment, const char *dst_arrmeta,
                 intptr_t src_element_size, size_t src_alignment,
                 kernel_request_t kernreq, const eval::eval_context *ectx);

--- a/include/dynd/kernels/byteswap_kernels.hpp
+++ b/include/dynd/kernels/byteswap_kernels.hpp
@@ -46,7 +46,7 @@ inline uint64_t byteswap_value(uint64_t value) {
  * of the specified data size.
  */
 size_t make_byteswap_assignment_function(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 intptr_t data_size, intptr_t data_alignment,
                 kernel_request_t kernreq);
 
@@ -55,7 +55,7 @@ size_t make_byteswap_assignment_function(
  * of the specified data size.
  */
 size_t make_pairwise_byteswap_assignment_function(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 intptr_t data_size, intptr_t data_alignment,
                 kernel_request_t kernreq);
 

--- a/include/dynd/kernels/ckernel_builder.hpp
+++ b/include/dynd/kernels/ckernel_builder.hpp
@@ -15,6 +15,24 @@
 
 namespace dynd {
 
+namespace kernels {
+  /**
+   * Increments a ``ckb_offset`` variable (offset into a ckernel_builder)
+   * by the provided increment. The increment needs to be aligned to 8 bytes,
+   * so padding may be added.
+   */
+  inline void inc_ckb_offset(intptr_t& inout_ckb_offset, size_t inc)
+  {
+    inout_ckb_offset += static_cast<intptr_t>((inc + size_t(7)) & ~size_t(7));
+  }
+
+  template<class T>
+  inline void inc_ckb_offset(intptr_t& inout_ckb_offset)
+  {
+    inc_ckb_offset(inout_ckb_offset, sizeof(T));
+  }
+} // namespace kernels
+
 /**
  * Function pointers + data for a hierarchical
  * kernel which operates on type/arrmeta in
@@ -26,126 +44,157 @@ namespace dynd {
  * own address.
  */
 class ckernel_builder {
-    // Pointer to the kernel function pointers + data
-    intptr_t *m_data;
-    intptr_t m_capacity;
-    // When the amount of data is small, this static data is used,
-    // otherwise dynamic memory is allocated when it gets too big
-    intptr_t m_static_data[16];
+  // Pointer to the kernel function pointers + data
+  char *m_data;
+  intptr_t m_capacity;
+  // When the amount of data is small, this static data is used,
+  // otherwise dynamic memory is allocated when it gets too big
+  char m_static_data[16 * 8];
 
-    inline bool using_static_data() const {
-        return m_data == &m_static_data[0];
-    }
+  inline bool using_static_data() const { return m_data == &m_static_data[0]; }
 
-    inline void destroy() {
-        if (m_data != NULL) {
-            ckernel_prefix *self = reinterpret_cast<ckernel_prefix *>(m_data);
-            // Destroy whatever was created
-            self->destroy();
-            if (!using_static_data()) {
-                // Free the memory
-                free(self);
-            }
-        }
+  inline void destroy()
+  {
+    if (m_data != NULL) {
+      ckernel_prefix *self = reinterpret_cast<ckernel_prefix *>(m_data);
+      // Destroy whatever was created
+      self->destroy();
+      if (!using_static_data()) {
+        // Free the memory
+        free(self);
+      }
     }
+  }
+
 protected:
 public:
-    ckernel_builder() {
+  ckernel_builder()
+  {
+    m_data = &m_static_data[0];
+    m_capacity = sizeof(m_static_data);
+    memset(m_static_data, 0, sizeof(m_static_data));
+  }
+
+  ~ckernel_builder() { destroy(); }
+
+  void reset()
+  {
+    destroy();
+    m_data = &m_static_data[0];
+    m_capacity = sizeof(m_static_data);
+    memset(m_static_data, 0, sizeof(m_static_data));
+  }
+
+  /**
+   * This function ensures that the ckernel's data
+   * is at least the required number of bytes. It
+   * should only be called during the construction phase
+   * of the kernel.
+   *
+   * NOTE: This function ensures that there is room for
+   *       another base at the end, so if you are sure
+   *       that you're a leaf kernel, use ensure_capacity_leaf
+   *       instead.
+   */
+  inline void ensure_capacity(intptr_t requested_capacity)
+  {
+    ensure_capacity_leaf(requested_capacity + sizeof(ckernel_prefix));
+  }
+
+  /**
+   * This function ensures that the ckernel's data
+   * is at least the required number of bytes. It
+   * should only be called during the construction phase
+   * of the kernel when constructing a leaf kernel.
+   */
+  void ensure_capacity_leaf(intptr_t requested_capacity);
+
+  /**
+   * For use during construction. This function ensures that the
+   * ckernel_builder has enough capacity (including a child), increments the
+   * provided offset appropriately based on the size of T, and returns a pointer
+   * to the allocated ckernel.
+   */
+  template <class T>
+  inline T *alloc_ck(intptr_t &inout_ckb_offset)
+  {
+    intptr_t ckb_offset = inout_ckb_offset;
+    kernels::inc_ckb_offset<T>(inout_ckb_offset);
+    ensure_capacity(inout_ckb_offset);
+    return reinterpret_cast<T *>(m_data + ckb_offset);
+  }
+
+  /**
+   * For use during construction. This function ensures that the
+   * ckernel_builder has enough capacity, increments the provided
+   * offset appropriately based on the size of T, and returns a pointer
+   * to the allocated ckernel.
+   */
+  template <class T>
+  inline T *alloc_ck_leaf(intptr_t &inout_ckb_offset)
+  {
+    intptr_t ckb_offset = inout_ckb_offset;
+    kernels::inc_ckb_offset<T>(inout_ckb_offset);
+    ensure_capacity_leaf(inout_ckb_offset);
+    return reinterpret_cast<T *>(m_data + ckb_offset);
+  }
+
+  /**
+   * For use during construction, gets the ckernel component
+   * at the requested offset.
+   */
+  template <class T>
+  inline T *get_at(size_t offset)
+  {
+    return reinterpret_cast<T *>(m_data + offset);
+  }
+
+  ckernel_prefix *get() const
+  {
+    return reinterpret_cast<ckernel_prefix *>(m_data);
+  }
+
+  void swap(ckernel_builder &rhs)
+  {
+    if (using_static_data()) {
+      if (rhs.using_static_data()) {
+        char tmp_static_data[sizeof(m_static_data)];
+        memcpy(tmp_static_data, m_static_data, sizeof(m_static_data));
+        memcpy(m_static_data, rhs.m_static_data, sizeof(m_static_data));
+        memcpy(rhs.m_static_data, tmp_static_data, sizeof(m_static_data));
+      } else {
+        memcpy(rhs.m_static_data, m_static_data, sizeof(m_static_data));
+        m_data = rhs.m_data;
+        m_capacity = rhs.m_capacity;
+        rhs.m_data = &rhs.m_static_data[0];
+        rhs.m_capacity = 16 * sizeof(intptr_t);
+      }
+    } else {
+      if (rhs.using_static_data()) {
+        memcpy(m_static_data, rhs.m_static_data, sizeof(m_static_data));
+        rhs.m_data = m_data;
+        rhs.m_capacity = m_capacity;
         m_data = &m_static_data[0];
         m_capacity = sizeof(m_static_data);
-        memset(m_static_data, 0, sizeof(m_static_data));
+      } else {
+        (std::swap)(m_data, rhs.m_data);
+        (std::swap)(m_capacity, rhs.m_capacity);
+      }
     }
+  }
 
-    ~ckernel_builder() {
-        destroy();
-    }
+  /** For debugging/informational purposes */
+  intptr_t get_capacity() const { return m_capacity; }
 
-    void reset() {
-        destroy();
-        m_data = &m_static_data[0];
-        m_capacity = sizeof(m_static_data);
-        memset(m_static_data, 0, sizeof(m_static_data));
-    }
-
-    /**
-     * This function ensures that the ckernel's data
-     * is at least the required number of bytes. It
-     * should only be called during the construction phase
-     * of the kernel.
-     *
-     * NOTE: This function ensures that there is room for
-     *       another base at the end, so if you are sure
-     *       that you're a leaf kernel, use ensure_capacity_leaf
-     *       instead.
-     */
-    inline void ensure_capacity(intptr_t requested_capacity) {
-        ensure_capacity_leaf(requested_capacity +
-                        sizeof(ckernel_prefix));
-    }
-
-    /**
-     * This function ensures that the ckernel's data
-     * is at least the required number of bytes. It
-     * should only be called during the construction phase
-     * of the kernel when constructing a leaf kernel.
-     */
-    void ensure_capacity_leaf(intptr_t requested_capacity);
-
-    /**
-     * For use during construction, gets the ckernel component
-     * at the requested offset.
-     */
-    template<class T>
-    T *get_at(size_t offset) {
-        return reinterpret_cast<T *>(
-                        reinterpret_cast<char *>(m_data) + offset);
-    }
-
-    ckernel_prefix *get() const {
-        return reinterpret_cast<ckernel_prefix *>(m_data);
-    }
-
-    void swap(ckernel_builder& rhs) {
-        if (using_static_data()) {
-            if (rhs.using_static_data()) {
-                intptr_t tmp_static_data[16];
-                memcpy(tmp_static_data, m_static_data, 16 * sizeof(intptr_t));
-                memcpy(m_static_data, rhs.m_static_data, 16 * sizeof(intptr_t));
-                memcpy(rhs.m_static_data, tmp_static_data, 16 * sizeof(intptr_t));
-            } else {
-                memcpy(rhs.m_static_data, m_static_data, 16 * sizeof(intptr_t));
-                m_data = rhs.m_data;
-                m_capacity = rhs.m_capacity;
-                rhs.m_data = &rhs.m_static_data[0];
-                rhs.m_capacity = 16 * sizeof(intptr_t);
-            }
-        } else {
-            if (rhs.using_static_data()) {
-                memcpy(m_static_data, rhs.m_static_data, 16 * sizeof(intptr_t));
-                rhs.m_data = m_data;
-                rhs.m_capacity = m_capacity;
-                m_data = &m_static_data[0];
-                m_capacity = 16 * sizeof(intptr_t);
-            } else {
-                (std::swap)(m_data, rhs.m_data);
-                (std::swap)(m_capacity, rhs.m_capacity);
-            }
-        }
-    }
-
-    /** For debugging/informational purposes */
-    intptr_t get_capacity() const {
-        return m_capacity;
-    }
-
-    friend int ckernel_builder_ensure_capacity_leaf(void *ckb, intptr_t requested_capacity);
+  friend int ckernel_builder_ensure_capacity_leaf(void *ckb,
+                                                  intptr_t requested_capacity);
 };
 
 /**
  * C API function for constructing a ckernel_builder object
  * in place. The `ckb` pointer must point to memory which
- * has sizeof(ckernel_builder) bytes (== 18 * sizeof(void *)),
- * and is aligned appropriately (to sizeof(void *)).
+ * has sizeof(ckernel_builder) bytes (== 128 + 2 * sizeof(void *)),
+ * and is aligned appropriately to 8 bytes.
  *
  * After a ckernel_builder instance is initialized this way,
  * all the other ckernel_builder functions can be used on it,
@@ -153,12 +202,12 @@ public:
  * by calling `ckernel_builder_destruct`.
  *
  * \param ckb  Pointer to the ckernel_builder instance. Must have
- *             size 18 * sizeof(void *), and alignment sizeof(void *).
+ *             128 + 2 * sizeof(void *), and alignment 8.
  */
 inline void ckernel_builder_construct(void *ckb)
 {
-    // Use the placement new operator to initialize in-place
-    new (ckb) ckernel_builder();
+  // Use the placement new operator to initialize in-place
+  new (ckb) ckernel_builder();
 }
 
 /**
@@ -170,9 +219,9 @@ inline void ckernel_builder_construct(void *ckb)
  */
 inline void ckernel_builder_destruct(void *ckb)
 {
-    // Call the destructor
-    ckernel_builder *ckb_ptr = reinterpret_cast<ckernel_builder *>(ckb);
-    ckb_ptr->~ckernel_builder();
+  // Call the destructor
+  ckernel_builder *ckb_ptr = reinterpret_cast<ckernel_builder *>(ckb);
+  ckb_ptr->~ckernel_builder();
 }
 
 /**
@@ -183,8 +232,8 @@ inline void ckernel_builder_destruct(void *ckb)
  */
 inline void ckernel_builder_reset(void *ckb)
 {
-    ckernel_builder *ckb_ptr = reinterpret_cast<ckernel_builder *>(ckb);
-    ckb_ptr->reset();
+  ckernel_builder *ckb_ptr = reinterpret_cast<ckernel_builder *>(ckb);
+  ckb_ptr->reset();
 }
 
 /**
@@ -201,41 +250,42 @@ inline void ckernel_builder_reset(void *ckb)
  *
  * \returns  0 on success, -1 on memory allocation failure.
  */
-inline int ckernel_builder_ensure_capacity_leaf(void *ckb, intptr_t requested_capacity)
+inline int ckernel_builder_ensure_capacity_leaf(void *ckb,
+                                                intptr_t requested_capacity)
 {
-    ckernel_builder *ckb_ptr = reinterpret_cast<ckernel_builder *>(ckb);
-    if (ckb_ptr->m_capacity < requested_capacity) {
-        // Grow by a factor of 1.5
-        // https://github.com/facebook/folly/blob/master/folly/docs/FBVector.md
-        intptr_t grown_capacity = ckb_ptr->m_capacity * 3 / 2;
-        if (requested_capacity < grown_capacity) {
-            requested_capacity = grown_capacity;
-        }
-        intptr_t *new_data;
-        if (ckb_ptr->using_static_data()) {
-            // If we were previously using the static data, do a malloc
-            new_data = reinterpret_cast<intptr_t *>(malloc(requested_capacity));
-            // If the allocation succeeded, copy the old data as the realloc would
-            if (new_data != NULL) {
-                memcpy(new_data, ckb_ptr->m_data, ckb_ptr->m_capacity);
-            }
-        } else {
-            // Otherwise do a realloc
-            new_data = reinterpret_cast<intptr_t *>(realloc(
-                            ckb_ptr->m_data, requested_capacity));
-        }
-        if (new_data == NULL) {
-            ckb_ptr->destroy();
-            ckb_ptr->m_data = NULL;
-            return -1;
-        }
-        // Zero out the newly allocated capacity
-        memset(reinterpret_cast<char *>(new_data) + ckb_ptr->m_capacity,
-                        0, requested_capacity - ckb_ptr->m_capacity);
-        ckb_ptr->m_data = new_data;
-        ckb_ptr->m_capacity = requested_capacity;
+  ckernel_builder *ckb_ptr = reinterpret_cast<ckernel_builder *>(ckb);
+  if (ckb_ptr->m_capacity < requested_capacity) {
+    // Grow by a factor of 1.5
+    // https://github.com/facebook/folly/blob/master/folly/docs/FBVector.md
+    intptr_t grown_capacity = ckb_ptr->m_capacity * 3 / 2;
+    if (requested_capacity < grown_capacity) {
+      requested_capacity = grown_capacity;
     }
-    return 0;
+    char *new_data;
+    if (ckb_ptr->using_static_data()) {
+      // If we were previously using the static data, do a malloc
+      new_data = reinterpret_cast<char *>(malloc(requested_capacity));
+      // If the allocation succeeded, copy the old data as the realloc would
+      if (new_data != NULL) {
+        memcpy(new_data, ckb_ptr->m_data, ckb_ptr->m_capacity);
+      }
+    } else {
+      // Otherwise do a realloc
+      new_data = reinterpret_cast<char *>(
+          realloc(ckb_ptr->m_data, requested_capacity));
+    }
+    if (new_data == NULL) {
+      ckb_ptr->destroy();
+      ckb_ptr->m_data = NULL;
+      return -1;
+    }
+    // Zero out the newly allocated capacity
+    memset(reinterpret_cast<char *>(new_data) + ckb_ptr->m_capacity, 0,
+           requested_capacity - ckb_ptr->m_capacity);
+    ckb_ptr->m_data = new_data;
+    ckb_ptr->m_capacity = requested_capacity;
+  }
+  return 0;
 }
 
 /**
@@ -254,123 +304,140 @@ inline int ckernel_builder_ensure_capacity_leaf(void *ckb, intptr_t requested_ca
  *
  * \returns  0 on success, -1 on memory allocation failure.
  */
-inline int ckernel_builder_ensure_capacity(void *ckb, intptr_t requested_capacity)
+inline int ckernel_builder_ensure_capacity(void *ckb,
+                                           intptr_t requested_capacity)
 {
-    return ckernel_builder_ensure_capacity_leaf(ckb,
-                    requested_capacity + sizeof(ckernel_prefix));
+  return ckernel_builder_ensure_capacity_leaf(ckb, requested_capacity +
+                                                       sizeof(ckernel_prefix));
 }
 
 inline void ckernel_builder::ensure_capacity_leaf(intptr_t requested_capacity)
 {
-    if (ckernel_builder_ensure_capacity_leaf(this, requested_capacity) < 0) {
-        throw std::bad_alloc();
-    }
+  if (ckernel_builder_ensure_capacity_leaf(this, requested_capacity) < 0) {
+    throw std::bad_alloc();
+  }
 }
 
 namespace kernels {
+  /**
+   * Some common shared implementation details of a CRTP
+   * (curiously recurring template pattern) base class to help
+   * create ckernels.
+   */
+  template <class CKT>
+  struct general_ck {
+    typedef CKT self_type;
+
+    ckernel_prefix base;
+
+    static self_type *get_self(ckernel_prefix *rawself)
+    {
+      return reinterpret_cast<self_type *>(rawself);
+    }
+
+    static const self_type *get_self(const ckernel_prefix *rawself)
+    {
+      return reinterpret_cast<const self_type *>(rawself);
+    }
+
+    static self_type *get_self(ckernel_builder *ckb, intptr_t ckb_offset)
+    {
+      return ckb->get_at<self_type>(ckb_offset);
+    }
+
     /**
-     * Some common shared implementation details of a CRTP
-     * (curiously recurring template pattern) base class to help
-     * create ckernels.
+     * Creates the ckernel, and increments ``inckb_offset``
+     * to the position after it.
      */
-    template<class CKT>
-    struct general_ck {
-        typedef CKT self_type;
+    static inline self_type *create(ckernel_builder *ckb,
+                                    kernel_request_t kernreq,
+                                    intptr_t &inout_ckb_offset)
+    {
+      intptr_t ckb_offset = inout_ckb_offset;
+      kernels::inc_ckb_offset<self_type>(inout_ckb_offset);
+      ckb->ensure_capacity(inout_ckb_offset);
+      ckernel_prefix *rawself = ckb->get_at<ckernel_prefix>(ckb_offset);
+      return self_type::init(rawself, kernreq);
+    }
 
-        ckernel_prefix base;
+    /**
+     * Creates the ckernel, and increments ``inckb_offset``
+     * to the position after it.
+     */
+    static inline self_type *create_leaf(ckernel_builder *ckb,
+                                         kernel_request_t kernreq,
+                                         intptr_t &inout_ckb_offset)
+    {
+      intptr_t ckb_offset = inout_ckb_offset;
+      kernels::inc_ckb_offset<self_type>(inout_ckb_offset);
+      ckb->ensure_capacity_leaf(inout_ckb_offset);
+      ckernel_prefix *rawself = ckb->get_at<ckernel_prefix>(ckb_offset);
+      return self_type::init(rawself, kernreq);
+    }
 
-        static self_type *get_self(ckernel_prefix *rawself) {
-            return reinterpret_cast<self_type *>(rawself);
-        }
+    /**
+     * Initializes an instance of this ckernel in-place according to the
+     * kernel request. This calls the constructor in-place, and initializes
+     * the base function and destructor
+     */
+    static inline self_type *init(ckernel_prefix *rawself,
+                                  kernel_request_t kernreq)
+    {
+      // Alignment requirement of the type
+      DYND_STATIC_ASSERT(
+          (size_t)scalar_align_of<self_type>::value ==
+              (size_t)scalar_align_of<void *>::value,
+          "ckernel types require alignment matching that of pointers");
 
-        static const self_type *get_self(const ckernel_prefix *rawself) {
-            return reinterpret_cast<const self_type *>(rawself);
-        }
+      // Call the constructor in-place
+      self_type *self = new (rawself) self_type();
+      // Double check that the C++ struct layout is as we expect
+      if (self != get_self(rawself)) {
+        throw std::runtime_error(
+            "internal ckernel error: struct layout is not valid");
+      }
+      self->base.destructor = &self_type::destruct;
+      // A child class must implement this to fill in self->base.function
+      self->init_kernfunc(kernreq);
+      return self;
+    }
 
-        static self_type *get_self(ckernel_builder *ckb, intptr_t ckb_offset) {
-            return ckb->get_at<self_type>(ckb_offset);
-        }
+    /**
+     * The ckernel destructor function, which is placed in
+     * base.destructor.
+     */
+    static void destruct(ckernel_prefix *rawself)
+    {
+      self_type *self = get_self(rawself);
+      // If there are any child kernels, a child class
+      // must implement this to destroy them.
+      self->destruct_children();
+      self->~self_type();
+    }
 
-        static inline self_type *create(ckernel_builder *ckb,
-                                        intptr_t ckb_offset,
-                                        kernel_request_t kernreq)
-        {
-            ckb->ensure_capacity(ckb_offset + sizeof(self_type));
-            ckernel_prefix *rawself = ckb->get_at<ckernel_prefix>(ckb_offset);
-            return self_type::init(rawself, kernreq);
-        }
+    /**
+     * Default implementation of destruct_children does nothing.
+     */
+    inline void destruct_children() {}
 
-        static inline self_type *create_leaf(ckernel_builder *ckb,
-                                             intptr_t ckb_offset,
-                                             kernel_request_t kernreq)
-        {
-            ckb->ensure_capacity_leaf(ckb_offset + sizeof(self_type));
-            ckernel_prefix *rawself = ckb->get_at<ckernel_prefix>(ckb_offset);
-            return self_type::init(rawself, kernreq);
-        }
+    /**
+     * Returns the child ckernel immediately following this one.
+     */
+    inline ckernel_prefix *get_child_ckernel()
+    {
+      return get_child_ckernel(sizeof(self_type));
+    }
 
-        /**
-         * Initializes an instance of this ckernel in-place according to the
-         * kernel request. This calls the constructor in-place, and initializes
-         * the base function and destructor
-         */
-        static inline self_type *init(ckernel_prefix *rawself,
-                                      kernel_request_t kernreq)
-        {
-            // Alignment requirement of the type
-            DYND_STATIC_ASSERT(
-                (size_t)scalar_align_of<self_type>::value ==
-                    (size_t)scalar_align_of<void *>::value,
-                "ckernel types require alignment matching that of pointers");
-
-            // Call the constructor in-place
-            self_type *self = new (rawself) self_type();
-            // Double check that the C++ struct layout is as we expect
-            if (self != get_self(rawself)) {
-                throw std::runtime_error("internal ckernel error: struct layout is not valid");
-            }
-            self->base.destructor = &self_type::destruct;
-            // A child class must implement this to fill in self->base.function
-            self->init_kernfunc(kernreq);
-            return self;
-        }
-
-        /**
-         * The ckernel destructor function, which is placed in
-         * base.destructor.
-         */
-        static void destruct(ckernel_prefix *rawself) {
-            self_type *self = get_self(rawself);
-            // If there are any child kernels, a child class
-            // must implement this to destroy them.
-            self->destruct_children();
-            self->~self_type();
-        }
-
-        /**
-         * Default implementation of destruct_children does nothing.
-         */
-        inline void destruct_children()
-        {
-        }
-
-        /**
-         * Returns the child ckernel immediately following this one.
-         */
-        inline ckernel_prefix *get_child_ckernel() {
-            return get_child_ckernel(sizeof(self_type));
-        }
-
-        /**
-         * Returns the child ckernel at the specified offset.
-         */
-        inline ckernel_prefix *get_child_ckernel(intptr_t offset) {
-            return base.get_child_ckernel(offset);
-        }
-    };
+    /**
+     * Returns the child ckernel at the specified offset.
+     */
+    inline ckernel_prefix *get_child_ckernel(intptr_t offset)
+    {
+      return base.get_child_ckernel(offset);
+    }
+  };
 } // namespace kernels
 
 } // namespace dynd
-
 
 #endif // _DYND__CKERNEL_BUILDER_HPP_

--- a/include/dynd/kernels/ckernel_common_functions.hpp
+++ b/include/dynd/kernels/ckernel_common_functions.hpp
@@ -62,7 +62,7 @@ void expr_as_unary_adapter_strided_ckernel(
  *
  */
 size_t make_constant_value_assignment_ckernel(
-    ckernel_builder *out_ckb, intptr_t ckb_offset, const ndt::type &dst_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_tp,
     const char *dst_arrmeta, const nd::array &constant,
     kernel_request_t kernreq, const eval::eval_context *ectx);
 
@@ -82,7 +82,7 @@ intptr_t wrap_expr_as_unary_ckernel(dynd::ckernel_builder *ckb,
  * as a unary reduction ckernel. The three types of the binary
  * expr kernel must all be equal.
  *
- * \param out_ckb  The ckernel_builder into which the kernel adapter is placed.
+ * \param ckb  The ckernel_builder into which the kernel adapter is placed.
  * \param ckb_offset  The offset within the ckernel_builder at which to place the adapter.
  * \param right_associative  If true, the reduction is to be evaluated right to left,
  *                           (x0 * (x1 * (x2 * x3))), if false, the reduction is to be
@@ -92,7 +92,7 @@ intptr_t wrap_expr_as_unary_ckernel(dynd::ckernel_builder *ckb,
  * \returns  The ckb_offset where the child ckernel should be placed.
  */
 intptr_t wrap_binary_as_unary_reduction_ckernel(
-                dynd::ckernel_builder *out_ckb, intptr_t ckb_offset,
+                dynd::ckernel_builder *ckb, intptr_t ckb_offset,
                 bool right_associative,
                 kernel_request_t kernreq);
 

--- a/include/dynd/kernels/ckernel_prefix.hpp
+++ b/include/dynd/kernels/ckernel_prefix.hpp
@@ -36,7 +36,7 @@ enum {
     kernel_request_predicate = 2,
     /**
      * Kernel function expr_single_t,
-     * but the data in the kernel at position 'offset_out'
+     * but the data in the kernel at position 'ckb_offset'
      * is for data that describes the accumulation
      * of multiple strided dimensions that work
      * in a simple NumPy fashion.
@@ -44,7 +44,7 @@ enum {
 //    kernel_request_single_multistride,
     /**
      * Kernel function expr_strided_t,
-     * but the data in the kernel at position 'offset_out'
+     * but the data in the kernel at position 'ckb_offset'
      * is for data that describes the accumulation
      * of multiple strided dimensions that work
      * in a simple NumPy fashion.

--- a/include/dynd/kernels/comparison_kernels.hpp
+++ b/include/dynd/kernels/comparison_kernels.hpp
@@ -64,16 +64,16 @@ public:
 
 /**
  * Creates a comparison kernel for two type/arrmeta
- * pairs. This adds the kernel at the 'out_offset' position
- * in 'out's data, as part of a hierarchy matching the
+ * pairs. This adds the kernel at the 'ckb_offset' position
+ * in 'ckb's data, as part of a hierarchy matching the
  * type's hierarchy.
  *
  * This function should always be called with this == src0_dt first,
  * and types which don't support the particular assignment should
  * then call the corresponding function with this == src1_dt.
  *
- * \param out  The hierarchical assignment kernel being constructed.
- * \param offset_out  The offset within 'out'.
+ * \param ckb  The hierarchical assignment kernel being constructed.
+ * \param ckb_offset  The offset within 'ckb'.
  * \param src0_dt  The first dynd type.
  * \param src0_arrmeta  Arrmeta for the first data.
  * \param src1_dt  The second dynd type.
@@ -84,7 +84,7 @@ public:
  * \returns  The offset within 'out' immediately after the
  *           created kernel.
  */
-size_t make_comparison_kernel(ckernel_builder *out, size_t offset_out,
+size_t make_comparison_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                               const ndt::type &src0_dt,
                               const char *src0_arrmeta,
                               const ndt::type &src1_dt,
@@ -96,14 +96,14 @@ size_t make_comparison_kernel(ckernel_builder *out, size_t offset_out,
  * Creates a comparison kernel that compares the two builtin
  * types.
  *
- * \param out  The hierarchical assignment kernel being constructed.
- * \param offset_out  The offset within 'out'.
+ * \param ckb  The hierarchical assignment kernel being constructed.
+ * \param ckb_offset  The offset within 'ckb'.
  * \param src0_type_id  The first dynd type id.
  * \param src1_type_id  The second dynd type id.
  * \param comptype  The type of comparison to do.
  */
-size_t make_builtin_type_comparison_kernel(ckernel_builder *out,
-                                           size_t offset_out,
+size_t make_builtin_type_comparison_kernel(ckernel_builder *ckb,
+                                           intptr_t ckb_offset,
                                            type_id_t src0_type_id,
                                            type_id_t src1_type_id,
                                            comparison_type_t comptype);

--- a/include/dynd/kernels/date_assignment_kernels.hpp
+++ b/include/dynd/kernels/date_assignment_kernels.hpp
@@ -14,8 +14,8 @@ namespace dynd {
 /**
  * Makes a kernel which converts strings to dates.
  */
-size_t make_string_to_date_assignment_kernel(ckernel_builder *out,
-                                             size_t offset_out,
+size_t make_string_to_date_assignment_kernel(ckernel_builder *ckb,
+                                             intptr_t ckb_offset,
                                              const ndt::type &src_string_dt,
                                              const char *src_arrmeta,
                                              kernel_request_t kernreq,
@@ -24,8 +24,8 @@ size_t make_string_to_date_assignment_kernel(ckernel_builder *out,
 /**
  * Makes a kernel which converts dates to strings.
  */
-size_t make_date_to_string_assignment_kernel(ckernel_builder *out,
-                                             size_t offset_out,
+size_t make_date_to_string_assignment_kernel(ckernel_builder *ckb,
+                                             intptr_t ckb_offset,
                                              const ndt::type &dst_string_dt,
                                              const char *dst_arrmeta,
                                              kernel_request_t kernreq,

--- a/include/dynd/kernels/datetime_assignment_kernels.hpp
+++ b/include/dynd/kernels/datetime_assignment_kernels.hpp
@@ -15,7 +15,7 @@ namespace dynd {
  * Makes a kernel which converts strings to datetimes.
  */
 size_t make_string_to_datetime_assignment_kernel(
-    ckernel_builder *out, size_t offset_out, const ndt::type &dst_datetime_dt,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_datetime_dt,
     const char *dst_arrmeta, const ndt::type &src_string_dt,
     const char *src_arrmeta, kernel_request_t kernreq,
     const eval::eval_context *ectx);
@@ -24,7 +24,7 @@ size_t make_string_to_datetime_assignment_kernel(
  * Makes a kernel which converts datetimes to strings.
  */
 size_t make_datetime_to_string_assignment_kernel(
-    ckernel_builder *out, size_t offset_out, const ndt::type &dst_string_dt,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_string_dt,
     const char *dst_arrmeta, const ndt::type &src_datetime_dt,
     const char *src_arrmeta, kernel_request_t kernreq,
     const eval::eval_context *ectx);

--- a/include/dynd/kernels/elwise_expr_kernels.hpp
+++ b/include/dynd/kernels/elwise_expr_kernels.hpp
@@ -10,7 +10,7 @@
 
 namespace dynd {
 
-size_t make_elwise_dimension_expr_kernel(ckernel_builder *out, size_t offset_out,
+size_t make_elwise_dimension_expr_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                 const ndt::type& dst_tp, const char *dst_arrmeta,
                 size_t src_count, const ndt::type *src_dt, const char *const*src_arrmeta,
                 kernel_request_t kernreq, const eval::eval_context *ectx,

--- a/include/dynd/kernels/expr_kernel_generator.hpp
+++ b/include/dynd/kernels/expr_kernel_generator.hpp
@@ -46,7 +46,7 @@ public:
     }
 
     virtual size_t make_expr_kernel(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 const ndt::type& dst_tp, const char *dst_arrmeta,
                 size_t src_count, const ndt::type *src_dt, const char *const*src_arrmeta,
                 kernel_request_t kernreq, const eval::eval_context *ectx) const = 0;

--- a/include/dynd/kernels/expr_kernels.hpp
+++ b/include/dynd/kernels/expr_kernels.hpp
@@ -86,7 +86,7 @@ class expr_kernel_generator;
  * types on to the handler to build the rest of the
  * kernel.
  */
-size_t make_expression_type_expr_kernel(ckernel_builder *out, size_t offset_out,
+size_t make_expression_type_expr_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                 const ndt::type& dst_tp, const char *dst_arrmeta,
                 size_t src_count, const ndt::type *src_dt, const char **src_arrmeta,
                 kernel_request_t kernreq, const eval::eval_context *ectx,

--- a/include/dynd/kernels/expression_assignment_kernels.hpp
+++ b/include/dynd/kernels/expression_assignment_kernels.hpp
@@ -16,7 +16,7 @@ namespace dynd {
  * expression_kind type.
  */
 size_t make_expression_assignment_kernel(
-    ckernel_builder *out, size_t offset_out, const ndt::type &dst_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_tp,
     const char *dst_arrmeta, const ndt::type &src_tp, const char *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx);
 

--- a/include/dynd/kernels/expression_comparison_kernels.hpp
+++ b/include/dynd/kernels/expression_comparison_kernels.hpp
@@ -16,7 +16,7 @@ namespace dynd {
  * expression_kind type.
  */
 size_t make_expression_comparison_kernel(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 const ndt::type& src0_dt, const char *src0_arrmeta,
                 const ndt::type& src1_dt, const char *src1_arrmeta,
                 comparison_type_t comptype,

--- a/include/dynd/kernels/make_lifted_reduction_ckernel.hpp
+++ b/include/dynd/kernels/make_lifted_reduction_ckernel.hpp
@@ -23,7 +23,7 @@ namespace dynd {
  *                            accumulator values from the source data.
  *                            If this is NULL, an assignment
  *                            kernel is used here.
- * \param out_ckb  The ckernel_builder into which to place the ckernel.
+ * \param ckb  The ckernel_builder into which to place the ckernel.
  * \param ckb_offset  Where within the ckernel_builder to place the ckernel.
  * \param dst_tp  The destination type to lift to.
  * \param dst_arrmeta  The destination arrmeta to lift to.
@@ -49,7 +49,7 @@ namespace dynd {
  */
 size_t make_lifted_reduction_ckernel(
     const arrfunc_type_data *elwise_reduction,
-    const arrfunc_type_data *dst_initialization, dynd::ckernel_builder *out_ckb,
+    const arrfunc_type_data *dst_initialization, dynd::ckernel_builder *ckb,
     intptr_t ckb_offset, const ndt::type &dst_tp, const char *dst_arrmeta,
     const ndt::type &src_tp, const char *src_arrmeta, intptr_t reduction_ndim,
     const bool *reduction_dimflags, bool associative, bool commutative,

--- a/include/dynd/kernels/option_assignment_kernels.hpp
+++ b/include/dynd/kernels/option_assignment_kernels.hpp
@@ -15,7 +15,7 @@ namespace dynd { namespace kernels {
  * Makes a ckernel for assignments containing an option type.
  */
 size_t make_option_assignment_kernel(
-    ckernel_builder *ckb, size_t ckb_offset, const ndt::type &dst_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_tp,
     const char *dst_arrmeta, const ndt::type &src_tp,
     const char *src_arrmeta, kernel_request_t kernreq,
     const eval::eval_context *ectx);

--- a/include/dynd/kernels/reduction_kernels.hpp
+++ b/include/dynd/kernels/reduction_kernels.hpp
@@ -16,7 +16,7 @@ namespace dynd { namespace kernels {
  * Makes a unary reduction ckernel which adds values for the
  * given type id. This is not defined for all type_id values.
  */
-intptr_t make_builtin_sum_reduction_ckernel(ckernel_builder *out_ckb,
+intptr_t make_builtin_sum_reduction_ckernel(ckernel_builder *ckb,
                                             intptr_t ckb_offset,
                                             type_id_t tid,
                                             kernel_request_t kernreq);

--- a/include/dynd/kernels/string_assignment_kernels.hpp
+++ b/include/dynd/kernels/string_assignment_kernels.hpp
@@ -15,7 +15,7 @@ namespace dynd {
  * Makes a kernel which converts strings of a fixed size from one codec to another.
  */
 size_t make_fixedstring_assignment_kernel(
-    ckernel_builder *out, size_t offset_out, intptr_t dst_data_size,
+    ckernel_builder *ckb, intptr_t ckb_offset, intptr_t dst_data_size,
     string_encoding_t dst_encoding, intptr_t src_data_size,
     string_encoding_t src_encoding, kernel_request_t kernreq,
     const eval::eval_context *ectx);
@@ -23,7 +23,7 @@ size_t make_fixedstring_assignment_kernel(
 /**
  * Makes a kernel which converts a single char from one encoding to another.
  */
-size_t make_char_assignment_kernel(ckernel_builder *out, size_t offset_out,
+size_t make_char_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                    string_encoding_t dst_encoding,
                                    string_encoding_t src_encoding,
                                    kernel_request_t kernreq,
@@ -33,7 +33,7 @@ size_t make_char_assignment_kernel(ckernel_builder *out, size_t offset_out,
  * Makes a kernel which converts blockref strings from one codec to another.
  */
 size_t make_blockref_string_assignment_kernel(
-    ckernel_builder *out, size_t offset_out, const char *dst_arrmeta,
+    ckernel_builder *ckb, intptr_t ckb_offset, const char *dst_arrmeta,
     string_encoding_t dst_encoding, const char *src_arrmeta,
     string_encoding_t src_encoding, kernel_request_t kernreq,
     const eval::eval_context *ectx);
@@ -42,7 +42,7 @@ size_t make_blockref_string_assignment_kernel(
  * Makes a kernel which converts strings of a fixed size into blockref strings.
  */
 size_t make_fixedstring_to_blockref_string_assignment_kernel(
-    ckernel_builder *out, size_t offset_out, const char *dst_arrmeta,
+    ckernel_builder *ckb, intptr_t ckb_offset, const char *dst_arrmeta,
     string_encoding_t dst_encoding, intptr_t src_element_size,
     string_encoding_t src_encoding, kernel_request_t kernreq,
     const eval::eval_context *ectx);
@@ -51,7 +51,7 @@ size_t make_fixedstring_to_blockref_string_assignment_kernel(
  * Makes a kernel which converts blockref strings into strings of a fixed size.
  */
 size_t make_blockref_string_to_fixedstring_assignment_kernel(
-    ckernel_builder *out, size_t offset_out, intptr_t dst_data_size,
+    ckernel_builder *ckb, intptr_t ckb_offset, intptr_t dst_data_size,
     string_encoding_t dst_encoding, string_encoding_t src_encoding,
     kernel_request_t kernreq, const eval::eval_context *ectx);
 

--- a/include/dynd/kernels/string_comparison_kernels.hpp
+++ b/include/dynd/kernels/string_comparison_kernels.hpp
@@ -19,7 +19,7 @@ namespace dynd {
  * \param encoding  The encoding of the string.
  */
 size_t make_fixedstring_comparison_kernel(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 size_t string_size, string_encoding_t encoding,
                 comparison_type_t comptype,
                 const eval::eval_context *ectx);
@@ -30,7 +30,7 @@ size_t make_fixedstring_comparison_kernel(
  * \param encoding  The encoding of the string.
  */
 size_t make_string_comparison_kernel(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 string_encoding_t encoding,
                 comparison_type_t comptype,
                 const eval::eval_context *ectx);
@@ -41,7 +41,7 @@ size_t make_string_comparison_kernel(
  * \param encoding  The encoding of the string.
  */
 size_t make_general_string_comparison_kernel(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 const ndt::type& src0_dt, const char *src0_arrmeta,
                 const ndt::type& src1_dt, const char *src1_arrmeta,
                 comparison_type_t comptype,

--- a/include/dynd/kernels/string_numeric_assignment_kernels.hpp
+++ b/include/dynd/kernels/string_numeric_assignment_kernels.hpp
@@ -22,7 +22,7 @@ void assign_utf8_string_to_builtin(type_id_t dst_type_id, char *dst,
  * Makes a kernel which converts strings to values of a builtin type id.
  */
 size_t make_builtin_to_string_assignment_kernel(
-    ckernel_builder *out, size_t offset_out, const ndt::type &dst_string_dt,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_string_dt,
     const char *dst_arrmeta, type_id_t src_type_id, kernel_request_t kernreq,
     const eval::eval_context *ectx);
 
@@ -30,7 +30,7 @@ size_t make_builtin_to_string_assignment_kernel(
  * Makes a kernel which converts values of a builtin type id to strings.
  */
 size_t make_string_to_builtin_assignment_kernel(
-    ckernel_builder *out, size_t offset_out, type_id_t dst_type_id,
+    ckernel_builder *ckb, intptr_t ckb_offset, type_id_t dst_type_id,
     const ndt::type &src_string_dt, const char *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx);
 } // namespace dynd

--- a/include/dynd/kernels/struct_assignment_kernels.hpp
+++ b/include/dynd/kernels/struct_assignment_kernels.hpp
@@ -17,7 +17,7 @@ namespace dynd {
  * \param val_struct_tp  The struct-kind type of both source and destination values.
  */
 size_t make_struct_identical_assignment_kernel(
-    ckernel_builder *out_ckb, size_t ckb_offset, const ndt::type &val_struct_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &val_struct_tp,
     const char *dst_arrmeta, const char *src_arrmeta, kernel_request_t kernreq,
     const eval::eval_context *ectx);
 
@@ -28,7 +28,7 @@ size_t make_struct_identical_assignment_kernel(
  * \param src_struct_tp  The struct-kind dtype of the source.
  */
 size_t make_struct_assignment_kernel(
-    ckernel_builder *out_ckb, size_t ckb_offset, const ndt::type &dst_struct_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_struct_tp,
     const char *dst_arrmeta, const ndt::type &src_struct_tp,
     const char *src_arrmeta, kernel_request_t kernreq,
     const eval::eval_context *ectx);
@@ -38,7 +38,7 @@ size_t make_struct_assignment_kernel(
  * of the destination struct.
  */
 size_t make_broadcast_to_struct_assignment_kernel(
-    ckernel_builder *out_ckb, size_t ckb_offset, const ndt::type &dst_struct_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_struct_tp,
     const char *dst_arrmeta, const ndt::type &src_tp, const char *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx);
 

--- a/include/dynd/kernels/struct_comparison_kernels.hpp
+++ b/include/dynd/kernels/struct_comparison_kernels.hpp
@@ -16,7 +16,7 @@ namespace dynd {
  * instances of the same struct/cstruct.
  */
 size_t make_struct_comparison_kernel(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 const ndt::type& src_tp,
                 const char *src0_arrmeta, const char *src1_arrmeta,
                 comparison_type_t comptype,
@@ -27,7 +27,7 @@ size_t make_struct_comparison_kernel(
  * instances with struct_kind.
  */
 size_t make_general_struct_comparison_kernel(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 const ndt::type& src0_dt, const char *src0_arrmeta,
                 const ndt::type& src1_dt, const char *src1_arrmeta,
                 comparison_type_t comptype,

--- a/include/dynd/kernels/time_assignment_kernels.hpp
+++ b/include/dynd/kernels/time_assignment_kernels.hpp
@@ -15,7 +15,7 @@ namespace dynd {
  * Makes a kernel which converts strings to times.
  */
 size_t make_string_to_time_assignment_kernel(
-    ckernel_builder *out, size_t offset_out, const ndt::type &dst_time_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_time_tp,
     const ndt::type &src_string_tp, const char *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx);
 
@@ -23,7 +23,7 @@ size_t make_string_to_time_assignment_kernel(
  * Makes a kernel which converts times to strings.
  */
 size_t make_time_to_string_assignment_kernel(
-    ckernel_builder *out, size_t offset_out, const ndt::type &dst_string_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_string_tp,
     const char *dst_arrmeta, const ndt::type &src_time_tp,
     kernel_request_t kernreq, const eval::eval_context *ectx);
 

--- a/include/dynd/kernels/var_dim_assignment_kernels.hpp
+++ b/include/dynd/kernels/var_dim_assignment_kernels.hpp
@@ -15,14 +15,14 @@ namespace dynd {
  * Makes a kernel which broadcasts the input to a var dim.
  */
 size_t make_broadcast_to_var_dim_assignment_kernel(
-    ckernel_builder *out, size_t offset_out, const ndt::type &dst_var_dim_dt,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_var_dim_dt,
     const char *dst_arrmeta, const ndt::type &src_tp, const char *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx);
 
 /**
  * Makes a kernel which assigns var dims.
  */
-size_t make_var_dim_assignment_kernel(ckernel_builder *out, size_t offset_out,
+size_t make_var_dim_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                       const ndt::type &dst_var_dim_dt,
                                       const char *dst_arrmeta,
                                       const ndt::type &src_var_dim_dt,
@@ -34,7 +34,7 @@ size_t make_var_dim_assignment_kernel(ckernel_builder *out, size_t offset_out,
  * Makes a kernel which assigns strided dims to var dims
  */
 size_t make_strided_to_var_dim_assignment_kernel(
-    ckernel_builder *out, size_t offset_out, const ndt::type &dst_var_dim_dt,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_var_dim_dt,
     const char *dst_arrmeta, intptr_t src_dim_size, intptr_t src_stride,
     const ndt::type &src_el_tp, const char *src_el_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx);
@@ -43,7 +43,7 @@ size_t make_strided_to_var_dim_assignment_kernel(
  * Makes a kernel which assigns var dims to strided dims
  */
 size_t make_var_to_strided_dim_assignment_kernel(
-    ckernel_builder *out, size_t offset_out,
+    ckernel_builder *ckb, intptr_t ckb_offset,
     const ndt::type &dst_strided_dim_dt, const char *dst_arrmeta,
     const ndt::type &src_var_dim_dt, const char *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx);

--- a/include/dynd/types/adapt_type.hpp
+++ b/include/dynd/types/adapt_type.hpp
@@ -42,11 +42,11 @@ public:
     ndt::type with_replaced_storage_type(const ndt::type& replacement_type) const;
 
     size_t make_operand_to_value_assignment_kernel(
-        ckernel_builder *out, size_t offset_out, const char *dst_arrmeta,
+        ckernel_builder *ckb, intptr_t ckb_offset, const char *dst_arrmeta,
         const char *src_arrmeta, kernel_request_t kernreq,
         const eval::eval_context *ectx) const;
     size_t make_value_to_operand_assignment_kernel(
-        ckernel_builder *out, size_t offset_out, const char *dst_arrmeta,
+        ckernel_builder *ckb, intptr_t ckb_offset, const char *dst_arrmeta,
         const char *src_arrmeta, kernel_request_t kernreq,
         const eval::eval_context *ectx) const;
 };

--- a/include/dynd/types/arrfunc_type.hpp
+++ b/include/dynd/types/arrfunc_type.hpp
@@ -36,7 +36,7 @@ public:
     void data_destruct_strided(const char *arrmeta, char *data,
                     intptr_t stride, size_t count) const;
 
-    size_t make_assignment_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &dst_tp,
                                   const char *dst_arrmeta,
                                   const ndt::type &src_tp,

--- a/include/dynd/types/base_expression_type.hpp
+++ b/include/dynd/types/base_expression_type.hpp
@@ -75,17 +75,17 @@ public:
 
     /** Makes a kernel which converts from (operand_type().value_type()) to (value_type()) */
     virtual size_t make_operand_to_value_assignment_kernel(
-        ckernel_builder *out, size_t offset_out, const char *dst_arrmeta,
+        ckernel_builder *ckb, intptr_t ckb_offset, const char *dst_arrmeta,
         const char *src_arrmeta, kernel_request_t kernreq,
         const eval::eval_context *ectx) const;
 
     /** Makes a kernel which converts from (value_type()) to (operand_type().value_type()) */
     virtual size_t make_value_to_operand_assignment_kernel(
-        ckernel_builder *out, size_t offset_out, const char *dst_arrmeta,
+        ckernel_builder *ckb, intptr_t ckb_offset, const char *dst_arrmeta,
         const char *src_arrmeta, kernel_request_t kernreq,
         const eval::eval_context *ectx) const;
 
-    size_t make_assignment_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &dst_tp,
                                   const char *dst_arrmeta,
                                   const ndt::type &src_tp,
@@ -93,7 +93,7 @@ public:
                                   kernel_request_t kernreq,
                                   const eval::eval_context *ectx) const;
 
-    size_t make_comparison_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_comparison_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &src0_dt,
                                   const char *src0_arrmeta,
                                   const ndt::type &src1_dt,

--- a/include/dynd/types/base_struct_type.hpp
+++ b/include/dynd/types/base_struct_type.hpp
@@ -73,12 +73,12 @@ public:
     ndt::type get_elwise_property_type(size_t elwise_property_index,
                     bool& out_readable, bool& out_writable) const;
     size_t make_elwise_property_getter_kernel(
-                    ckernel_builder *out, size_t offset_out,
+                    ckernel_builder *ckb, intptr_t ckb_offset,
                     const char *dst_arrmeta,
                     const char *src_arrmeta, size_t src_elwise_property_index,
                     kernel_request_t kernreq, const eval::eval_context *ectx) const;
     size_t make_elwise_property_setter_kernel(
-                    ckernel_builder *out, size_t offset_out,
+                    ckernel_builder *ckb, intptr_t ckb_offset,
                     const char *dst_arrmeta, size_t dst_elwise_property_index,
                     const char *src_arrmeta,
                     kernel_request_t kernreq, const eval::eval_context *ectx) const;

--- a/include/dynd/types/base_type.hpp
+++ b/include/dynd/types/base_type.hpp
@@ -502,18 +502,18 @@ public:
     /**
      * Creates an assignment kernel for one data value from the
      * src type/arrmeta to the dst type/arrmeta. This adds the
-     * kernel at the 'out_offset' position in 'out's data, as part
+     * kernel at the 'ckb_offset' position in 'ckb's data, as part
      * of a hierarchy matching the type's hierarchy.
      *
      * This function should always be called with this == dst_tp first,
      * and types which don't support the particular assignment should
      * then call the corresponding function with this == src_dt.
      *
-     * \returns  The offset at the end of 'out' after adding this
+     * \returns  The offset at the end of 'ckb' after adding this
      *           kernel.
      */
     virtual size_t
-    make_assignment_kernel(ckernel_builder *out, size_t offset_out,
+    make_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                            const ndt::type &dst_tp, const char *dst_arrmeta,
                            const ndt::type &src_tp, const char *src_arrmeta,
                            kernel_request_t kernreq,
@@ -522,18 +522,18 @@ public:
     /**
      * Creates a comparison kernel for one data value from one
      * type/arrmeta to another type/arrmeta. This adds the
-     * kernel at the 'out_offset' position in 'out's data, as part
+     * kernel at the 'ckb_offset' position in 'ckb's data, as part
      * of a hierarchy matching the type's hierarchy.
      *
      * This function should always be called with this == src0_dt first,
      * and types which don't support the particular comparison should
      * then call the corresponding function with this == src1_dt.
      *
-     * \returns  The offset at the end of 'out' after adding this
+     * \returns  The offset at the end of 'ckb' after adding this
      *           kernel.
      */
     virtual size_t
-    make_comparison_kernel(ckernel_builder *out, size_t offset_out,
+    make_comparison_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                            const ndt::type &src0_dt, const char *src0_arrmeta,
                            const ndt::type &src1_dt, const char *src1_arrmeta,
                            comparison_type_t comptype,
@@ -630,15 +630,15 @@ public:
      * Returns a kernel to transform instances of this type into values of the
      * element-wise property.
      *
-     * \param out  The hierarchical assignment kernel being constructed.
-     * \param offset_out  The offset within 'out'.
+     * \param ckb  The ckernel_builder being constructed.
+     * \param ckb_offset  The offset within 'ckb'.
      * \param dst_arrmeta  Arrmeta for the destination property being written to.
      * \param src_arrmeta  Arrmeta for the operand type being read from.
      * \param src_elwise_property_index  The index of the property, from get_elwise_property_index().
      * \param ectx  DyND evaluation context.
      */
     virtual size_t make_elwise_property_getter_kernel(
-        ckernel_builder *out, size_t offset_out, const char *dst_arrmeta,
+        ckernel_builder *ckb, intptr_t ckb_offset, const char *dst_arrmeta,
         const char *src_arrmeta, size_t src_elwise_property_index,
         kernel_request_t kernreq, const eval::eval_context *ectx) const;
 
@@ -651,7 +651,7 @@ public:
      *       setting just the "year" property of a date is not possible
      *       with this mechanism.
      *
-     * \param ckb  The hierarchical assignment kernel being constructed.
+     * \param ckb  The ckernel_builder being constructed.
      * \param ckb_offset  The offset within 'ckb'.
      * \param dst_arrmeta  Arrmeta for the operand type being written to.
      * \param dst_elwise_property_index  The index of the property, from get_elwise_property_index().
@@ -659,7 +659,7 @@ public:
      * \param ectx  DyND evaluation contrext.
      */
     virtual size_t make_elwise_property_setter_kernel(
-        ckernel_builder *ckb, size_t ckb_offset, const char *dst_arrmeta,
+        ckernel_builder *ckb, intptr_t ckb_offset, const char *dst_arrmeta,
         size_t dst_elwise_property_index, const char *src_arrmeta,
         kernel_request_t kernreq, const eval::eval_context *ectx) const;
 

--- a/include/dynd/types/builtin_type_properties.hpp
+++ b/include/dynd/types/builtin_type_properties.hpp
@@ -26,14 +26,14 @@ ndt::type get_builtin_type_elwise_property_type(
                 bool& out_readable, bool& out_writable);
 
 size_t make_builtin_type_elwise_property_getter_kernel(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 type_id_t builtin_type_id,
                 const char *dst_arrmeta,
                 const char *src_arrmeta, size_t src_elwise_property_index,
                 kernel_request_t kernreq, const eval::eval_context *ectx);
 
 size_t make_builtin_type_elwise_property_setter_kernel(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 type_id_t builtin_type_id,
                 const char *dst_arrmeta, size_t dst_elwise_property_index,
                 const char *src_arrmeta,

--- a/include/dynd/types/bytes_type.hpp
+++ b/include/dynd/types/bytes_type.hpp
@@ -70,7 +70,7 @@ public:
     void arrmeta_debug_print(const char *arrmeta, std::ostream &o,
                              const std::string &indent) const;
 
-    size_t make_assignment_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &dst_tp,
                                   const char *dst_arrmeta,
                                   const ndt::type &src_tp,

--- a/include/dynd/types/byteswap_type.hpp
+++ b/include/dynd/types/byteswap_type.hpp
@@ -45,11 +45,11 @@ public:
     ndt::type with_replaced_storage_type(const ndt::type& replacement_type) const;
 
     size_t make_operand_to_value_assignment_kernel(
-                    ckernel_builder *out, size_t offset_out,
+                    ckernel_builder *ckb, intptr_t ckb_offset,
                     const char *dst_arrmeta, const char *src_arrmeta,
                     kernel_request_t kernreq, const eval::eval_context *ectx) const;
     size_t make_value_to_operand_assignment_kernel(
-                    ckernel_builder *out, size_t offset_out,
+                    ckernel_builder *ckb, intptr_t ckb_offset,
                     const char *dst_arrmeta, const char *src_arrmeta,
                     kernel_request_t kernreq, const eval::eval_context *ectx) const;
 };

--- a/include/dynd/types/categorical_type.hpp
+++ b/include/dynd/types/categorical_type.hpp
@@ -101,7 +101,7 @@ public:
     void arrmeta_debug_print(const char *arrmeta, std::ostream &o,
                              const std::string &indent) const;
 
-    size_t make_assignment_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &dst_tp,
                                   const char *dst_arrmeta,
                                   const ndt::type &src_tp,

--- a/include/dynd/types/cfixed_dim_type.hpp
+++ b/include/dynd/types/cfixed_dim_type.hpp
@@ -21,8 +21,7 @@ struct cfixed_dim_type_iterdata {
 };
 
 class cfixed_dim_type : public base_uniform_dim_type {
-    intptr_t m_stride;
-    size_t m_dim_size;
+    intptr_t m_stride, m_dim_size;
     std::vector<std::pair<std::string, gfunc::callable> > m_array_properties, m_array_functions;
 
 public:
@@ -39,7 +38,7 @@ public:
         return m_stride;
     }
 
-    inline size_t get_fixed_dim_size() const {
+    inline intptr_t get_fixed_dim_size() const {
         return m_dim_size;
     }
 
@@ -96,7 +95,7 @@ public:
     void data_destruct_strided(const char *arrmeta, char *data,
                     intptr_t stride, size_t count) const;
 
-    size_t make_assignment_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &dst_tp,
                                   const char *dst_arrmeta,
                                   const ndt::type &src_tp,

--- a/include/dynd/types/char_type.hpp
+++ b/include/dynd/types/char_type.hpp
@@ -59,7 +59,7 @@ public:
     void arrmeta_debug_print(const char *DYND_UNUSED(arrmeta), std::ostream& DYND_UNUSED(o), const std::string& DYND_UNUSED(indent)) const {
     }
 
-    size_t make_assignment_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &dst_tp,
                                   const char *dst_arrmeta,
                                   const ndt::type &src_tp,
@@ -67,7 +67,7 @@ public:
                                   kernel_request_t kernreq,
                                   const eval::eval_context *ectx) const;
 
-    size_t make_comparison_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_comparison_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &src0_dt,
                                   const char *src0_arrmeta,
                                   const ndt::type &src1_dt,

--- a/include/dynd/types/convert_type.hpp
+++ b/include/dynd/types/convert_type.hpp
@@ -45,11 +45,11 @@ public:
     ndt::type with_replaced_storage_type(const ndt::type& replacement_type) const;
 
     size_t make_operand_to_value_assignment_kernel(
-                    ckernel_builder *out, size_t offset_out,
+                    ckernel_builder *ckb, intptr_t ckb_offset,
                     const char *dst_arrmeta, const char *src_arrmeta,
                     kernel_request_t kernreq, const eval::eval_context *ectx) const;
     size_t make_value_to_operand_assignment_kernel(
-                    ckernel_builder *out, size_t offset_out,
+                    ckernel_builder *ckb, intptr_t ckb_offset,
                     const char *dst_arrmeta, const char *src_arrmeta,
                     kernel_request_t kernreq, const eval::eval_context *ectx) const;
 

--- a/include/dynd/types/cstruct_type.hpp
+++ b/include/dynd/types/cstruct_type.hpp
@@ -77,7 +77,7 @@ public:
 
     void arrmeta_debug_print(const char *arrmeta, std::ostream& o, const std::string& indent) const;
 
-    size_t make_assignment_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &dst_tp,
                                   const char *dst_arrmeta,
                                   const ndt::type &src_tp,
@@ -85,7 +85,7 @@ public:
                                   kernel_request_t kernreq,
                                   const eval::eval_context *ectx) const;
 
-    size_t make_comparison_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_comparison_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &src0_dt,
                                   const char *src0_arrmeta,
                                   const ndt::type &src1_dt,

--- a/include/dynd/types/ctuple_type.hpp
+++ b/include/dynd/types/ctuple_type.hpp
@@ -56,7 +56,7 @@ public:
 
     void arrmeta_debug_print(const char *arrmeta, std::ostream& o, const std::string& indent) const;
 
-    size_t make_assignment_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &dst_tp,
                                   const char *dst_arrmeta,
                                   const ndt::type &src_tp,
@@ -64,7 +64,7 @@ public:
                                   kernel_request_t kernreq,
                                   const eval::eval_context *ectx) const;
 
-    size_t make_comparison_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_comparison_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &src0_dt,
                                   const char *src0_arrmeta,
                                   const ndt::type &src1_dt,

--- a/include/dynd/types/cuda_device_type.hpp
+++ b/include/dynd/types/cuda_device_type.hpp
@@ -29,7 +29,7 @@ public:
     void data_zeroinit(char *data, size_t size) const;
     void data_free(char *data) const;
 
-    size_t make_assignment_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &dst_tp,
                                   const char *dst_arrmeta,
                                   const ndt::type &src_tp,

--- a/include/dynd/types/cuda_host_type.hpp
+++ b/include/dynd/types/cuda_host_type.hpp
@@ -37,7 +37,7 @@ public:
     void data_zeroinit(char *data, size_t size) const;
     void data_free(char *data) const;
 
-    size_t make_assignment_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &dst_tp,
                                   const char *dst_arrmeta,
                                   const ndt::type &src_tp,

--- a/include/dynd/types/date_type.hpp
+++ b/include/dynd/types/date_type.hpp
@@ -50,7 +50,7 @@ public:
     {
     }
 
-    size_t make_assignment_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &dst_tp,
                                   const char *dst_arrmeta,
                                   const ndt::type &src_tp,
@@ -58,7 +58,7 @@ public:
                                   kernel_request_t kernreq,
                                   const eval::eval_context *ectx) const;
 
-    size_t make_comparison_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_comparison_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &src0_dt,
                                   const char *src0_arrmeta,
                                   const ndt::type &src1_dt,
@@ -79,12 +79,12 @@ public:
     ndt::type get_elwise_property_type(size_t elwise_property_index,
                     bool& out_readable, bool& out_writable) const;
     size_t make_elwise_property_getter_kernel(
-                    ckernel_builder *out, size_t offset_out,
+                    ckernel_builder *ckb, intptr_t ckb_offset,
                     const char *dst_arrmeta,
                     const char *src_arrmeta, size_t src_elwise_property_index,
                     kernel_request_t kernreq, const eval::eval_context *ectx) const;
     size_t make_elwise_property_setter_kernel(
-                    ckernel_builder *out, size_t offset_out,
+                    ckernel_builder *ckb, intptr_t ckb_offset,
                     const char *dst_arrmeta, size_t dst_elwise_property_index,
                     const char *src_arrmeta,
                     kernel_request_t kernreq, const eval::eval_context *ectx) const;

--- a/include/dynd/types/datetime_type.hpp
+++ b/include/dynd/types/datetime_type.hpp
@@ -65,7 +65,7 @@ public:
     void arrmeta_debug_print(const char *DYND_UNUSED(arrmeta), std::ostream& DYND_UNUSED(o), const std::string& DYND_UNUSED(indent)) const {
     }
 
-    size_t make_assignment_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &dst_tp,
                                   const char *dst_arrmeta,
                                   const ndt::type &src_tp,
@@ -82,12 +82,12 @@ public:
     ndt::type get_elwise_property_type(size_t elwise_property_index,
                     bool& out_readable, bool& out_writable) const;
     size_t make_elwise_property_getter_kernel(
-                    ckernel_builder *out, size_t offset_out,
+                    ckernel_builder *ckb, intptr_t ckb_offset,
                     const char *dst_arrmeta,
                     const char *src_arrmeta, size_t src_elwise_property_index,
                     kernel_request_t kernreq, const eval::eval_context *ectx) const;
     size_t make_elwise_property_setter_kernel(
-                    ckernel_builder *out, size_t offset_out,
+                    ckernel_builder *ckb, intptr_t ckb_offset,
                     const char *dst_arrmeta, size_t dst_elwise_property_index,
                     const char *src_arrmeta,
                     kernel_request_t kernreq, const eval::eval_context *ectx) const;

--- a/include/dynd/types/expr_type.hpp
+++ b/include/dynd/types/expr_type.hpp
@@ -77,11 +77,11 @@ public:
     }
 
     size_t make_operand_to_value_assignment_kernel(
-                    ckernel_builder *out, size_t offset_out,
+                    ckernel_builder *ckb, intptr_t ckb_offset,
                     const char *dst_arrmeta, const char *src_arrmeta,
                     kernel_request_t kernreq, const eval::eval_context *ectx) const;
     size_t make_value_to_operand_assignment_kernel(
-                    ckernel_builder *out, size_t offset_out,
+                    ckernel_builder *ckb, intptr_t ckb_offset,
                     const char *dst_arrmeta, const char *src_arrmeta,
                     kernel_request_t kernreq, const eval::eval_context *ectx) const;
 

--- a/include/dynd/types/fixed_dim_type.hpp
+++ b/include/dynd/types/fixed_dim_type.hpp
@@ -24,16 +24,16 @@ struct fixed_dim_type_iterdata {
 };
 
 class fixed_dim_type : public base_uniform_dim_type {
-    size_t m_dim_size;
+    intptr_t m_dim_size;
     std::vector<std::pair<std::string, gfunc::callable> > m_array_properties, m_array_functions;
 public:
-    fixed_dim_type(size_t dim_size, const ndt::type& element_tp);
+    fixed_dim_type(intptr_t dim_size, const ndt::type& element_tp);
 
     virtual ~fixed_dim_type();
 
     size_t get_default_data_size(intptr_t ndim, const intptr_t *shape) const;
 
-    inline size_t get_fixed_dim_size() const {
+    inline intptr_t get_fixed_dim_size() const {
         return m_dim_size;
     }
 
@@ -90,7 +90,7 @@ public:
     void data_destruct_strided(const char *arrmeta, char *data,
                     intptr_t stride, size_t count) const;
 
-    size_t make_assignment_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &dst_tp,
                                   const char *dst_arrmeta,
                                   const ndt::type &src_tp,

--- a/include/dynd/types/fixedbytes_type.hpp
+++ b/include/dynd/types/fixedbytes_type.hpp
@@ -38,7 +38,7 @@ public:
     void arrmeta_debug_print(const char *DYND_UNUSED(arrmeta), std::ostream& DYND_UNUSED(o), const std::string& DYND_UNUSED(indent)) const {
     }
 
-    size_t make_assignment_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &dst_tp,
                                   const char *dst_arrmeta,
                                   const ndt::type &src_tp,

--- a/include/dynd/types/fixedstring_type.hpp
+++ b/include/dynd/types/fixedstring_type.hpp
@@ -54,7 +54,7 @@ public:
     void arrmeta_debug_print(const char *DYND_UNUSED(arrmeta), std::ostream& DYND_UNUSED(o), const std::string& DYND_UNUSED(indent)) const {
     }
 
-    size_t make_assignment_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &dst_tp,
                                   const char *dst_arrmeta,
                                   const ndt::type &src_tp,
@@ -62,7 +62,7 @@ public:
                                   kernel_request_t kernreq,
                                   const eval::eval_context *ectx) const;
 
-    size_t make_comparison_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_comparison_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &src0_dt,
                                   const char *src0_arrmeta,
                                   const ndt::type &src1_dt,

--- a/include/dynd/types/groupby_type.hpp
+++ b/include/dynd/types/groupby_type.hpp
@@ -103,11 +103,11 @@ public:
     with_replaced_storage_type(const ndt::type &replacement_type) const;
 
     size_t make_operand_to_value_assignment_kernel(
-        ckernel_builder *out, size_t offset_out, const char *dst_arrmeta,
+        ckernel_builder *ckb, intptr_t ckb_offset, const char *dst_arrmeta,
         const char *src_arrmeta, kernel_request_t kernreq,
         const eval::eval_context *ectx) const;
     size_t make_value_to_operand_assignment_kernel(
-        ckernel_builder *out, size_t offset_out, const char *dst_arrmeta,
+        ckernel_builder *ckb, intptr_t ckb_offset, const char *dst_arrmeta,
         const char *src_arrmeta, kernel_request_t kernreq,
         const eval::eval_context *ectx) const;
 

--- a/include/dynd/types/json_type.hpp
+++ b/include/dynd/types/json_type.hpp
@@ -49,7 +49,7 @@ public:
     void arrmeta_destruct(char *arrmeta) const;
     void arrmeta_debug_print(const char *arrmeta, std::ostream& o, const std::string& indent) const;
 
-    size_t make_assignment_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &dst_tp,
                                   const char *dst_arrmeta,
                                   const ndt::type &src_tp,

--- a/include/dynd/types/ndarrayarg_type.hpp
+++ b/include/dynd/types/ndarrayarg_type.hpp
@@ -56,7 +56,7 @@ public:
     {
     }
 
-    size_t make_assignment_kernel(ckernel_builder *ckb, size_t ckb_offset,
+    size_t make_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &dst_tp,
                                   const char *dst_arrmeta,
                                   const ndt::type &src_tp,
@@ -64,7 +64,7 @@ public:
                                   kernel_request_t kernreq,
                                   const eval::eval_context *ectx) const;
 
-    size_t make_comparison_kernel(ckernel_builder *ckb, size_t ckb_offset,
+    size_t make_comparison_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &src0_dt,
                                   const char *src0_arrmeta,
                                   const ndt::type &src1_dt,

--- a/include/dynd/types/option_type.hpp
+++ b/include/dynd/types/option_type.hpp
@@ -105,7 +105,7 @@ public:
     void arrmeta_debug_print(const char *arrmeta, std::ostream &o,
                               const std::string &indent) const;
 
-    size_t make_assignment_kernel(ckernel_builder *ckb, size_t ckb_offset,
+    size_t make_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &dst_tp,
                                   const char *dst_arrmeta,
                                   const ndt::type &src_tp,

--- a/include/dynd/types/property_type.hpp
+++ b/include/dynd/types/property_type.hpp
@@ -74,12 +74,12 @@ public:
     ndt::type with_replaced_storage_type(const ndt::type& replacement_type) const;
 
     size_t make_operand_to_value_assignment_kernel(
-                    ckernel_builder *out, size_t offset_out,
+                    ckernel_builder *ckb, intptr_t ckb_offset,
                     const char *dst_arrmeta, const char *src_arrmeta,
                     kernel_request_t kernreq, const eval::eval_context *ectx) const;
 
     size_t make_value_to_operand_assignment_kernel(
-                    ckernel_builder *out, size_t offset_out,
+                    ckernel_builder *ckb, intptr_t ckb_offset,
                     const char *dst_arrmeta, const char *src_arrmeta,
                     kernel_request_t kernreq, const eval::eval_context *ectx) const;
 

--- a/include/dynd/types/strided_dim_type.hpp
+++ b/include/dynd/types/strided_dim_type.hpp
@@ -88,7 +88,7 @@ public:
     void data_destruct_strided(const char *arrmeta, char *data,
                     intptr_t stride, size_t count) const;
 
-    size_t make_assignment_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &dst_tp,
                                   const char *dst_arrmeta,
                                   const ndt::type &src_tp,

--- a/include/dynd/types/string_type.hpp
+++ b/include/dynd/types/string_type.hpp
@@ -72,7 +72,7 @@ public:
     void arrmeta_destruct(char *arrmeta) const;
     void arrmeta_debug_print(const char *arrmeta, std::ostream& o, const std::string& indent) const;
 
-    size_t make_assignment_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &dst_tp,
                                   const char *dst_arrmeta,
                                   const ndt::type &src_tp,
@@ -81,7 +81,7 @@ public:
                                   const eval::eval_context *ectx) const;
 
     size_t make_comparison_kernel(
-                    ckernel_builder *out, size_t offset_out,
+                    ckernel_builder *ckb, intptr_t ckb_offset,
                     const ndt::type& src0_dt, const char *src0_arrmeta,
                     const ndt::type& src1_dt, const char *src1_arrmeta,
                     comparison_type_t comptype,

--- a/include/dynd/types/struct_type.hpp
+++ b/include/dynd/types/struct_type.hpp
@@ -54,7 +54,7 @@ public:
 
     void arrmeta_debug_print(const char *arrmeta, std::ostream& o, const std::string& indent) const;
 
-    size_t make_assignment_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &dst_tp,
                                   const char *dst_arrmeta,
                                   const ndt::type &src_tp,
@@ -62,7 +62,7 @@ public:
                                   kernel_request_t kernreq,
                                   const eval::eval_context *ectx) const;
 
-    size_t make_comparison_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_comparison_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &src0_dt,
                                   const char *src0_arrmeta,
                                   const ndt::type &src1_dt,

--- a/include/dynd/types/time_type.hpp
+++ b/include/dynd/types/time_type.hpp
@@ -49,7 +49,7 @@ public:
     void arrmeta_debug_print(const char *DYND_UNUSED(arrmeta), std::ostream& DYND_UNUSED(o), const std::string& DYND_UNUSED(indent)) const {
     }
 
-    size_t make_assignment_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &dst_tp,
                                   const char *dst_arrmeta,
                                   const ndt::type &src_tp,
@@ -57,7 +57,7 @@ public:
                                   kernel_request_t kernreq,
                                   const eval::eval_context *ectx) const;
 
-    size_t make_comparison_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_comparison_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &src0_dt,
                                   const char *src0_arrmeta,
                                   const ndt::type &src1_dt,
@@ -83,11 +83,11 @@ public:
                                        bool &out_readable,
                                        bool &out_writable) const;
     size_t make_elwise_property_getter_kernel(
-        ckernel_builder *out, size_t offset_out, const char *dst_arrmeta,
+        ckernel_builder *ckb, intptr_t ckb_offset, const char *dst_arrmeta,
         const char *src_arrmeta, size_t src_elwise_property_index,
         kernel_request_t kernreq, const eval::eval_context *ectx) const;
     size_t make_elwise_property_setter_kernel(
-        ckernel_builder *out, size_t offset_out, const char *dst_arrmeta,
+        ckernel_builder *ckb, intptr_t ckb_offset, const char *dst_arrmeta,
         size_t dst_elwise_property_index, const char *src_arrmeta,
         kernel_request_t kernreq, const eval::eval_context *ectx) const;
 

--- a/include/dynd/types/tuple_type.hpp
+++ b/include/dynd/types/tuple_type.hpp
@@ -48,7 +48,7 @@ public:
 
     void arrmeta_debug_print(const char *arrmeta, std::ostream& o, const std::string& indent) const;
 
-    size_t make_assignment_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &dst_tp,
                                   const char *dst_arrmeta,
                                   const ndt::type &src_tp,
@@ -56,7 +56,7 @@ public:
                                   kernel_request_t kernreq,
                                   const eval::eval_context *ectx) const;
 
-    size_t make_comparison_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_comparison_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &src0_dt,
                                   const char *src0_arrmeta,
                                   const ndt::type &src1_dt,

--- a/include/dynd/types/type_type.hpp
+++ b/include/dynd/types/type_type.hpp
@@ -46,7 +46,7 @@ public:
     void data_destruct_strided(const char *arrmeta, char *data,
                     intptr_t stride, size_t count) const;
 
-    size_t make_assignment_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &dst_tp,
                                   const char *dst_arrmeta,
                                   const ndt::type &src_tp,
@@ -54,7 +54,7 @@ public:
                                   kernel_request_t kernreq,
                                   const eval::eval_context *ectx) const;
 
-    size_t make_comparison_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_comparison_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &src0_dt,
                                   const char *src0_arrmeta,
                                   const ndt::type &src1_dt,

--- a/include/dynd/types/unary_expr_type.hpp
+++ b/include/dynd/types/unary_expr_type.hpp
@@ -61,11 +61,11 @@ public:
     ndt::type with_replaced_storage_type(const ndt::type& replacement_type) const;
 
     size_t make_operand_to_value_assignment_kernel(
-                    ckernel_builder *out, size_t offset_out,
+                    ckernel_builder *ckb, intptr_t ckb_offset,
                     const char *dst_arrmeta, const char *src_arrmeta,
                     kernel_request_t kernreq, const eval::eval_context *ectx) const;
     size_t make_value_to_operand_assignment_kernel(
-                    ckernel_builder *out, size_t offset_out,
+                    ckernel_builder *ckb, intptr_t ckb_offset,
                     const char *dst_arrmeta, const char *src_arrmeta,
                     kernel_request_t kernreq, const eval::eval_context *ectx) const;
 

--- a/include/dynd/types/var_dim_type.hpp
+++ b/include/dynd/types/var_dim_type.hpp
@@ -95,7 +95,7 @@ public:
     size_t iterdata_construct(iterdata_common *iterdata, const char **inout_arrmeta, intptr_t ndim, const intptr_t* shape, ndt::type& out_uniform_tp) const;
     size_t iterdata_destruct(iterdata_common *iterdata, intptr_t ndim) const;
 
-    size_t make_assignment_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &dst_tp,
                                   const char *dst_arrmeta,
                                   const ndt::type &src_tp,

--- a/include/dynd/types/view_type.hpp
+++ b/include/dynd/types/view_type.hpp
@@ -38,11 +38,11 @@ public:
     ndt::type with_replaced_storage_type(const ndt::type& replacement_type) const;
 
     size_t make_operand_to_value_assignment_kernel(
-                    ckernel_builder *out, size_t offset_out,
+                    ckernel_builder *ckb, intptr_t ckb_offset,
                     const char *dst_arrmeta, const char *src_arrmeta,
                     kernel_request_t kernreq, const eval::eval_context *ectx) const;
     size_t make_value_to_operand_assignment_kernel(
-                    ckernel_builder *out, size_t offset_out,
+                    ckernel_builder *ckb, intptr_t ckb_offset,
                     const char *dst_arrmeta, const char *src_arrmeta,
                     kernel_request_t kernreq, const eval::eval_context *ectx) const;
 

--- a/include/dynd/types/void_pointer_type.hpp
+++ b/include/dynd/types/void_pointer_type.hpp
@@ -41,7 +41,7 @@ public:
     void arrmeta_debug_print(const char *DYND_UNUSED(arrmeta), std::ostream& DYND_UNUSED(o), const std::string& DYND_UNUSED(indent)) const {
     }
 
-    size_t make_assignment_kernel(ckernel_builder *out, size_t offset_out,
+    size_t make_assignment_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                   const ndt::type &dst_tp,
                                   const char *dst_arrmeta,
                                   const ndt::type &src_tp,

--- a/src/dynd/arithmetic_op.cpp
+++ b/src/dynd/arithmetic_op.cpp
@@ -80,7 +80,7 @@ namespace {
         virtual ~arithmetic_op_kernel_generator() {
         }
 
-        size_t make_expr_kernel(ckernel_builder *ckb, size_t ckb_offset,
+        size_t make_expr_kernel(ckernel_builder *ckb, intptr_t ckb_offset,
                                 const ndt::type &dst_tp,
                                 const char *dst_arrmeta, size_t src_count,
                                 const ndt::type *src_tp,
@@ -107,7 +107,7 @@ namespace {
                                 this);
             }
             // This is a leaf kernel, so no additional allocation is needed
-            extra_type *e = ckb->get_at<extra_type>(ckb_offset);
+            extra_type *e = ckb->alloc_ck_leaf<extra_type>(ckb_offset);
             switch (kernreq) {
                 case kernel_request_single:
                     e->base().set_function(m_op_pair.single);
@@ -122,7 +122,7 @@ namespace {
                 }
             }
             e->init(2, dst_arrmeta, (const char **)src_arrmeta);
-            return ckb_offset + sizeof(extra_type);
+            return ckb_offset;
         }
 
 

--- a/src/dynd/func/arrfunc.cpp
+++ b/src/dynd/func/arrfunc.cpp
@@ -34,13 +34,13 @@ static intptr_t instantiate_assignment_ckernel(
       if (errmode == ectx->errmode) {
         return make_assignment_kernel(ckb, ckb_offset, dst_tp, dst_arrmeta,
                                       src_tp[0], src_arrmeta[0],
-                                      (kernel_request_t)kernreq, ectx);
+                                      kernreq, ectx);
       } else {
         eval::eval_context ectx_tmp(*ectx);
         ectx_tmp.errmode = errmode;
         return make_assignment_kernel(ckb, ckb_offset, dst_tp, dst_arrmeta,
                                       src_tp[0], src_arrmeta[0],
-                                      (kernel_request_t)kernreq, &ectx_tmp);
+                                      kernreq, &ectx_tmp);
       }
     } else {
       stringstream ss;

--- a/src/dynd/json_formatter.cpp
+++ b/src/dynd/json_formatter.cpp
@@ -261,7 +261,7 @@ static void format_json_uniform_dim(output_data& out, const ndt::type& dt, const
             const fixed_dim_type_arrmeta *md =
                 reinterpret_cast<const fixed_dim_type_arrmeta *>(arrmeta);
             ndt::type element_tp = fad->get_element_type();
-            intptr_t size = (intptr_t)fad->get_fixed_dim_size(),
+            intptr_t size = fad->get_fixed_dim_size(),
                      stride = md->stride;
             for (intptr_t i = 0; i < size; ++i) {
                 ::format_json(out, element_tp,
@@ -276,7 +276,7 @@ static void format_json_uniform_dim(output_data& out, const ndt::type& dt, const
         case cfixed_dim_type_id: {
             const cfixed_dim_type *fad = dt.tcast<cfixed_dim_type>();
             ndt::type element_tp = fad->get_element_type();
-            intptr_t size = (intptr_t)fad->get_fixed_dim_size(), stride = fad->get_fixed_stride();
+            intptr_t size = fad->get_fixed_dim_size(), stride = fad->get_fixed_stride();
             for (intptr_t i = 0; i < size; ++i) {
                 ::format_json(out, element_tp, arrmeta, data + i * stride);
                 if (i != size - 1) {

--- a/src/dynd/kernels/assignment_kernels.cpp
+++ b/src/dynd/kernels/assignment_kernels.cpp
@@ -115,162 +115,164 @@ static void unaligned_copy_strided(char *dst, intptr_t dst_stride,
 }
 
 size_t dynd::make_assignment_kernel(
-    ckernel_builder *out, size_t offset_out, const ndt::type &dst_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_tp,
     const char *dst_arrmeta, const ndt::type &src_tp, const char *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx)
 {
     if (dst_tp.is_builtin()) {
         if (src_tp.is_builtin()) {
             if (dst_tp.extended() == src_tp.extended()) {
-                return make_pod_typed_data_assignment_kernel(out, offset_out,
+                return make_pod_typed_data_assignment_kernel(ckb, ckb_offset,
                                 dst_tp.get_data_size(), dst_tp.get_data_alignment(),
                                 kernreq);
             } else {
-                return make_builtin_type_assignment_kernel(out, offset_out,
+                return make_builtin_type_assignment_kernel(ckb, ckb_offset,
                                 dst_tp.get_type_id(), src_tp.get_type_id(),
                                 kernreq, ectx->errmode);
             }
         } else {
-            return src_tp.extended()->make_assignment_kernel(out, offset_out,
+            return src_tp.extended()->make_assignment_kernel(ckb, ckb_offset,
                             dst_tp, dst_arrmeta,
                             src_tp, src_arrmeta,
                             kernreq, ectx);
         }
     } else {
-        return dst_tp.extended()->make_assignment_kernel(out, offset_out,
+        return dst_tp.extended()->make_assignment_kernel(ckb, ckb_offset,
                         dst_tp, dst_arrmeta,
                         src_tp, src_arrmeta,
                         kernreq, ectx);
     }
 }
 
-size_t dynd::make_pod_typed_data_assignment_kernel(ckernel_builder *out,
-                                                   size_t offset_out,
+size_t dynd::make_pod_typed_data_assignment_kernel(ckernel_builder *ckb,
+                                                   intptr_t ckb_offset,
                                                    size_t data_size,
                                                    size_t data_alignment,
                                                    kernel_request_t kernreq)
 {
-    bool single = (kernreq == kernel_request_single);
-    if (!single && kernreq != kernel_request_strided) {
-        stringstream ss;
-        ss << "make_pod_typed_data_assignment_kernel: unrecognized request " << (int)kernreq;
-        throw runtime_error(ss.str());
+  bool single = (kernreq == kernel_request_single);
+  if (!single && kernreq != kernel_request_strided) {
+    stringstream ss;
+    ss << "make_pod_typed_data_assignment_kernel: unrecognized request "
+       << (int)kernreq;
+    throw runtime_error(ss.str());
+  }
+  ckernel_prefix *result = NULL;
+  if (data_size == data_alignment) {
+    // Aligned specialization tables
+    // No need to reserve more space in the trivial cases, the space for a leaf
+    // is already there
+    switch (data_size) {
+    case 1:
+      result = ckb->alloc_ck_leaf<ckernel_prefix>(ckb_offset);
+      if (single) {
+        result->set_function<expr_single_t>(
+            &aligned_fixed_size_copy_assign<1>::single);
+      } else {
+        result->set_function<expr_strided_t>(
+            &aligned_fixed_size_copy_assign<1>::strided);
+      }
+      return ckb_offset;
+    case 2:
+      result = ckb->alloc_ck_leaf<ckernel_prefix>(ckb_offset);
+      if (single) {
+        result->set_function<expr_single_t>(
+            &aligned_fixed_size_copy_assign<2>::single);
+      } else {
+        result->set_function<expr_strided_t>(
+            &aligned_fixed_size_copy_assign<2>::strided);
+      }
+      return ckb_offset;
+    case 4:
+      result = ckb->alloc_ck_leaf<ckernel_prefix>(ckb_offset);
+      if (single) {
+        result->set_function<expr_single_t>(
+            &aligned_fixed_size_copy_assign<4>::single);
+      } else {
+        result->set_function<expr_strided_t>(
+            &aligned_fixed_size_copy_assign<4>::strided);
+      }
+      return ckb_offset;
+    case 8:
+      result = ckb->alloc_ck_leaf<ckernel_prefix>(ckb_offset);
+      if (single) {
+        result->set_function<expr_single_t>(
+            &aligned_fixed_size_copy_assign<8>::single);
+      } else {
+        result->set_function<expr_strided_t>(
+            &aligned_fixed_size_copy_assign<8>::strided);
+      }
+      return ckb_offset;
+    default: {
+      unaligned_copy_ck *self =
+          ckb->alloc_ck_leaf<unaligned_copy_ck>(ckb_offset);
+      if (single) {
+        self->base.set_function<expr_single_t>(&unaligned_copy_single);
+      } else {
+        self->base.set_function<expr_strided_t>(&unaligned_copy_strided);
+      }
+      self->data_size = data_size;
+      return ckb_offset;
     }
-    ckernel_prefix *result = NULL;
-    if (data_size == data_alignment) {
-        // Aligned specialization tables
-        // No need to reserve more space in the trivial cases, the space for a leaf is already there
-        switch (data_size) {
-            case 1:
-                result = out->get_at<ckernel_prefix>(offset_out);
-                if (single) {
-                    result->set_function<expr_single_t>(
-                                    &aligned_fixed_size_copy_assign<1>::single);
-                } else {
-                    result->set_function<expr_strided_t>(
-                                    &aligned_fixed_size_copy_assign<1>::strided);
-                }
-                return offset_out + sizeof(ckernel_prefix);
-            case 2:
-                result = out->get_at<ckernel_prefix>(offset_out);
-                if (single) {
-                    result->set_function<expr_single_t>(
-                                    &aligned_fixed_size_copy_assign<2>::single);
-                } else {
-                    result->set_function<expr_strided_t>(
-                                    &aligned_fixed_size_copy_assign<2>::strided);
-                }
-                return offset_out + sizeof(ckernel_prefix);
-            case 4:
-                result = out->get_at<ckernel_prefix>(offset_out);
-                if (single) {
-                    result->set_function<expr_single_t>(
-                                    &aligned_fixed_size_copy_assign<4>::single);
-                } else {
-                    result->set_function<expr_strided_t>(
-                                    &aligned_fixed_size_copy_assign<4>::strided);
-                }
-                return offset_out + sizeof(ckernel_prefix);
-            case 8:
-                result = out->get_at<ckernel_prefix>(offset_out);
-                if (single) {
-                    result->set_function<expr_single_t>(
-                                    &aligned_fixed_size_copy_assign<8>::single);
-                } else {
-                    result->set_function<expr_strided_t>(
-                                    &aligned_fixed_size_copy_assign<8>::strided);
-                }
-                return offset_out + sizeof(ckernel_prefix);
-            default:
-                out->ensure_capacity_leaf(offset_out + sizeof(unaligned_copy_ck));
-                result = out->get_at<ckernel_prefix>(offset_out);
-                if (single) {
-                    result->set_function<expr_single_t>(&unaligned_copy_single);
-                } else {
-                    result->set_function<expr_strided_t>(&unaligned_copy_strided);
-                }
-                reinterpret_cast<unaligned_copy_ck *>(result)->data_size = data_size;
-                return offset_out + sizeof(unaligned_copy_ck);
-        }
-    } else {
-        // Unaligned specialization tables
-        switch (data_size) {
-            case 2:
-                result = out->get_at<ckernel_prefix>(offset_out);
-                if (single) {
-                    result->set_function<expr_single_t>(
-                                    unaligned_fixed_size_copy_assign<2>::single);
-                } else {
-                    result->set_function<expr_strided_t>(
-                                    unaligned_fixed_size_copy_assign<2>::strided);
-                }
-                return offset_out + sizeof(ckernel_prefix);
-            case 4:
-                result = out->get_at<ckernel_prefix>(offset_out);
-                if (single) {
-                    result->set_function<expr_single_t>(
-                                    unaligned_fixed_size_copy_assign<4>::single);
-                } else {
-                    result->set_function<expr_strided_t>(
-                                    unaligned_fixed_size_copy_assign<4>::strided);
-                }
-                return offset_out + sizeof(ckernel_prefix);
-            case 8:
-                result = out->get_at<ckernel_prefix>(offset_out);
-                if (single) {
-                    result->set_function<expr_single_t>(
-                                    unaligned_fixed_size_copy_assign<8>::single);
-                } else {
-                    result->set_function<expr_strided_t>(
-                                    unaligned_fixed_size_copy_assign<8>::strided);
-                }
-                return offset_out + sizeof(ckernel_prefix);
-            default:
-                // Subtract the base amount to avoid over-reserving memory in this leaf case
-                out->ensure_capacity(offset_out + sizeof(unaligned_copy_ck) -
-                                sizeof(ckernel_prefix));
-                result = out->get_at<ckernel_prefix>(offset_out);
-                if (single) {
-                    result->set_function<expr_single_t>(&unaligned_copy_single);
-                } else {
-                    result->set_function<expr_strided_t>(&unaligned_copy_strided);
-                }
-                reinterpret_cast<unaligned_copy_ck *>(result)->data_size = data_size;
-                return offset_out + sizeof(unaligned_copy_ck);
-        }
     }
+  } else {
+    // Unaligned specialization tables
+    switch (data_size) {
+    case 2:
+      result = ckb->alloc_ck_leaf<ckernel_prefix>(ckb_offset);
+      if (single) {
+        result->set_function<expr_single_t>(
+            unaligned_fixed_size_copy_assign<2>::single);
+      } else {
+        result->set_function<expr_strided_t>(
+            unaligned_fixed_size_copy_assign<2>::strided);
+      }
+      return ckb_offset;
+    case 4:
+      result = ckb->alloc_ck_leaf<ckernel_prefix>(ckb_offset);
+      if (single) {
+        result->set_function<expr_single_t>(
+            unaligned_fixed_size_copy_assign<4>::single);
+      } else {
+        result->set_function<expr_strided_t>(
+            unaligned_fixed_size_copy_assign<4>::strided);
+      }
+      return ckb_offset;
+    case 8:
+      result = ckb->alloc_ck_leaf<ckernel_prefix>(ckb_offset);
+      if (single) {
+        result->set_function<expr_single_t>(
+            unaligned_fixed_size_copy_assign<8>::single);
+      } else {
+        result->set_function<expr_strided_t>(
+            unaligned_fixed_size_copy_assign<8>::strided);
+      }
+      return ckb_offset;
+    default: {
+      unaligned_copy_ck *self =
+          ckb->alloc_ck_leaf<unaligned_copy_ck>(ckb_offset);
+      if (single) {
+        self->base.set_function<expr_single_t>(&unaligned_copy_single);
+      } else {
+        self->base.set_function<expr_strided_t>(&unaligned_copy_strided);
+      }
+      self->data_size = data_size;
+      return ckb_offset;
+    }
+    }
+  }
 }
 
 namespace {
 template<class dst_type, class src_type, assign_error_mode errmode>
 struct single_assigner_as_expr_single {
-    static void single(char *dst, const char *const *src,
-                       ckernel_prefix *DYND_UNUSED(self))
-    {
-        single_assigner_builtin<dst_type, src_type, errmode>::assign(
-            reinterpret_cast<dst_type *>(dst),
-            reinterpret_cast<const src_type *>(*src));
-    }
+  static void single(char *dst, const char *const *src,
+                     ckernel_prefix *DYND_UNUSED(self))
+  {
+    single_assigner_builtin<dst_type, src_type, errmode>::assign(
+        reinterpret_cast<dst_type *>(dst),
+        reinterpret_cast<const src_type *>(*src));
+  }
 };
 } // anonymous namespace
 
@@ -422,7 +424,7 @@ static expr_strided_t assign_table_strided_kernel[builtin_type_id_count-2][built
 };
 
 size_t dynd::make_builtin_type_assignment_kernel(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 type_id_t dst_type_id, type_id_t src_type_id,
                 kernel_request_t kernreq, assign_error_mode errmode)
 {
@@ -431,7 +433,8 @@ size_t dynd::make_builtin_type_assignment_kernel(
                     src_type_id >= bool_type_id && src_type_id <= complex_float64_type_id &&
                     errmode != assign_error_default) {
         // No need to reserve more space, the space for a leaf is already there
-        ckernel_prefix *result = out->get_at<ckernel_prefix>(offset_out);
+        ckernel_prefix *result = ckb->get_at<ckernel_prefix>(ckb_offset);
+        kernels::inc_ckb_offset<ckernel_prefix>(ckb_offset);
         switch (kernreq) {
             case kernel_request_single:
                 result->set_function<expr_single_t>(
@@ -449,7 +452,7 @@ size_t dynd::make_builtin_type_assignment_kernel(
                 throw runtime_error(ss.str());
             }   
         }
-        return offset_out + sizeof(ckernel_prefix);
+        return ckb_offset;
     } else {
         stringstream ss;
         ss << "Cannot assign from " << ndt::type(src_type_id) << " to " << ndt::type(dst_type_id);
@@ -482,18 +485,18 @@ struct wrap_single_as_strided_fixedcount_ck {
 
 template<>
 struct wrap_single_as_strided_fixedcount_ck<0> {
-    static void strided(char *dst, intptr_t dst_stride,
-                        const char *const *DYND_UNUSED(src),
-                        const intptr_t *DYND_UNUSED(src_stride), size_t count,
-                        ckernel_prefix *self)
-    {
-        ckernel_prefix *echild = self->get_child_ckernel(sizeof(ckernel_prefix));
-        expr_single_t opchild = echild->get_function<expr_single_t>();
-        for (size_t i = 0; i != count; ++i) {
-            opchild(dst, NULL, echild);
-            dst += dst_stride;
-        }
+  static void strided(char *dst, intptr_t dst_stride,
+                      const char *const *DYND_UNUSED(src),
+                      const intptr_t *DYND_UNUSED(src_stride), size_t count,
+                      ckernel_prefix *self)
+  {
+    ckernel_prefix *echild = self->get_child_ckernel(sizeof(ckernel_prefix));
+    expr_single_t opchild = echild->get_function<expr_single_t>();
+    for (size_t i = 0; i != count; ++i) {
+      opchild(dst, NULL, echild);
+      dst += dst_stride;
     }
+  }
 };
 
 static const expr_strided_t wrap_single_as_strided_fixedcount[7] = {
@@ -508,73 +511,69 @@ static const expr_strided_t wrap_single_as_strided_fixedcount[7] = {
 
 static void simple_wrapper_kernel_destruct(ckernel_prefix *self)
 {
-    self->destroy_child_ckernel(sizeof(ckernel_prefix));
+  self->destroy_child_ckernel(sizeof(ckernel_prefix));
 }
 
 struct wrap_single_as_strided_ck {
-    typedef wrap_single_as_strided_ck self_type;
-    ckernel_prefix base;
-    intptr_t nsrc;
+  typedef wrap_single_as_strided_ck self_type;
+  ckernel_prefix base;
+  intptr_t nsrc;
 
-    static inline void strided(char *dst, intptr_t dst_stride,
-                               const char *const *src,
-                               const intptr_t *src_stride, size_t count,
-                               ckernel_prefix *self)
-    {
-        intptr_t nsrc = reinterpret_cast<self_type *>(self)->nsrc;
-        shortvector<const char *> src_copy(nsrc, src);
-        ckernel_prefix *child =
-            self->get_child_ckernel(sizeof(self_type));
-        expr_single_t child_fn = child->get_function<expr_single_t>();
-        for (size_t i = 0; i != count; ++i) {
-            child_fn(dst, src_copy.get(), child);
-            dst += dst_stride;
-            for (intptr_t j = 0; j < nsrc; ++j) {
-                src_copy[j] += src_stride[j];
-            }
-        }
+  static inline void strided(char *dst, intptr_t dst_stride,
+                             const char *const *src, const intptr_t *src_stride,
+                             size_t count, ckernel_prefix *self)
+  {
+    intptr_t nsrc = reinterpret_cast<self_type *>(self)->nsrc;
+    shortvector<const char *> src_copy(nsrc, src);
+    ckernel_prefix *child = self->get_child_ckernel(sizeof(self_type));
+    expr_single_t child_fn = child->get_function<expr_single_t>();
+    for (size_t i = 0; i != count; ++i) {
+      child_fn(dst, src_copy.get(), child);
+      dst += dst_stride;
+      for (intptr_t j = 0; j < nsrc; ++j) {
+        src_copy[j] += src_stride[j];
+      }
     }
+  }
 
-    static void destruct(ckernel_prefix *self)
-    {
-        self->destroy_child_ckernel(sizeof(self_type));
-    }
+  static void destruct(ckernel_prefix *self)
+  {
+    self->destroy_child_ckernel(sizeof(self_type));
+  }
 };
 
 } // anonymous namespace
 
 size_t dynd::make_kernreq_to_single_kernel_adapter(ckernel_builder *ckb,
-                                                   size_t ckb_offset, int nsrc,
+                                                   intptr_t ckb_offset, int nsrc,
                                                    kernel_request_t kernreq)
 {
-    switch (kernreq) {
-        case kernel_request_single: {
-            return ckb_offset;
-        }
-        case kernel_request_strided: {
-            if (nsrc >= 0 &&
-                    nsrc < (int)(sizeof(wrap_single_as_strided_fixedcount) /
-                            sizeof(wrap_single_as_strided_fixedcount[0]))) {
-                ckb->ensure_capacity(ckb_offset + sizeof(ckernel_prefix));
-                ckernel_prefix *e = ckb->get_at<ckernel_prefix>(ckb_offset);
-                e->set_function<expr_strided_t>(
-                    wrap_single_as_strided_fixedcount[nsrc]);
-                e->destructor = &simple_wrapper_kernel_destruct;
-                return ckb_offset + sizeof(ckernel_prefix);
-            } else {
-                ckb->ensure_capacity(ckb_offset + sizeof(wrap_single_as_strided_ck));
-                wrap_single_as_strided_ck *e = ckb->get_at<wrap_single_as_strided_ck>(ckb_offset);
-                e->base.set_function<expr_strided_t>(
-                    &wrap_single_as_strided_ck::strided);
-                e->base.destructor = &wrap_single_as_strided_ck::destruct;
-                e->nsrc = nsrc;
-                return ckb_offset + sizeof(wrap_single_as_strided_ck);
-            }
-        }
-        default: {
-            stringstream ss;
-            ss << "make_kernreq_to_single_kernel_adapter: unrecognized request " << (int)kernreq;
-            throw runtime_error(ss.str());
-        }
+  switch (kernreq) {
+  case kernel_request_single: {
+    return ckb_offset;
+  }
+  case kernel_request_strided: {
+    if (nsrc >= 0 &&
+        nsrc < (int)(sizeof(wrap_single_as_strided_fixedcount) /
+                     sizeof(wrap_single_as_strided_fixedcount[0]))) {
+      ckernel_prefix *e = ckb->alloc_ck<ckernel_prefix>(ckb_offset);
+      e->set_function<expr_strided_t>(wrap_single_as_strided_fixedcount[nsrc]);
+      e->destructor = &simple_wrapper_kernel_destruct;
+      return ckb_offset;
+    } else {
+      wrap_single_as_strided_ck *e =
+          ckb->alloc_ck<wrap_single_as_strided_ck>(ckb_offset);
+      e->base.set_function<expr_strided_t>(&wrap_single_as_strided_ck::strided);
+      e->base.destructor = &wrap_single_as_strided_ck::destruct;
+      e->nsrc = nsrc;
+      return ckb_offset;
     }
+  }
+  default: {
+    stringstream ss;
+    ss << "make_kernreq_to_single_kernel_adapter: unrecognized request "
+       << (int)kernreq;
+    throw runtime_error(ss.str());
+  }
+  }
 }

--- a/src/dynd/kernels/bytes_assignment_kernels.cpp
+++ b/src/dynd/kernels/bytes_assignment_kernels.cpp
@@ -69,21 +69,21 @@ namespace {
 } // anonymous namespace
 
 size_t dynd::make_blockref_bytes_assignment_kernel(
-    ckernel_builder *out, size_t offset_out, size_t dst_alignment,
+    ckernel_builder *ckb, intptr_t ckb_offset, size_t dst_alignment,
     const char *dst_arrmeta, size_t src_alignment, const char *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *DYND_UNUSED(ectx))
 {
     // Adapt the incoming request to a 'single' kernel
-    offset_out =
-        make_kernreq_to_single_kernel_adapter(out, offset_out, 1, kernreq);
-    out->ensure_capacity_leaf(offset_out + sizeof(blockref_bytes_kernel_extra));
-    blockref_bytes_kernel_extra *e = out->get_at<blockref_bytes_kernel_extra>(offset_out);
-    e->base.set_function<expr_single_t>(&blockref_bytes_kernel_extra::single);
-    e->dst_alignment = dst_alignment;
-    e->src_alignment = src_alignment;
-    e->dst_arrmeta = reinterpret_cast<const bytes_type_arrmeta *>(dst_arrmeta);
-    e->src_arrmeta = reinterpret_cast<const bytes_type_arrmeta *>(src_arrmeta);
-    return offset_out + sizeof(blockref_bytes_kernel_extra);
+  ckb_offset =
+      make_kernreq_to_single_kernel_adapter(ckb, ckb_offset, 1, kernreq);
+  blockref_bytes_kernel_extra *e =
+      ckb->alloc_ck_leaf<blockref_bytes_kernel_extra>(ckb_offset);
+  e->base.set_function<expr_single_t>(&blockref_bytes_kernel_extra::single);
+  e->dst_alignment = dst_alignment;
+  e->src_alignment = src_alignment;
+  e->dst_arrmeta = reinterpret_cast<const bytes_type_arrmeta *>(dst_arrmeta);
+  e->src_arrmeta = reinterpret_cast<const bytes_type_arrmeta *>(src_arrmeta);
+  return ckb_offset;
 }
 
 /////////////////////////////////////////
@@ -130,19 +130,20 @@ namespace {
 } // anonymous namespace
 
 size_t dynd::make_fixedbytes_to_blockref_bytes_assignment_kernel(
-    ckernel_builder *out, size_t offset_out, size_t dst_alignment,
+    ckernel_builder *ckb, intptr_t ckb_offset, size_t dst_alignment,
     const char *dst_arrmeta, intptr_t src_data_size, size_t src_alignment,
     kernel_request_t kernreq, const eval::eval_context *DYND_UNUSED(ectx))
 {
-    // Adapt the incoming request to a 'single' kernel
-    offset_out =
-        make_kernreq_to_single_kernel_adapter(out, offset_out, 1, kernreq);
-    out->ensure_capacity_leaf(offset_out + sizeof(fixedbytes_to_blockref_bytes_kernel_extra));
-    fixedbytes_to_blockref_bytes_kernel_extra *e = out->get_at<fixedbytes_to_blockref_bytes_kernel_extra>(offset_out);
-    e->base.set_function<expr_single_t>(&fixedbytes_to_blockref_bytes_kernel_extra::single);
-    e->dst_alignment = dst_alignment;
-    e->src_data_size = src_data_size;
-    e->src_alignment = src_alignment;
-    e->dst_arrmeta = reinterpret_cast<const bytes_type_arrmeta *>(dst_arrmeta);
-    return offset_out + sizeof(fixedbytes_to_blockref_bytes_kernel_extra);
+  // Adapt the incoming request to a 'single' kernel
+  ckb_offset =
+      make_kernreq_to_single_kernel_adapter(ckb, ckb_offset, 1, kernreq);
+  fixedbytes_to_blockref_bytes_kernel_extra *e =
+      ckb->alloc_ck_leaf<fixedbytes_to_blockref_bytes_kernel_extra>(ckb_offset);
+  e->base.set_function<expr_single_t>(
+      &fixedbytes_to_blockref_bytes_kernel_extra::single);
+  e->dst_alignment = dst_alignment;
+  e->src_data_size = src_data_size;
+  e->src_alignment = src_alignment;
+  e->dst_arrmeta = reinterpret_cast<const bytes_type_arrmeta *>(dst_arrmeta);
+  return ckb_offset;
 }

--- a/src/dynd/kernels/byteswap_kernels.cpp
+++ b/src/dynd/kernels/byteswap_kernels.cpp
@@ -131,7 +131,7 @@ namespace {
 } // anonymous namespace
 
 size_t dynd::make_byteswap_assignment_function(
-                ckernel_builder *out_ckb, size_t ckb_offset,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 intptr_t data_size, intptr_t data_alignment,
                 kernel_request_t kernreq)
 {
@@ -140,21 +140,21 @@ size_t dynd::make_byteswap_assignment_function(
     if (data_size == data_alignment) {
         switch (data_size) {
         case 2:
-            result = out_ckb->get_at<ckernel_prefix>(ckb_offset);
+            result = ckb->alloc_ck_leaf<ckernel_prefix>(ckb_offset);
             result->set_expr_function<aligned_fixed_size_byteswap<uint16_t> >(
                 kernreq);
-            return ckb_offset + sizeof(ckernel_prefix);
+            return ckb_offset;
         case 4:
-            result = out_ckb->get_at<ckernel_prefix>(ckb_offset);
+            result = ckb->alloc_ck_leaf<ckernel_prefix>(ckb_offset);
             result->set_expr_function<aligned_fixed_size_byteswap<uint32_t> >(
                 kernreq);
-            return ckb_offset + sizeof(ckernel_prefix);
+            return ckb_offset;
             break;
         case 8:
-            result = out_ckb->get_at<ckernel_prefix>(ckb_offset);
+            result = ckb->alloc_ck_leaf<ckernel_prefix>(ckb_offset);
             result->set_expr_function<aligned_fixed_size_byteswap<uint64_t> >(
                 kernreq);
-            return ckb_offset + sizeof(ckernel_prefix);
+            return ckb_offset;
             break;
         default:
             break;
@@ -162,13 +162,13 @@ size_t dynd::make_byteswap_assignment_function(
     }
 
     // Otherwise use the general case ckernel
-    byteswap_ck *self = byteswap_ck::create_leaf(out_ckb, ckb_offset, kernreq);
+    byteswap_ck *self = byteswap_ck::create_leaf(ckb, kernreq, ckb_offset);
     self->m_data_size = data_size;
-    return ckb_offset + sizeof(byteswap_ck);
+    return ckb_offset;
 }
 
 size_t dynd::make_pairwise_byteswap_assignment_function(
-                ckernel_builder *out_ckb, size_t ckb_offset,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 intptr_t data_size, intptr_t data_alignment,
                 kernel_request_t kernreq)
 {
@@ -177,23 +177,23 @@ size_t dynd::make_pairwise_byteswap_assignment_function(
     if (data_size == data_alignment) {
         switch (data_size) {
         case 4:
-            result = out_ckb->get_at<ckernel_prefix>(ckb_offset);
+            result = ckb->alloc_ck_leaf<ckernel_prefix>(ckb_offset);
             result->set_expr_function<
                 aligned_fixed_size_pairwise_byteswap_kernel<uint16_t> >(
                 kernreq);
-            return ckb_offset + sizeof(ckernel_prefix);
+            return ckb_offset;
         case 8:
-            result = out_ckb->get_at<ckernel_prefix>(ckb_offset);
+            result = ckb->alloc_ck_leaf<ckernel_prefix>(ckb_offset);
             result->set_expr_function<
                 aligned_fixed_size_pairwise_byteswap_kernel<uint32_t> >(
                 kernreq);
-            return ckb_offset + sizeof(ckernel_prefix);
+            return ckb_offset;
         case 16:
-            result = out_ckb->get_at<ckernel_prefix>(ckb_offset);
+            result = ckb->alloc_ck_leaf<ckernel_prefix>(ckb_offset);
             result->set_expr_function<
                 aligned_fixed_size_pairwise_byteswap_kernel<uint64_t> >(
                 kernreq);
-            return ckb_offset + sizeof(ckernel_prefix);
+            return ckb_offset;
         default:
             break;
         }
@@ -201,7 +201,7 @@ size_t dynd::make_pairwise_byteswap_assignment_function(
 
     // Otherwise use the general case ckernel
     pairwise_byteswap_ck *self =
-        pairwise_byteswap_ck::create_leaf(out_ckb, ckb_offset, kernreq);
+        pairwise_byteswap_ck::create_leaf(ckb, kernreq, ckb_offset);
     self->m_data_size = data_size;
-    return ckb_offset + sizeof(byteswap_ck);
+    return ckb_offset;
 }

--- a/src/dynd/kernels/date_adapter_kernels.cpp
+++ b/src/dynd/kernels/date_adapter_kernels.cpp
@@ -84,9 +84,9 @@ static intptr_t instantiate_int_offset_arrfunc(
         ss << src_tp[0] << ") -> " << dst_tp;
         throw type_error(ss.str());
     }
-    self_type *self = self_type::create_leaf(ckb, ckb_offset, kernreq);
-    self_af->get_data_unaligned(&self->m_offset);
-    return ckb_offset + sizeof(self_type);
+    self_type *self = self_type::create_leaf(ckb, kernreq, ckb_offset);
+    self->m_offset = *self_af->get_data_as<Tdst>();
+    return ckb_offset;
 }
 
 template <class Tsrc, class Tdst>
@@ -96,7 +96,7 @@ nd::arrfunc make_int_offset_arrfunc(Tdst offset, const ndt::type &func_proto)
     arrfunc_type_data *af =
         reinterpret_cast<arrfunc_type_data *>(out_af.get_readwrite_originptr());
     af->func_proto = func_proto;
-    af->set_data_unaligned(&offset);
+    *af->get_data_as<Tdst>() = offset;
     af->instantiate = &instantiate_int_offset_arrfunc<Tsrc, Tdst>;
     out_af.flag_as_immutable();
     return out_af;

--- a/src/dynd/kernels/date_assignment_kernels.cpp
+++ b/src/dynd/kernels/date_assignment_kernels.cpp
@@ -38,7 +38,7 @@ namespace {
 } // anonymous namespace
 
 size_t dynd::make_string_to_date_assignment_kernel(
-    ckernel_builder *out_ckb, size_t ckb_offset, const ndt::type &src_string_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &src_string_tp,
     const char *src_arrmeta, kernel_request_t kernreq,
     const eval::eval_context *ectx)
 {
@@ -50,13 +50,13 @@ size_t dynd::make_string_to_date_assignment_kernel(
         throw runtime_error(ss.str());
     }
 
-    self_type *self = self_type::create_leaf(out_ckb, ckb_offset, kernreq);
+    self_type *self = self_type::create_leaf(ckb, kernreq, ckb_offset);
     self->m_src_string_tp = src_string_tp;
     self->m_src_arrmeta = src_arrmeta;
     self->m_errmode = ectx->errmode;
     self->m_date_parse_order = ectx->date_parse_order;
     self->m_century_window = ectx->century_window;
-    return ckb_offset + sizeof(self_type);
+    return ckb_offset;
 }
 
 /////////////////////////////////////////
@@ -83,7 +83,7 @@ namespace {
 } // anonymous namespace
 
 size_t dynd::make_date_to_string_assignment_kernel(
-    ckernel_builder *out_ckb, size_t ckb_offset, const ndt::type &dst_string_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_string_tp,
     const char *dst_arrmeta, kernel_request_t kernreq,
     const eval::eval_context *ectx)
 {
@@ -95,10 +95,10 @@ size_t dynd::make_date_to_string_assignment_kernel(
         throw runtime_error(ss.str());
     }
 
-    self_type *self = self_type::create_leaf(out_ckb, ckb_offset, kernreq);
+    self_type *self = self_type::create_leaf(ckb, kernreq, ckb_offset);
     self->m_dst_string_tp = dst_string_tp;
     self->m_dst_arrmeta = dst_arrmeta;
     self->m_ectx = *ectx;
-    return ckb_offset + sizeof(self_type);
+    return ckb_offset;
 }
 

--- a/src/dynd/kernels/datetime_adapter_kernels.cpp
+++ b/src/dynd/kernels/datetime_adapter_kernels.cpp
@@ -120,9 +120,9 @@ static intptr_t instantiate_int_multiply_and_offset_arrfunc(
     ss << src_tp[0] << ") -> " << dst_tp;
     throw type_error(ss.str());
   }
-  self_type *self = self_type::create_leaf(ckb, ckb_offset, kernreq);
-  self_af->get_data_unaligned(&self->m_factor_offset);
-  return ckb_offset + sizeof(self_type);
+  self_type *self = self_type::create_leaf(ckb, kernreq, ckb_offset);
+  self->m_factor_offset = *self_af->get_data_as<pair<Tdst, Tdst> >();
+  return ckb_offset;
 }
 
 template <class Tsrc, class Tdst>
@@ -133,8 +133,7 @@ nd::arrfunc make_int_multiply_and_offset_arrfunc(Tdst factor, Tdst offset,
   arrfunc_type_data *af =
       reinterpret_cast<arrfunc_type_data *>(out_af.get_readwrite_originptr());
   af->func_proto = func_proto;
-  pair<Tdst, Tdst> factor_offset = make_pair(factor, offset);
-  af->set_data_unaligned(&factor_offset);
+  *af->get_data_as<pair<Tdst, Tdst> >() = make_pair(factor, offset);
   af->instantiate = &instantiate_int_multiply_and_offset_arrfunc<Tsrc, Tdst>;
   out_af.flag_as_immutable();
   return out_af;
@@ -148,10 +147,10 @@ struct int_offset_and_divide_ck
   Tdst operator()(Tsrc value)
   {
     if (value != std::numeric_limits<Tsrc>::min()) {
-        value += m_offset_divisor.first;
-        return floordiv(value, m_offset_divisor.second);
+      value += m_offset_divisor.first;
+      return floordiv(value, m_offset_divisor.second);
     } else {
-        return std::numeric_limits<Tdst>::min();
+      return std::numeric_limits<Tdst>::min();
     }
   }
 };
@@ -164,20 +163,20 @@ static intptr_t instantiate_int_offset_and_divide_arrfunc(
     const char *const *DYND_UNUSED(src_arrmeta), kernel_request_t kernreq,
     const eval::eval_context *DYND_UNUSED(ectx))
 {
-    typedef int_offset_and_divide_ck<Tsrc, Tdst> self_type;
-    if (dst_tp !=
-                self_af->func_proto.tcast<funcproto_type>()->get_return_type() ||
-            src_tp[0] !=
-                self_af->func_proto.tcast<funcproto_type>()->get_param_type(0)) {
-        stringstream ss;
-        ss << "Cannot instantiate arrfunc with signature ";
-        ss << self_af->func_proto << " with types (";
-        ss << src_tp[0] << ") -> " << dst_tp;
-        throw type_error(ss.str());
-    }
-    self_type *self = self_type::create_leaf(ckb, ckb_offset, kernreq);
-    self_af->get_data_unaligned(&self->m_offset_divisor);
-    return ckb_offset + sizeof(self_type);
+  typedef int_offset_and_divide_ck<Tsrc, Tdst> self_type;
+  if (dst_tp !=
+          self_af->func_proto.tcast<funcproto_type>()->get_return_type() ||
+      src_tp[0] !=
+          self_af->func_proto.tcast<funcproto_type>()->get_param_type(0)) {
+    stringstream ss;
+    ss << "Cannot instantiate arrfunc with signature ";
+    ss << self_af->func_proto << " with types (";
+    ss << src_tp[0] << ") -> " << dst_tp;
+    throw type_error(ss.str());
+  }
+  self_type *self = self_type::create_leaf(ckb, kernreq, ckb_offset);
+  self->m_offset_divisor = *self_af->get_data_as<pair<Tdst, Tdst> >();
+  return ckb_offset;
 }
 
 template <class Tsrc, class Tdst>
@@ -188,8 +187,7 @@ nd::arrfunc make_int_offset_and_divide_arrfunc(Tdst offset, Tdst divisor,
   arrfunc_type_data *af =
       reinterpret_cast<arrfunc_type_data *>(out_af.get_readwrite_originptr());
   af->func_proto = func_proto;
-  pair<Tdst, Tdst> offset_divisor = make_pair(offset, divisor);
-  af->set_data_unaligned(&offset_divisor);
+  *af->get_data_as<pair<Tdst, Tdst> >() = make_pair(offset, divisor);
   af->instantiate = &instantiate_int_offset_and_divide_arrfunc<Tsrc, Tdst>;
   out_af.flag_as_immutable();
   return out_af;

--- a/src/dynd/kernels/datetime_assignment_kernels.cpp
+++ b/src/dynd/kernels/datetime_assignment_kernels.cpp
@@ -41,7 +41,7 @@ namespace {
 } // anonymous namespace
 
 size_t dynd::make_string_to_datetime_assignment_kernel(
-    ckernel_builder *out_ckb, size_t ckb_offset,
+    ckernel_builder *ckb, intptr_t ckb_offset,
     const ndt::type &dst_datetime_tp, const char *DYND_UNUSED(dst_arrmeta),
     const ndt::type &src_string_tp, const char *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx)
@@ -54,14 +54,14 @@ size_t dynd::make_string_to_datetime_assignment_kernel(
         throw runtime_error(ss.str());
     }
 
-    self_type *self = self_type::create_leaf(out_ckb, ckb_offset, kernreq);
+    self_type *self = self_type::create_leaf(ckb, kernreq, ckb_offset);
     self->m_dst_datetime_tp = dst_datetime_tp;
     self->m_src_string_tp = src_string_tp;
     self->m_src_arrmeta = src_arrmeta;
     self->m_errmode = ectx->errmode;
     self->m_date_parse_order = ectx->date_parse_order;
     self->m_century_window = ectx->century_window;
-    return ckb_offset + sizeof(self_type);
+    return ckb_offset;
 }
 
 /////////////////////////////////////////
@@ -92,7 +92,7 @@ namespace {
 } // anonymous namespace
 
 size_t dynd::make_datetime_to_string_assignment_kernel(
-                ckernel_builder *out_ckb, size_t ckb_offset,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 const ndt::type& dst_string_tp, const char *dst_arrmeta,
                 const ndt::type& src_datetime_tp, const char *DYND_UNUSED(src_arrmeta),
                 kernel_request_t kernreq,
@@ -105,11 +105,11 @@ size_t dynd::make_datetime_to_string_assignment_kernel(
         throw runtime_error(ss.str());
     }
 
-    self_type *self = self_type::create_leaf(out_ckb, ckb_offset, kernreq);
+    self_type *self = self_type::create_leaf(ckb, kernreq, ckb_offset);
     self->m_dst_string_tp = dst_string_tp;
     self->m_src_datetime_tp = src_datetime_tp;
     self->m_dst_arrmeta = dst_arrmeta;
     self->m_ectx = *ectx;
-    return ckb_offset + sizeof(self_type);
+    return ckb_offset;
 }
 

--- a/src/dynd/kernels/elwise_expr_kernels.cpp
+++ b/src/dynd/kernels/elwise_expr_kernels.cpp
@@ -64,69 +64,57 @@ struct strided_expr_kernel_extra {
     }
 };
 
-template<int N>
+template <int N>
 static size_t make_elwise_strided_dimension_expr_kernel_for_N(
-                ckernel_builder *out, size_t offset_out,
-                const ndt::type& dst_tp, const char *dst_arrmeta,
-                size_t DYND_UNUSED(src_count), const ndt::type *src_tp, const char *const*src_arrmeta,
-                kernel_request_t kernreq, const eval::eval_context *ectx,
-                const expr_kernel_generator *elwise_handler)
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_tp,
+    const char *dst_arrmeta, size_t DYND_UNUSED(src_count),
+    const ndt::type *src_tp, const char *const *src_arrmeta,
+    kernel_request_t kernreq, const eval::eval_context *ectx,
+    const expr_kernel_generator *elwise_handler)
 {
-    intptr_t undim = dst_tp.get_ndim();
-    const char *dst_child_arrmeta;
-    const char *src_child_arrmeta[N];
-    ndt::type dst_child_dt;
-    ndt::type src_child_dt[N];
- 
-    out->ensure_capacity(offset_out + sizeof(strided_expr_kernel_extra<N>));
-    strided_expr_kernel_extra<N> *e = out->get_at<strided_expr_kernel_extra<N> >(offset_out);
-    switch (kernreq) {
-        case kernel_request_single:
-            e->base.template set_function<expr_single_t>(&strided_expr_kernel_extra<N>::single);
-            break;
-        case kernel_request_strided:
-            e->base.template set_function<expr_strided_t>(&strided_expr_kernel_extra<N>::strided);
-            break;
-        default: {
-            stringstream ss;
-            ss << "make_elwise_strided_dimension_expr_kernel: unrecognized request " << (int)kernreq;
-            throw runtime_error(ss.str());
-        }
+  intptr_t undim = dst_tp.get_ndim();
+  const char *dst_child_arrmeta;
+  const char *src_child_arrmeta[N];
+  ndt::type dst_child_dt;
+  ndt::type src_child_dt[N];
+
+  strided_expr_kernel_extra<N> *e =
+      ckb->alloc_ck<strided_expr_kernel_extra<N> >(ckb_offset);
+  e->base.template set_expr_function<strided_expr_kernel_extra<N> >(kernreq);
+  e->base.destructor = strided_expr_kernel_extra<N>::destruct;
+  // The dst strided parameters
+  if (!dst_tp.get_as_strided_dim(dst_arrmeta, e->size, e->dst_stride,
+                                 dst_child_dt, dst_child_arrmeta)) {
+    throw type_error("make_elwise_strided_dimension_expr_kernel: dst was not "
+                     "strided as expected");
+  }
+  for (int i = 0; i < N; ++i) {
+    intptr_t src_size;
+    // The src[i] strided parameters
+    if (src_tp[i].get_ndim() < undim) {
+      // This src value is getting broadcasted
+      e->src_stride[i] = 0;
+      src_child_arrmeta[i] = src_arrmeta[i];
+      src_child_dt[i] = src_tp[i];
+    } else if (src_tp[i].get_as_strided_dim(src_arrmeta[i], src_size,
+                                            e->src_stride[i], src_child_dt[i],
+                                            src_child_arrmeta[i])) {
+      // Check for a broadcasting error
+      if (src_size != 1 && e->size != src_size) {
+        throw broadcast_error(dst_tp, dst_arrmeta, src_tp[i], src_arrmeta[i]);
+      }
+    } else {
+      throw type_error("make_elwise_strided_dimension_expr_kernel: src was "
+                       "not strided as expected");
     }
-    e->base.destructor = strided_expr_kernel_extra<N>::destruct;
-    // The dst strided parameters
-    if (!dst_tp.get_as_strided_dim(dst_arrmeta, e->size, e->dst_stride,
-                                   dst_child_dt, dst_child_arrmeta)) {
-        throw type_error("make_elwise_strided_dimension_expr_kernel: dst was not strided as expected");
-    }
-    for (int i = 0; i < N; ++i) {
-        intptr_t src_size;
-        // The src[i] strided parameters
-        if (src_tp[i].get_ndim() < undim) {
-            // This src value is getting broadcasted
-            e->src_stride[i] = 0;
-            src_child_arrmeta[i] = src_arrmeta[i];
-            src_child_dt[i] = src_tp[i];
-        } else if (src_tp[i].get_as_strided_dim(
-                       src_arrmeta[i], src_size, e->src_stride[i],
-                       src_child_dt[i], src_child_arrmeta[i])) {
-            // Check for a broadcasting error
-            if (src_size != 1 && e->size != src_size) {
-                throw broadcast_error(dst_tp, dst_arrmeta, src_tp[i], src_arrmeta[i]);
-            }
-        } else {
-        throw type_error("make_elwise_strided_dimension_expr_kernel: src was not strided as expected");
-        }
-    }
-    return elwise_handler->make_expr_kernel(
-                    out, offset_out + sizeof(strided_expr_kernel_extra<N>),
-                    dst_child_dt, dst_child_arrmeta,
-                    N, src_child_dt, src_child_arrmeta,
-                    kernel_request_strided, ectx);
+  }
+  return elwise_handler->make_expr_kernel(
+      ckb, ckb_offset, dst_child_dt, dst_child_arrmeta, N, src_child_dt,
+      src_child_arrmeta, kernel_request_strided, ectx);
 }
 
 inline static size_t make_elwise_strided_dimension_expr_kernel(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 const ndt::type& dst_tp, const char *dst_arrmeta,
                 size_t src_count, const ndt::type *src_tp, const char *const*src_arrmeta,
                 kernel_request_t kernreq, const eval::eval_context *ectx,
@@ -135,42 +123,42 @@ inline static size_t make_elwise_strided_dimension_expr_kernel(
     switch (src_count) {
         case 1:
             return make_elwise_strided_dimension_expr_kernel_for_N<1>(
-                            out, offset_out,
+                            ckb, ckb_offset,
                             dst_tp, dst_arrmeta,
                             src_count, src_tp, src_arrmeta,
                             kernreq, ectx,
                             elwise_handler);
         case 2:
             return make_elwise_strided_dimension_expr_kernel_for_N<2>(
-                            out, offset_out,
+                            ckb, ckb_offset,
                             dst_tp, dst_arrmeta,
                             src_count, src_tp, src_arrmeta,
                             kernreq, ectx,
                             elwise_handler);
         case 3:
             return make_elwise_strided_dimension_expr_kernel_for_N<3>(
-                            out, offset_out,
+                            ckb, ckb_offset,
                             dst_tp, dst_arrmeta,
                             src_count, src_tp, src_arrmeta,
                             kernreq, ectx,
                             elwise_handler);
         case 4:
             return make_elwise_strided_dimension_expr_kernel_for_N<4>(
-                            out, offset_out,
+                            ckb, ckb_offset,
                             dst_tp, dst_arrmeta,
                             src_count, src_tp, src_arrmeta,
                             kernreq, ectx,
                             elwise_handler);
         case 5:
             return make_elwise_strided_dimension_expr_kernel_for_N<5>(
-                            out, offset_out,
+                            ckb, ckb_offset,
                             dst_tp, dst_arrmeta,
                             src_count, src_tp, src_arrmeta,
                             kernreq, ectx,
                             elwise_handler);
         case 6:
             return make_elwise_strided_dimension_expr_kernel_for_N<6>(
-                            out, offset_out,
+                            ckb, ckb_offset,
                             dst_tp, dst_arrmeta,
                             src_count, src_tp, src_arrmeta,
                             kernreq, ectx,
@@ -249,81 +237,72 @@ struct strided_or_var_to_strided_expr_kernel_extra {
     }
 };
 
-template<int N>
+template <int N>
 static size_t make_elwise_strided_or_var_to_strided_dimension_expr_kernel_for_N(
-                ckernel_builder *out, size_t offset_out,
-                const ndt::type& dst_tp, const char *dst_arrmeta,
-                size_t DYND_UNUSED(src_count), const ndt::type *src_tp, const char *const*src_arrmeta,
-                kernel_request_t kernreq, const eval::eval_context *ectx,
-                const expr_kernel_generator *elwise_handler)
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_tp,
+    const char *dst_arrmeta, size_t DYND_UNUSED(src_count),
+    const ndt::type *src_tp, const char *const *src_arrmeta,
+    kernel_request_t kernreq, const eval::eval_context *ectx,
+    const expr_kernel_generator *elwise_handler)
 {
-    intptr_t undim = dst_tp.get_ndim();
-    const char *dst_child_arrmeta;
-    const char *src_child_arrmeta[N];
-    ndt::type dst_child_dt;
-    ndt::type src_child_dt[N];
- 
-    out->ensure_capacity(offset_out + sizeof(strided_or_var_to_strided_expr_kernel_extra<N>));
-    strided_or_var_to_strided_expr_kernel_extra<N> *e =
-                    out->get_at<strided_or_var_to_strided_expr_kernel_extra<N> >(offset_out);
-    switch (kernreq) {
-        case kernel_request_single:
-            e->base.template set_function<expr_single_t>(&strided_or_var_to_strided_expr_kernel_extra<N>::single);
-            break;
-        case kernel_request_strided:
-            e->base.template set_function<expr_strided_t>(&strided_or_var_to_strided_expr_kernel_extra<N>::strided);
-            break;
-        default: {
-            stringstream ss;
-            ss << "make_elwise_strided_or_var_to_strided_dimension_expr_kernel: unrecognized request " << (int)kernreq;
-            throw runtime_error(ss.str());
-        }
-    }
-    e->base.destructor = strided_or_var_to_strided_expr_kernel_extra<N>::destruct;
-    // The dst strided parameters
-    if (!dst_tp.get_as_strided_dim(dst_arrmeta, e->size, e->dst_stride, dst_child_dt, dst_child_arrmeta)) {
-        throw type_error("make_elwise_strided_dimension_expr_kernel: dst was not strided as expected");
-    }
+  intptr_t undim = dst_tp.get_ndim();
+  const char *dst_child_arrmeta;
+  const char *src_child_arrmeta[N];
+  ndt::type dst_child_dt;
+  ndt::type src_child_dt[N];
 
-    for (int i = 0; i < N; ++i) {
-        intptr_t src_size;
-        // The src[i] strided parameters
-        if (src_tp[i].get_ndim() < undim) {
-            // This src value is getting broadcasted
-            e->src_stride[i] = 0;
-            e->src_offset[i] = 0;
-            e->is_src_var[i] = false;
-            src_child_arrmeta[i] = src_arrmeta[i];
-            src_child_dt[i] = src_tp[i];
-        } else if (src_tp[i].get_as_strided_dim(
-                       src_arrmeta[i], src_size, e->src_stride[i],
-                       src_child_dt[i], src_child_arrmeta[i])) {
-            // Check for a broadcasting error
-            if (src_size != 1 && e->size != src_size) {
-                throw broadcast_error(dst_tp, dst_arrmeta, src_tp[i], src_arrmeta[i]);
-            }
-            e->src_offset[i] = 0;
-            e->is_src_var[i] = false;
-        } else {
-            const var_dim_type *vdd = static_cast<const var_dim_type *>(src_tp[i].extended());
-            const var_dim_type_arrmeta *src_md =
-                            reinterpret_cast<const var_dim_type_arrmeta *>(src_arrmeta[i]);
-            e->src_stride[i] = src_md->stride;
-            e->src_offset[i] = src_md->offset;
-            e->is_src_var[i] = true;
-            src_child_arrmeta[i] = src_arrmeta[i] + sizeof(var_dim_type_arrmeta);
-            src_child_dt[i] = vdd->get_element_type();
-        }
+  strided_or_var_to_strided_expr_kernel_extra<N> *e =
+      ckb->alloc_ck<strided_or_var_to_strided_expr_kernel_extra<N> >(
+          ckb_offset);
+  e->base.template set_expr_function<
+      strided_or_var_to_strided_expr_kernel_extra<N> >(kernreq);
+  e->base.destructor =
+      &strided_or_var_to_strided_expr_kernel_extra<N>::destruct;
+  // The dst strided parameters
+  if (!dst_tp.get_as_strided_dim(dst_arrmeta, e->size, e->dst_stride,
+                                 dst_child_dt, dst_child_arrmeta)) {
+    throw type_error("make_elwise_strided_dimension_expr_kernel: dst was not "
+                     "strided as expected");
+  }
+
+  for (int i = 0; i < N; ++i) {
+    intptr_t src_size;
+    // The src[i] strided parameters
+    if (src_tp[i].get_ndim() < undim) {
+      // This src value is getting broadcasted
+      e->src_stride[i] = 0;
+      e->src_offset[i] = 0;
+      e->is_src_var[i] = false;
+      src_child_arrmeta[i] = src_arrmeta[i];
+      src_child_dt[i] = src_tp[i];
+    } else if (src_tp[i].get_as_strided_dim(src_arrmeta[i], src_size,
+                                            e->src_stride[i], src_child_dt[i],
+                                            src_child_arrmeta[i])) {
+      // Check for a broadcasting error
+      if (src_size != 1 && e->size != src_size) {
+        throw broadcast_error(dst_tp, dst_arrmeta, src_tp[i], src_arrmeta[i]);
+      }
+      e->src_offset[i] = 0;
+      e->is_src_var[i] = false;
+    } else {
+      const var_dim_type *vdd =
+          static_cast<const var_dim_type *>(src_tp[i].extended());
+      const var_dim_type_arrmeta *src_md =
+          reinterpret_cast<const var_dim_type_arrmeta *>(src_arrmeta[i]);
+      e->src_stride[i] = src_md->stride;
+      e->src_offset[i] = src_md->offset;
+      e->is_src_var[i] = true;
+      src_child_arrmeta[i] = src_arrmeta[i] + sizeof(var_dim_type_arrmeta);
+      src_child_dt[i] = vdd->get_element_type();
     }
-    return elwise_handler->make_expr_kernel(
-                    out, offset_out + sizeof(strided_or_var_to_strided_expr_kernel_extra<N>),
-                    dst_child_dt, dst_child_arrmeta,
-                    N, src_child_dt, src_child_arrmeta,
-                    kernel_request_strided, ectx);
+  }
+  return elwise_handler->make_expr_kernel(
+      ckb, ckb_offset, dst_child_dt, dst_child_arrmeta, N, src_child_dt,
+      src_child_arrmeta, kernel_request_strided, ectx);
 }
 
 static size_t make_elwise_strided_or_var_to_strided_dimension_expr_kernel(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 const ndt::type& dst_tp, const char *dst_arrmeta,
                 size_t src_count, const ndt::type *src_tp, const char *const*src_arrmeta,
                 kernel_request_t kernreq, const eval::eval_context *ectx,
@@ -332,42 +311,42 @@ static size_t make_elwise_strided_or_var_to_strided_dimension_expr_kernel(
     switch (src_count) {
         case 1:
             return make_elwise_strided_or_var_to_strided_dimension_expr_kernel_for_N<1>(
-                            out, offset_out,
+                            ckb, ckb_offset,
                             dst_tp, dst_arrmeta,
                             src_count, src_tp, src_arrmeta,
                             kernreq, ectx,
                             elwise_handler);
         case 2:
             return make_elwise_strided_or_var_to_strided_dimension_expr_kernel_for_N<2>(
-                            out, offset_out,
+                            ckb, ckb_offset,
                             dst_tp, dst_arrmeta,
                             src_count, src_tp, src_arrmeta,
                             kernreq, ectx,
                             elwise_handler);
         case 3:
             return make_elwise_strided_or_var_to_strided_dimension_expr_kernel_for_N<3>(
-                            out, offset_out,
+                            ckb, ckb_offset,
                             dst_tp, dst_arrmeta,
                             src_count, src_tp, src_arrmeta,
                             kernreq, ectx,
                             elwise_handler);
         case 4:
             return make_elwise_strided_or_var_to_strided_dimension_expr_kernel_for_N<4>(
-                            out, offset_out,
+                            ckb, ckb_offset,
                             dst_tp, dst_arrmeta,
                             src_count, src_tp, src_arrmeta,
                             kernreq, ectx,
                             elwise_handler);
         case 5:
             return make_elwise_strided_or_var_to_strided_dimension_expr_kernel_for_N<5>(
-                            out, offset_out,
+                            ckb, ckb_offset,
                             dst_tp, dst_arrmeta,
                             src_count, src_tp, src_arrmeta,
                             kernreq, ectx,
                             elwise_handler);
         case 6:
             return make_elwise_strided_or_var_to_strided_dimension_expr_kernel_for_N<6>(
-                            out, offset_out,
+                            ckb, ckb_offset,
                             dst_tp, dst_arrmeta,
                             src_count, src_tp, src_arrmeta,
                             kernreq, ectx,
@@ -507,217 +486,177 @@ struct strided_or_var_to_var_expr_kernel_extra {
 
 template<int N>
 static size_t make_elwise_strided_or_var_to_var_dimension_expr_kernel_for_N(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 const ndt::type& dst_tp, const char *dst_arrmeta,
                 size_t DYND_UNUSED(src_count), const ndt::type *src_tp, const char *const*src_arrmeta,
                 kernel_request_t kernreq, const eval::eval_context *ectx,
                 const expr_kernel_generator *elwise_handler)
 {
-    intptr_t undim = dst_tp.get_ndim();
-    const char *dst_child_arrmeta;
-    const char *src_child_arrmeta[N];
-    ndt::type dst_child_dt;
-    ndt::type src_child_dt[N];
- 
-    out->ensure_capacity(offset_out + sizeof(strided_or_var_to_var_expr_kernel_extra<N>));
-    strided_or_var_to_var_expr_kernel_extra<N> *e =
-                    out->get_at<strided_or_var_to_var_expr_kernel_extra<N> >(offset_out);
-    switch (kernreq) {
-        case kernel_request_single:
-            e->base.template set_function<expr_single_t>(
-                            &strided_or_var_to_var_expr_kernel_extra<N>::single);
-            break;
-        case kernel_request_strided:
-            e->base.template set_function<expr_strided_t>(
-                            &strided_or_var_to_var_expr_kernel_extra<N>::strided);
-            break;
-        default: {
-            stringstream ss;
-            ss << "make_elwise_strided_or_var_to_var_dimension_expr_kernel: unrecognized request " << (int)kernreq;
-            throw runtime_error(ss.str());
-        }
-    }
-    e->base.destructor = strided_or_var_to_var_expr_kernel_extra<N>::destruct;
-    // The dst var parameters
-    const var_dim_type *dst_vdd = dst_tp.tcast<var_dim_type>();
-    const var_dim_type_arrmeta *dst_md =
-                    reinterpret_cast<const var_dim_type_arrmeta *>(dst_arrmeta);
-    e->dst_memblock = dst_md->blockref;
-    e->dst_stride = dst_md->stride;
-    e->dst_offset = dst_md->offset;
-    e->dst_target_alignment = dst_vdd->get_target_alignment();
-    dst_child_arrmeta = dst_arrmeta + sizeof(var_dim_type_arrmeta);
-    dst_child_dt = dst_vdd->get_element_type();
+  intptr_t undim = dst_tp.get_ndim();
+  const char *dst_child_arrmeta;
+  const char *src_child_arrmeta[N];
+  ndt::type dst_child_dt;
+  ndt::type src_child_dt[N];
 
-    for (int i = 0; i < N; ++i) {
-        intptr_t src_size;
-        // The src[i] strided parameters
-        if (src_tp[i].get_ndim() < undim) {
-            // This src value is getting broadcasted
-            e->src_stride[i] = 0;
-            e->src_offset[i] = 0;
-            e->is_src_var[i] = false;
-            src_child_arrmeta[i] = src_arrmeta[i];
-            src_child_dt[i] = src_tp[i];
-        } else if (src_tp[i].get_as_strided_dim(src_arrmeta[i], src_size, e->src_stride[i], src_child_dt[i], src_child_arrmeta[i])) {
-            // Check for a broadcasting error (the strided dimension size must be 1,
-            // otherwise the destination should be strided, not var)
-            if (src_size != 1) {
-                throw broadcast_error(dst_tp, dst_arrmeta, src_tp[i], src_arrmeta[i]);
-            }
-            e->src_offset[i] = 0;
-            e->is_src_var[i] = false;
-        } else {
-            const var_dim_type *vdd = static_cast<const var_dim_type *>(src_tp[i].extended());
-            const var_dim_type_arrmeta *src_md =
-                            reinterpret_cast<const var_dim_type_arrmeta *>(src_arrmeta[i]);
-            e->src_stride[i] = src_md->stride;
-            e->src_offset[i] = src_md->offset;
-            e->is_src_var[i] = true;
-            src_child_arrmeta[i] = src_arrmeta[i] + sizeof(var_dim_type_arrmeta);
-            src_child_dt[i] = vdd->get_element_type();
-        }
+  strided_or_var_to_var_expr_kernel_extra<N> *e =
+      ckb->alloc_ck<strided_or_var_to_var_expr_kernel_extra<N> >(ckb_offset);
+  e->base.template set_expr_function<strided_or_var_to_var_expr_kernel_extra<N> >(
+      kernreq);
+  e->base.destructor = &strided_or_var_to_var_expr_kernel_extra<N>::destruct;
+  // The dst var parameters
+  const var_dim_type *dst_vdd = dst_tp.tcast<var_dim_type>();
+  const var_dim_type_arrmeta *dst_md =
+      reinterpret_cast<const var_dim_type_arrmeta *>(dst_arrmeta);
+  e->dst_memblock = dst_md->blockref;
+  e->dst_stride = dst_md->stride;
+  e->dst_offset = dst_md->offset;
+  e->dst_target_alignment = dst_vdd->get_target_alignment();
+  dst_child_arrmeta = dst_arrmeta + sizeof(var_dim_type_arrmeta);
+  dst_child_dt = dst_vdd->get_element_type();
+
+  for (int i = 0; i < N; ++i) {
+    intptr_t src_size;
+    // The src[i] strided parameters
+    if (src_tp[i].get_ndim() < undim) {
+      // This src value is getting broadcasted
+      e->src_stride[i] = 0;
+      e->src_offset[i] = 0;
+      e->is_src_var[i] = false;
+      src_child_arrmeta[i] = src_arrmeta[i];
+      src_child_dt[i] = src_tp[i];
+    } else if (src_tp[i].get_as_strided_dim(src_arrmeta[i], src_size,
+                                            e->src_stride[i], src_child_dt[i],
+                                            src_child_arrmeta[i])) {
+      // Check for a broadcasting error (the strided dimension size must be 1,
+      // otherwise the destination should be strided, not var)
+      if (src_size != 1) {
+        throw broadcast_error(dst_tp, dst_arrmeta, src_tp[i], src_arrmeta[i]);
+      }
+      e->src_offset[i] = 0;
+      e->is_src_var[i] = false;
+    } else {
+      const var_dim_type *vdd =
+          static_cast<const var_dim_type *>(src_tp[i].extended());
+      const var_dim_type_arrmeta *src_md =
+          reinterpret_cast<const var_dim_type_arrmeta *>(src_arrmeta[i]);
+      e->src_stride[i] = src_md->stride;
+      e->src_offset[i] = src_md->offset;
+      e->is_src_var[i] = true;
+      src_child_arrmeta[i] = src_arrmeta[i] + sizeof(var_dim_type_arrmeta);
+      src_child_dt[i] = vdd->get_element_type();
     }
-    return elwise_handler->make_expr_kernel(
-                    out, offset_out + sizeof(strided_or_var_to_var_expr_kernel_extra<N>),
-                    dst_child_dt, dst_child_arrmeta,
-                    N, src_child_dt, src_child_arrmeta,
-                    kernel_request_strided, ectx);
+  }
+  return elwise_handler->make_expr_kernel(
+      ckb, ckb_offset, dst_child_dt, dst_child_arrmeta, N, src_child_dt,
+      src_child_arrmeta, kernel_request_strided, ectx);
 }
 
 static size_t make_elwise_strided_or_var_to_var_dimension_expr_kernel(
-                ckernel_builder *out, size_t offset_out,
-                const ndt::type& dst_tp, const char *dst_arrmeta,
-                size_t src_count, const ndt::type *src_tp, const char *const*src_arrmeta,
-                kernel_request_t kernreq, const eval::eval_context *ectx,
-                const expr_kernel_generator *elwise_handler)
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_tp,
+    const char *dst_arrmeta, size_t src_count, const ndt::type *src_tp,
+    const char *const *src_arrmeta, kernel_request_t kernreq,
+    const eval::eval_context *ectx, const expr_kernel_generator *elwise_handler)
 {
-    switch (src_count) {
-        case 1:
-            return make_elwise_strided_or_var_to_var_dimension_expr_kernel_for_N<1>(
-                            out, offset_out,
-                            dst_tp, dst_arrmeta,
-                            src_count, src_tp, src_arrmeta,
-                            kernreq, ectx,
-                            elwise_handler);
-        case 2:
-            return make_elwise_strided_or_var_to_var_dimension_expr_kernel_for_N<2>(
-                            out, offset_out,
-                            dst_tp, dst_arrmeta,
-                            src_count, src_tp, src_arrmeta,
-                            kernreq, ectx,
-                            elwise_handler);
-        case 3:
-            return make_elwise_strided_or_var_to_var_dimension_expr_kernel_for_N<3>(
-                            out, offset_out,
-                            dst_tp, dst_arrmeta,
-                            src_count, src_tp, src_arrmeta,
-                            kernreq, ectx,
-                            elwise_handler);
-        case 4:
-            return make_elwise_strided_or_var_to_var_dimension_expr_kernel_for_N<4>(
-                            out, offset_out,
-                            dst_tp, dst_arrmeta,
-                            src_count, src_tp, src_arrmeta,
-                            kernreq, ectx,
-                            elwise_handler);
-        case 5:
-            return make_elwise_strided_or_var_to_var_dimension_expr_kernel_for_N<5>(
-                            out, offset_out,
-                            dst_tp, dst_arrmeta,
-                            src_count, src_tp, src_arrmeta,
-                            kernreq, ectx,
-                            elwise_handler);
-        case 6:
-            return make_elwise_strided_or_var_to_var_dimension_expr_kernel_for_N<6>(
-                            out, offset_out,
-                            dst_tp, dst_arrmeta,
-                            src_count, src_tp, src_arrmeta,
-                            kernreq, ectx,
-                            elwise_handler);
-        default:
-            throw runtime_error("make_elwise_strided_or_var_to_var_dimension_expr_kernel with src_count > 6 not implemented yet");
-    }
+  switch (src_count) {
+  case 1:
+    return make_elwise_strided_or_var_to_var_dimension_expr_kernel_for_N<1>(
+        ckb, ckb_offset, dst_tp, dst_arrmeta, src_count, src_tp, src_arrmeta,
+        kernreq, ectx, elwise_handler);
+  case 2:
+    return make_elwise_strided_or_var_to_var_dimension_expr_kernel_for_N<2>(
+        ckb, ckb_offset, dst_tp, dst_arrmeta, src_count, src_tp, src_arrmeta,
+        kernreq, ectx, elwise_handler);
+  case 3:
+    return make_elwise_strided_or_var_to_var_dimension_expr_kernel_for_N<3>(
+        ckb, ckb_offset, dst_tp, dst_arrmeta, src_count, src_tp, src_arrmeta,
+        kernreq, ectx, elwise_handler);
+  case 4:
+    return make_elwise_strided_or_var_to_var_dimension_expr_kernel_for_N<4>(
+        ckb, ckb_offset, dst_tp, dst_arrmeta, src_count, src_tp, src_arrmeta,
+        kernreq, ectx, elwise_handler);
+  case 5:
+    return make_elwise_strided_or_var_to_var_dimension_expr_kernel_for_N<5>(
+        ckb, ckb_offset, dst_tp, dst_arrmeta, src_count, src_tp, src_arrmeta,
+        kernreq, ectx, elwise_handler);
+  case 6:
+    return make_elwise_strided_or_var_to_var_dimension_expr_kernel_for_N<6>(
+        ckb, ckb_offset, dst_tp, dst_arrmeta, src_count, src_tp, src_arrmeta,
+        kernreq, ectx, elwise_handler);
+  default:
+    throw runtime_error("make_elwise_strided_or_var_to_var_dimension_expr_"
+                        "kernel with src_count > 6 not implemented yet");
+  }
 }
 
-size_t dynd::make_elwise_dimension_expr_kernel(ckernel_builder *out, size_t offset_out,
-                const ndt::type& dst_tp, const char *dst_arrmeta,
-                size_t src_count, const ndt::type *src_tp, const char *const*src_arrmeta,
-                kernel_request_t kernreq, const eval::eval_context *ectx,
-                const expr_kernel_generator *elwise_handler)
+size_t dynd::make_elwise_dimension_expr_kernel(
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_tp,
+    const char *dst_arrmeta, size_t src_count, const ndt::type *src_tp,
+    const char *const *src_arrmeta, kernel_request_t kernreq,
+    const eval::eval_context *ectx, const expr_kernel_generator *elwise_handler)
 {
-    // Do a pass through the src types to classify them
-    bool src_all_strided = true, src_all_strided_or_var = true;
-    for (size_t i = 0; i != src_count; ++i) {
-        switch (src_tp[i].get_type_id()) {
-            case strided_dim_type_id:
-            case fixed_dim_type_id:
-            case cfixed_dim_type_id:
-                break;
-            case var_dim_type_id:
-                src_all_strided = false;
-                break;
-            default:
-                // If it's a scalar, allow it to broadcast like
-                // a strided dimension
-                if (src_tp[i].get_ndim() > 0) {
-                    src_all_strided_or_var = false;
-                }
-                break;
-        }
+  // Do a pass through the src types to classify them
+  bool src_all_strided = true, src_all_strided_or_var = true;
+  for (size_t i = 0; i != src_count; ++i) {
+    switch (src_tp[i].get_type_id()) {
+    case strided_dim_type_id:
+    case fixed_dim_type_id:
+    case cfixed_dim_type_id:
+      break;
+    case var_dim_type_id:
+      src_all_strided = false;
+      break;
+    default:
+      // If it's a scalar, allow it to broadcast like
+      // a strided dimension
+      if (src_tp[i].get_ndim() > 0) {
+        src_all_strided_or_var = false;
+      }
+      break;
     }
+  }
 
-    // Call to some special-case functions based on the
-    // destination type
-    switch (dst_tp.get_type_id()) {
-        case strided_dim_type_id:
-        case fixed_dim_type_id:
-        case cfixed_dim_type_id:
-            if (src_all_strided) {
-                return make_elwise_strided_dimension_expr_kernel(
-                                out, offset_out,
-                                dst_tp, dst_arrmeta,
-                                src_count, src_tp, src_arrmeta,
-                                kernreq, ectx,
-                                elwise_handler);
-            } else if (src_all_strided_or_var) {
-                return make_elwise_strided_or_var_to_strided_dimension_expr_kernel(
-                                out, offset_out,
-                                dst_tp, dst_arrmeta,
-                                src_count, src_tp, src_arrmeta,
-                                kernreq, ectx,
-                                elwise_handler);
-            } else {
-                // TODO
-            }
-            break;
-        case var_dim_type_id:
-            if (src_all_strided_or_var) {
-                return make_elwise_strided_or_var_to_var_dimension_expr_kernel(
-                                out, offset_out,
-                                dst_tp, dst_arrmeta,
-                                src_count, src_tp, src_arrmeta,
-                                kernreq, ectx,
-                                elwise_handler);
-            } else {
-                // TODO
-            }
-            break;
-        case offset_dim_type_id:
-            // TODO
-            break;
-        default:
-            break;
+  // Call to some special-case functions based on the
+  // destination type
+  switch (dst_tp.get_type_id()) {
+  case strided_dim_type_id:
+  case fixed_dim_type_id:
+  case cfixed_dim_type_id:
+    if (src_all_strided) {
+      return make_elwise_strided_dimension_expr_kernel(
+          ckb, ckb_offset, dst_tp, dst_arrmeta, src_count, src_tp, src_arrmeta,
+          kernreq, ectx, elwise_handler);
+    } else if (src_all_strided_or_var) {
+      return make_elwise_strided_or_var_to_strided_dimension_expr_kernel(
+          ckb, ckb_offset, dst_tp, dst_arrmeta, src_count, src_tp, src_arrmeta,
+          kernreq, ectx, elwise_handler);
+    } else {
+      // TODO
     }
+    break;
+  case var_dim_type_id:
+    if (src_all_strided_or_var) {
+      return make_elwise_strided_or_var_to_var_dimension_expr_kernel(
+          ckb, ckb_offset, dst_tp, dst_arrmeta, src_count, src_tp, src_arrmeta,
+          kernreq, ectx, elwise_handler);
+    } else {
+      // TODO
+    }
+    break;
+  case offset_dim_type_id:
+    // TODO
+    break;
+  default:
+    break;
+  }
 
-    stringstream ss;
-    ss << "Cannot evaluate elwise expression from (";
-    for (size_t i = 0; i != src_count; ++i) {
-        ss << src_tp[i];
-        if (i != src_count - 1) {
-            ss << ", ";
-        }
+  stringstream ss;
+  ss << "Cannot evaluate elwise expression from (";
+  for (size_t i = 0; i != src_count; ++i) {
+    ss << src_tp[i];
+    if (i != src_count - 1) {
+      ss << ", ";
     }
-    ss << ") to " << dst_tp;
-    throw runtime_error(ss.str());
+  }
+  ss << ") to " << dst_tp;
+  throw runtime_error(ss.str());
 }

--- a/src/dynd/kernels/expr_kernels.cpp
+++ b/src/dynd/kernels/expr_kernels.cpp
@@ -21,7 +21,7 @@ struct expression_type_expr_kernel_extra {
 
 } // anonymous namespace
 
-size_t dynd::make_expression_type_expr_kernel(ckernel_builder *DYND_UNUSED(out), size_t DYND_UNUSED(offset_out),
+size_t dynd::make_expression_type_expr_kernel(ckernel_builder *DYND_UNUSED(ckb), intptr_t DYND_UNUSED(ckb_offset),
                 const ndt::type& DYND_UNUSED(dst_tp), const char *DYND_UNUSED(dst_arrmeta),
                 size_t DYND_UNUSED(src_count), const ndt::type *DYND_UNUSED(src_tp), const char **DYND_UNUSED(src_arrmeta),
                 kernel_request_t DYND_UNUSED(kernreq), const eval::eval_context *DYND_UNUSED(ectx),

--- a/src/dynd/kernels/expression_assignment_kernels.cpp
+++ b/src/dynd/kernels/expression_assignment_kernels.cpp
@@ -156,10 +156,11 @@ namespace {
 } // anonymous namespace
 
 size_t dynd::make_expression_assignment_kernel(
-    ckernel_builder *out, size_t offset_out, const ndt::type &dst_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_tp,
     const char *dst_arrmeta, const ndt::type &src_tp, const char *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx)
 {
+    intptr_t root_ckb_offset = ckb_offset;
     if (dst_tp.get_kind() == expression_kind) {
         const base_expression_type *dst_bed = dst_tp.tcast<base_expression_type>();
         if (src_tp == dst_bed->get_value_type()) {
@@ -167,31 +168,31 @@ size_t dynd::make_expression_assignment_kernel(
             const ndt::type& opdt = dst_bed->get_operand_type();
             if (opdt.get_kind() != expression_kind) {
                 // Leaf case, just a single value -> operand kernel
-                return dst_bed->make_value_to_operand_assignment_kernel(out, offset_out,
+                return dst_bed->make_value_to_operand_assignment_kernel(ckb, ckb_offset,
                                 dst_arrmeta, src_arrmeta, kernreq, ectx);
             } else {
                 // Chain case, buffer one segment of the chain
                 const ndt::type& buffer_tp = static_cast<const base_expression_type *>(
                                     opdt.extended())->get_value_type();
-                out->ensure_capacity(offset_out + sizeof(buffered_kernel_extra));
-                buffered_kernel_extra *e = out->get_at<buffered_kernel_extra>(offset_out);
+                buffered_kernel_extra *e = ckb->alloc_ck<buffered_kernel_extra>(ckb_offset);
                 e->init(buffer_tp, kernreq);
-                size_t buffer_data_size = e->buffer_data_size;
                 // Construct the first kernel (src -> buffer)
-                e->first_kernel_offset = sizeof(buffered_kernel_extra);
-                size_t buffer_data_offset;
-                buffer_data_offset = dst_bed->make_value_to_operand_assignment_kernel(
-                                out, offset_out + e->first_kernel_offset,
-                                e->buffer_arrmeta, src_arrmeta, kernreq, ectx);
+                e->first_kernel_offset = ckb_offset - root_ckb_offset;
+                ckb_offset = dst_bed->make_value_to_operand_assignment_kernel(
+                    ckb, ckb_offset, e->buffer_arrmeta, src_arrmeta, kernreq,
+                    ectx);
                 // Allocate the buffer data
-                buffer_data_offset = inc_to_alignment(buffer_data_offset, buffer_tp.get_data_alignment());
-                out->ensure_capacity(offset_out + buffer_data_offset + buffer_data_size);
+                ckb_offset = inc_to_alignment(ckb_offset,
+                                              buffer_tp.get_data_alignment());
+                intptr_t buffer_data_offset = ckb_offset;
+                kernels::inc_ckb_offset(ckb_offset, e->buffer_data_size);
+                ckb->ensure_capacity(ckb_offset);
                 // This may have invalidated the 'e' pointer, so get it again!
-                e = out->get_at<buffered_kernel_extra>(offset_out);
-                e->buffer_data_offset = buffer_data_offset;
+                e = ckb->get_at<buffered_kernel_extra>(root_ckb_offset);
+                e->buffer_data_offset = buffer_data_offset - root_ckb_offset;
                 // Construct the second kernel (buffer -> dst)
-                e->second_kernel_offset = buffer_data_offset + e->buffer_data_size;
-                return ::make_assignment_kernel(out, offset_out + e->second_kernel_offset,
+                e->second_kernel_offset = ckb_offset - root_ckb_offset;
+                return ::make_assignment_kernel(ckb, ckb_offset,
                                 opdt, dst_arrmeta,
                                 buffer_tp, e->buffer_arrmeta,
                                 kernreq, ectx);
@@ -207,26 +208,26 @@ size_t dynd::make_expression_assignment_kernel(
                 // the src value type to dst type as the two segments to buffer together
                 buffer_tp = src_tp.value_type();
             }
-            out->ensure_capacity(offset_out + sizeof(buffered_kernel_extra));
-            buffered_kernel_extra *e = out->get_at<buffered_kernel_extra>(offset_out);
+            buffered_kernel_extra *e =
+                ckb->alloc_ck<buffered_kernel_extra>(ckb_offset);
             e->init(buffer_tp, kernreq);
-            size_t buffer_data_size = e->buffer_data_size;
             // Construct the first kernel (src -> buffer)
-            e->first_kernel_offset = sizeof(buffered_kernel_extra);
-            size_t buffer_data_offset;
-            buffer_data_offset = ::make_assignment_kernel(out, offset_out + e->first_kernel_offset,
+            e->first_kernel_offset = ckb_offset - root_ckb_offset;
+            ckb_offset = ::make_assignment_kernel(ckb, ckb_offset,
                             buffer_tp, e->buffer_arrmeta,
                             src_tp, src_arrmeta,
                             kernreq, ectx);
+            ckb_offset = inc_to_alignment(ckb_offset, buffer_tp.get_data_alignment());
             // Allocate the buffer data
-            buffer_data_offset = inc_to_alignment(buffer_data_offset, buffer_tp.get_data_alignment());
-            out->ensure_capacity(offset_out + buffer_data_offset + buffer_data_size);
+            intptr_t buffer_data_offset = ckb_offset;
+            kernels::inc_ckb_offset(ckb_offset, e->buffer_data_size);
+            ckb->ensure_capacity(ckb_offset);
             // This may have invalidated the 'e' pointer, so get it again!
-            e = out->get_at<buffered_kernel_extra>(offset_out);
-            e->buffer_data_offset = buffer_data_offset;
+            e = ckb->get_at<buffered_kernel_extra>(root_ckb_offset);
+            e->buffer_data_offset = buffer_data_offset - root_ckb_offset;
             // Construct the second kernel (buffer -> dst)
-            e->second_kernel_offset = buffer_data_offset + e->buffer_data_size;
-            return ::make_assignment_kernel(out, offset_out + e->second_kernel_offset,
+            e->second_kernel_offset = ckb_offset - root_ckb_offset;
+            return ::make_assignment_kernel(ckb, ckb_offset,
                             dst_tp, dst_arrmeta,
                             buffer_tp, e->buffer_arrmeta,
                             kernreq, ectx);
@@ -238,59 +239,59 @@ size_t dynd::make_expression_assignment_kernel(
             const ndt::type& opdt = src_bed->get_operand_type();
             if (opdt.get_kind() != expression_kind) {
                 // Leaf case, just a single value -> operand kernel
-                return src_bed->make_operand_to_value_assignment_kernel(out, offset_out,
+                return src_bed->make_operand_to_value_assignment_kernel(ckb, ckb_offset,
                                 dst_arrmeta, src_arrmeta, kernreq, ectx);
             } else {
                 // Chain case, buffer one segment of the chain
                 const ndt::type& buffer_tp = static_cast<const base_expression_type *>(
                                 opdt.extended())->get_value_type();
-                out->ensure_capacity(offset_out + sizeof(buffered_kernel_extra));
-                buffered_kernel_extra *e = out->get_at<buffered_kernel_extra>(offset_out);
+                buffered_kernel_extra *e = ckb->alloc_ck<buffered_kernel_extra>(ckb_offset);
                 e->init(buffer_tp, kernreq);
                 size_t buffer_data_size = e->buffer_data_size;
                 // Construct the first kernel (src -> buffer)
-                e->first_kernel_offset = sizeof(buffered_kernel_extra);
-                size_t buffer_data_offset;
-                buffer_data_offset = ::make_assignment_kernel(
-                    out, offset_out + e->first_kernel_offset, buffer_tp,
+                e->first_kernel_offset = ckb_offset - root_ckb_offset;
+                ckb_offset = ::make_assignment_kernel(
+                    ckb, ckb_offset, buffer_tp,
                     e->buffer_arrmeta, opdt, src_arrmeta, kernreq, ectx);
                 // Allocate the buffer data
-                buffer_data_offset = inc_to_alignment(buffer_data_offset, buffer_tp.get_data_alignment());
-                out->ensure_capacity(offset_out + buffer_data_offset + buffer_data_size);
+                ckb_offset = inc_to_alignment(ckb_offset, buffer_tp.get_data_alignment());
+                size_t buffer_data_offset = ckb_offset;
+                kernels::inc_ckb_offset(ckb_offset, buffer_data_size);
+                ckb->ensure_capacity(ckb_offset);
                 // This may have invalidated the 'e' pointer, so get it again!
-                e = out->get_at<buffered_kernel_extra>(offset_out);
-                e->buffer_data_offset = buffer_data_offset;
+                e = ckb->get_at<buffered_kernel_extra>(root_ckb_offset);
+                e->buffer_data_offset = buffer_data_offset - root_ckb_offset;
                 // Construct the second kernel (buffer -> dst)
-                e->second_kernel_offset = buffer_data_offset + e->buffer_data_size;
+                e->second_kernel_offset = ckb_offset - root_ckb_offset;
                 return src_bed->make_operand_to_value_assignment_kernel(
-                                out, offset_out + e->second_kernel_offset,
+                                ckb, ckb_offset,
                                 dst_arrmeta, e->buffer_arrmeta, kernreq, ectx);
             }
         } else {
             // Put together the src expression chain and the src value type
             // to dst value type conversion
             const ndt::type& buffer_tp = src_tp.value_type();
-            out->ensure_capacity(offset_out + sizeof(buffered_kernel_extra));
-            buffered_kernel_extra *e = out->get_at<buffered_kernel_extra>(offset_out);
+            buffered_kernel_extra *e = ckb->alloc_ck<buffered_kernel_extra>(ckb_offset);
             e->init(buffer_tp, kernreq);
             size_t buffer_data_size = e->buffer_data_size;
             // Construct the first kernel (src -> buffer)
-            e->first_kernel_offset = sizeof(buffered_kernel_extra);
-            size_t buffer_data_offset;
-            buffer_data_offset = ::make_assignment_kernel(
-                out, offset_out + e->first_kernel_offset, buffer_tp,
-                e->buffer_arrmeta, src_tp, src_arrmeta, kernreq, ectx);
+            e->first_kernel_offset = ckb_offset - root_ckb_offset;
+            ckb_offset = ::make_assignment_kernel(ckb, ckb_offset, buffer_tp,
+                                                  e->buffer_arrmeta, src_tp,
+                                                  src_arrmeta, kernreq, ectx);
             // Allocate the buffer data
-            buffer_data_offset = inc_to_alignment(
-                buffer_data_offset, buffer_tp.get_data_alignment());
-            out->ensure_capacity(offset_out + buffer_data_offset + buffer_data_size);
+            ckb_offset =
+                inc_to_alignment(ckb_offset, buffer_tp.get_data_alignment());
+            size_t buffer_data_offset = ckb_offset;
+            kernels::inc_ckb_offset(ckb_offset, buffer_data_size);
+            ckb->ensure_capacity(ckb_offset);
             // This may have invalidated the 'e' pointer, so get it again!
-            e = out->get_at<buffered_kernel_extra>(offset_out);
-            e->buffer_data_offset = buffer_data_offset;
+            e = ckb->get_at<buffered_kernel_extra>(root_ckb_offset);
+            e->buffer_data_offset = buffer_data_offset - root_ckb_offset;
             // Construct the second kernel (buffer -> dst)
-            e->second_kernel_offset = buffer_data_offset + e->buffer_data_size;
+            e->second_kernel_offset = ckb_offset - root_ckb_offset;
             return ::make_assignment_kernel(
-                out, offset_out + e->second_kernel_offset, dst_tp, dst_arrmeta,
+                ckb, ckb_offset, dst_tp, dst_arrmeta,
                 buffer_tp, e->buffer_arrmeta, kernreq, ectx);
         }
     }

--- a/src/dynd/kernels/make_lifted_reduction_ckernel.cpp
+++ b/src/dynd/kernels/make_lifted_reduction_ckernel.cpp
@@ -636,13 +636,11 @@ struct strided_inner_broadcast_kernel_extra {
  * the final dimension before the accumulation operation.
  */
 static size_t make_strided_initial_reduction_dimension_kernel(
-            ckernel_builder *out_ckb, size_t ckb_offset,
+            ckernel_builder *ckb, intptr_t ckb_offset,
             intptr_t src_stride, intptr_t src_size,
             kernel_request_t kernreq)
 {
-    intptr_t ckb_end = ckb_offset + sizeof(strided_initial_reduction_kernel_extra);
-    out_ckb->ensure_capacity(ckb_end);
-    strided_initial_reduction_kernel_extra *e = out_ckb->get_at<strided_initial_reduction_kernel_extra>(ckb_offset);
+    strided_initial_reduction_kernel_extra *e = ckb->alloc_ck<strided_initial_reduction_kernel_extra>(ckb_offset);
     e->base().destructor = &strided_initial_reduction_kernel_extra::destruct;
     // Get the function pointer for the first_call
     if (kernreq == kernel_request_single) {
@@ -659,7 +657,7 @@ static size_t make_strided_initial_reduction_dimension_kernel(
     // The striding parameters
     e->src_stride = src_stride;
     e->size = src_size;
-    return ckb_end;
+    return ckb_offset;
 }
 
 /**
@@ -668,13 +666,11 @@ static size_t make_strided_initial_reduction_dimension_kernel(
  * the final dimension before the accumulation operation.
  */
 static size_t make_strided_initial_broadcast_dimension_kernel(
-            ckernel_builder *out_ckb, size_t ckb_offset,
+            ckernel_builder *ckb, intptr_t ckb_offset,
             intptr_t dst_stride, intptr_t src_stride, intptr_t src_size,
             kernel_request_t kernreq)
 {
-    intptr_t ckb_end = ckb_offset + sizeof(strided_initial_broadcast_kernel_extra);
-    out_ckb->ensure_capacity(ckb_end);
-    strided_initial_broadcast_kernel_extra *e = out_ckb->get_at<strided_initial_broadcast_kernel_extra>(ckb_offset);
+    strided_initial_broadcast_kernel_extra *e = ckb->alloc_ck<strided_initial_broadcast_kernel_extra>(ckb_offset);
     e->base().destructor = &strided_initial_broadcast_kernel_extra::destruct;
     // Get the function pointer for the first_call
     if (kernreq == kernel_request_single) {
@@ -692,7 +688,7 @@ static size_t make_strided_initial_broadcast_dimension_kernel(
     e->dst_stride = dst_stride;
     e->src_stride = src_stride;
     e->size = src_size;
-    return ckb_end;
+    return ckb_offset;
 }
 
 static void check_dst_initialization(const arrfunc_type_data *dst_initialization,
@@ -724,121 +720,128 @@ static void check_dst_initialization(const arrfunc_type_data *dst_initialization
  */
 static size_t make_strided_inner_reduction_dimension_kernel(
     const arrfunc_type_data *elwise_reduction,
-    const arrfunc_type_data *dst_initialization, ckernel_builder *out_ckb,
-    size_t ckb_offset, intptr_t src_stride, intptr_t src_size,
+    const arrfunc_type_data *dst_initialization, ckernel_builder *ckb,
+    intptr_t ckb_offset, intptr_t src_stride, intptr_t src_size,
     const ndt::type &dst_tp, const char *dst_arrmeta, const ndt::type &src_tp,
     const char *src_arrmeta, bool right_associative,
     const nd::array &reduction_identity, kernel_request_t kernreq,
     const eval::eval_context *ectx)
 {
-    intptr_t ckb_end = ckb_offset + sizeof(strided_inner_reduction_kernel_extra);
-    out_ckb->ensure_capacity(ckb_end);
-    strided_inner_reduction_kernel_extra *e = out_ckb->get_at<strided_inner_reduction_kernel_extra>(ckb_offset);
-    e->base().destructor = &strided_inner_reduction_kernel_extra::destruct;
-    // Cannot have both a dst_initialization kernel and a reduction identity
-    if (dst_initialization != NULL && !reduction_identity.is_null()) {
-        throw invalid_argument("make_lifted_reduction_ckernel: cannot specify"
-            " both a dst_initialization kernel and a reduction_identity");
-    }
-    if (reduction_identity.is_null()) {
-        // Get the function pointer for the first_call, for the case with
-        // no reduction identity
-        if (kernreq == kernel_request_single) {
-            e->ckpbase.set_first_call_function(&strided_inner_reduction_kernel_extra::single_first);
-        } else if (kernreq == kernel_request_strided) {
-            e->ckpbase.set_first_call_function(&strided_inner_reduction_kernel_extra::strided_first);
-        } else {
-            stringstream ss;
-            ss << "make_lifted_reduction_ckernel: unrecognized request " << (int)kernreq;
-            throw runtime_error(ss.str());
-        }
+  intptr_t root_ckb_offset = ckb_offset;
+  strided_inner_reduction_kernel_extra *e =
+      ckb->alloc_ck<strided_inner_reduction_kernel_extra>(ckb_offset);
+  e->base().destructor = &strided_inner_reduction_kernel_extra::destruct;
+  // Cannot have both a dst_initialization kernel and a reduction identity
+  if (dst_initialization != NULL && !reduction_identity.is_null()) {
+    throw invalid_argument(
+        "make_lifted_reduction_ckernel: cannot specify"
+        " both a dst_initialization kernel and a reduction_identity");
+  }
+  if (reduction_identity.is_null()) {
+    // Get the function pointer for the first_call, for the case with
+    // no reduction identity
+    if (kernreq == kernel_request_single) {
+      e->ckpbase.set_first_call_function(
+          &strided_inner_reduction_kernel_extra::single_first);
+    } else if (kernreq == kernel_request_strided) {
+      e->ckpbase.set_first_call_function(
+          &strided_inner_reduction_kernel_extra::strided_first);
     } else {
-        // Get the function pointer for the first_call, for the case with
-        // a reduction identity
-        if (kernreq == kernel_request_single) {
-            e->ckpbase.set_first_call_function(&strided_inner_reduction_kernel_extra::single_first_with_ident);
-        } else if (kernreq == kernel_request_strided) {
-            e->ckpbase.set_first_call_function(&strided_inner_reduction_kernel_extra::strided_first_with_ident);
-        } else {
-            stringstream ss;
-            ss << "make_lifted_reduction_ckernel: unrecognized request " << (int)kernreq;
-            throw runtime_error(ss.str());
-        }
-        if (reduction_identity.get_type() != dst_tp) {
-            stringstream ss;
-            ss << "make_lifted_reduction_ckernel: reduction identity type ";
-            ss << reduction_identity.get_type() << " does not match dst type ";
-            ss << dst_tp;
-            throw runtime_error(ss.str());
-        }
-        e->ident_data = reduction_identity.get_readonly_originptr();
-        e->ident_ref = reduction_identity.get_memblock().release();
+      stringstream ss;
+      ss << "make_lifted_reduction_ckernel: unrecognized request "
+         << (int)kernreq;
+      throw runtime_error(ss.str());
     }
-    // The function pointer for followup accumulation calls
-    e->ckpbase.set_followup_call_function(&strided_inner_reduction_kernel_extra::strided_followup);
-    // The striding parameters
-    e->src_stride = src_stride;
-    e->size = src_size;
-    // Validate that the provided arrfuncs are unary operations,
-    // and have the correct types
-    if (elwise_reduction->get_param_count() != 1 &&
-            elwise_reduction->get_param_count() != 2) {
-        stringstream ss;
-        ss << "make_lifted_reduction_ckernel: elwise reduction ckernel ";
-        ss << "funcproto must be unary or a binary expr with all equal types";
-        throw runtime_error(ss.str());
-    }
-    if (elwise_reduction->get_return_type() != dst_tp) {
-        stringstream ss;
-        ss << "make_lifted_reduction_ckernel: elwise reduction ckernel ";
-        ss << "dst type is " << elwise_reduction->get_return_type();
-        ss << ", expected " << dst_tp;
-        throw type_error(ss.str());
-    }
-    if (elwise_reduction->get_param_type(0) != src_tp) {
-        stringstream ss;
-        ss << "make_lifted_reduction_ckernel: elwise reduction ckernel ";
-        ss << "src type is " << elwise_reduction->get_return_type();
-        ss << ", expected " << src_tp;
-        throw type_error(ss.str());
-    }
-    if (dst_initialization != NULL) {
-        check_dst_initialization(dst_initialization, dst_tp, src_tp);
-    }
-    if (elwise_reduction->get_param_count() == 2) {
-        ckb_end = kernels::wrap_binary_as_unary_reduction_ckernel(
-                        out_ckb, ckb_end, right_associative, kernel_request_strided);
-        ndt::type src_tp_doubled[2] = {src_tp, src_tp};
-        const char *src_arrmeta_doubled[2] = {src_arrmeta, src_arrmeta};
-        ckb_end = elwise_reduction->instantiate(
-            elwise_reduction, out_ckb, ckb_end, dst_tp, dst_arrmeta,
-            src_tp_doubled, src_arrmeta_doubled, kernel_request_strided, ectx);
+  } else {
+    // Get the function pointer for the first_call, for the case with
+    // a reduction identity
+    if (kernreq == kernel_request_single) {
+      e->ckpbase.set_first_call_function(
+          &strided_inner_reduction_kernel_extra::single_first_with_ident);
+    } else if (kernreq == kernel_request_strided) {
+      e->ckpbase.set_first_call_function(
+          &strided_inner_reduction_kernel_extra::strided_first_with_ident);
     } else {
-        ckb_end = elwise_reduction->instantiate(
-            elwise_reduction, out_ckb, ckb_end, dst_tp, dst_arrmeta, &src_tp,
-            &src_arrmeta, kernel_request_strided, ectx);
+      stringstream ss;
+      ss << "make_lifted_reduction_ckernel: unrecognized request "
+         << (int)kernreq;
+      throw runtime_error(ss.str());
     }
-    // Make sure there's capacity for the next ckernel
-    out_ckb->ensure_capacity(ckb_end);
-    // Need to retrieve 'e' again because it may have moved
-    e = out_ckb->get_at<strided_inner_reduction_kernel_extra>(ckb_offset);
-    e->dst_init_kernel_offset = ckb_end - ckb_offset;
-    if (dst_initialization != NULL) {
-        ckb_end = dst_initialization->instantiate(
-            dst_initialization, out_ckb, ckb_end, dst_tp, dst_arrmeta, &src_tp,
-            &src_arrmeta, kernel_request_single, ectx);
-    } else if (reduction_identity.is_null()) {
-        ckb_end = make_assignment_kernel(out_ckb, ckb_end, dst_tp, dst_arrmeta,
-                                         src_tp, src_arrmeta,
-                                         kernel_request_single, ectx);
-    } else {
-        ckb_end = make_assignment_kernel(out_ckb, ckb_end, dst_tp, dst_arrmeta,
-                                         reduction_identity.get_type(),
-                                         reduction_identity.get_arrmeta(),
-                                         kernel_request_single, ectx);
+    if (reduction_identity.get_type() != dst_tp) {
+      stringstream ss;
+      ss << "make_lifted_reduction_ckernel: reduction identity type ";
+      ss << reduction_identity.get_type() << " does not match dst type ";
+      ss << dst_tp;
+      throw runtime_error(ss.str());
     }
+    e->ident_data = reduction_identity.get_readonly_originptr();
+    e->ident_ref = reduction_identity.get_memblock().release();
+  }
+  // The function pointer for followup accumulation calls
+  e->ckpbase.set_followup_call_function(
+      &strided_inner_reduction_kernel_extra::strided_followup);
+  // The striding parameters
+  e->src_stride = src_stride;
+  e->size = src_size;
+  // Validate that the provided arrfuncs are unary operations,
+  // and have the correct types
+  if (elwise_reduction->get_param_count() != 1 &&
+      elwise_reduction->get_param_count() != 2) {
+    stringstream ss;
+    ss << "make_lifted_reduction_ckernel: elwise reduction ckernel ";
+    ss << "funcproto must be unary or a binary expr with all equal types";
+    throw runtime_error(ss.str());
+  }
+  if (elwise_reduction->get_return_type() != dst_tp) {
+    stringstream ss;
+    ss << "make_lifted_reduction_ckernel: elwise reduction ckernel ";
+    ss << "dst type is " << elwise_reduction->get_return_type();
+    ss << ", expected " << dst_tp;
+    throw type_error(ss.str());
+  }
+  if (elwise_reduction->get_param_type(0) != src_tp) {
+    stringstream ss;
+    ss << "make_lifted_reduction_ckernel: elwise reduction ckernel ";
+    ss << "src type is " << elwise_reduction->get_return_type();
+    ss << ", expected " << src_tp;
+    throw type_error(ss.str());
+  }
+  if (dst_initialization != NULL) {
+    check_dst_initialization(dst_initialization, dst_tp, src_tp);
+  }
+  if (elwise_reduction->get_param_count() == 2) {
+    ckb_offset = kernels::wrap_binary_as_unary_reduction_ckernel(
+        ckb, ckb_offset, right_associative, kernel_request_strided);
+    ndt::type src_tp_doubled[2] = {src_tp, src_tp};
+    const char *src_arrmeta_doubled[2] = {src_arrmeta, src_arrmeta};
+    ckb_offset = elwise_reduction->instantiate(
+        elwise_reduction, ckb, ckb_offset, dst_tp, dst_arrmeta, src_tp_doubled,
+        src_arrmeta_doubled, kernel_request_strided, ectx);
+  } else {
+    ckb_offset = elwise_reduction->instantiate(
+        elwise_reduction, ckb, ckb_offset, dst_tp, dst_arrmeta, &src_tp,
+        &src_arrmeta, kernel_request_strided, ectx);
+  }
+  // Make sure there's capacity for the next ckernel
+  ckb->ensure_capacity(ckb_offset);
+  // Need to retrieve 'e' again because it may have moved
+  e = ckb->get_at<strided_inner_reduction_kernel_extra>(root_ckb_offset);
+  e->dst_init_kernel_offset = ckb_offset - root_ckb_offset;
+  if (dst_initialization != NULL) {
+    ckb_offset = dst_initialization->instantiate(
+        dst_initialization, ckb, ckb_offset, dst_tp, dst_arrmeta, &src_tp,
+        &src_arrmeta, kernel_request_single, ectx);
+  } else if (reduction_identity.is_null()) {
+    ckb_offset =
+        make_assignment_kernel(ckb, ckb_offset, dst_tp, dst_arrmeta, src_tp,
+                               src_arrmeta, kernel_request_single, ectx);
+  } else {
+    ckb_offset = make_assignment_kernel(
+        ckb, ckb_offset, dst_tp, dst_arrmeta, reduction_identity.get_type(),
+        reduction_identity.get_arrmeta(), kernel_request_single, ectx);
+  }
 
-    return ckb_end;
+  return ckb_offset;
 }
 
 /**
@@ -848,122 +851,129 @@ static size_t make_strided_inner_reduction_dimension_kernel(
  */
 static size_t make_strided_inner_broadcast_dimension_kernel(
     const arrfunc_type_data *elwise_reduction,
-    const arrfunc_type_data *dst_initialization, ckernel_builder *out_ckb,
-    size_t ckb_offset, intptr_t dst_stride, intptr_t src_stride,
+    const arrfunc_type_data *dst_initialization, ckernel_builder *ckb,
+    intptr_t ckb_offset, intptr_t dst_stride, intptr_t src_stride,
     intptr_t src_size, const ndt::type &dst_tp, const char *dst_arrmeta,
-    const ndt::type &src_tp, const char *src_arrmeta,
-    bool right_associative, const nd::array &reduction_identity,
-    kernel_request_t kernreq, const eval::eval_context *ectx)
+    const ndt::type &src_tp, const char *src_arrmeta, bool right_associative,
+    const nd::array &reduction_identity, kernel_request_t kernreq,
+    const eval::eval_context *ectx)
 {
-    intptr_t ckb_end = ckb_offset + sizeof(strided_inner_broadcast_kernel_extra);
-    out_ckb->ensure_capacity(ckb_end);
-    strided_inner_broadcast_kernel_extra *e = out_ckb->get_at<strided_inner_broadcast_kernel_extra>(ckb_offset);
-    e->base().destructor = &strided_inner_broadcast_kernel_extra::destruct;
-    // Cannot have both a dst_initialization kernel and a reduction identity
-    if (dst_initialization != NULL && !reduction_identity.is_null()) {
-        throw invalid_argument("make_lifted_reduction_ckernel: cannot specify"
-            " both a dst_initialization kernel and a reduction_identity");
-    }
-    if (reduction_identity.is_null()) {
-        // Get the function pointer for the first_call, for the case with
-        // no reduction identity
-        if (kernreq == kernel_request_single) {
-            e->ckpbase.set_first_call_function(&strided_inner_broadcast_kernel_extra::single_first);
-        } else if (kernreq == kernel_request_strided) {
-            e->ckpbase.set_first_call_function(&strided_inner_broadcast_kernel_extra::strided_first);
-        } else {
-            stringstream ss;
-            ss << "make_lifted_reduction_ckernel: unrecognized request " << (int)kernreq;
-            throw runtime_error(ss.str());
-        }
+  intptr_t root_ckb_offset = ckb_offset;
+  strided_inner_broadcast_kernel_extra *e =
+      ckb->alloc_ck<strided_inner_broadcast_kernel_extra>(ckb_offset);
+  e->base().destructor = &strided_inner_broadcast_kernel_extra::destruct;
+  // Cannot have both a dst_initialization kernel and a reduction identity
+  if (dst_initialization != NULL && !reduction_identity.is_null()) {
+    throw invalid_argument(
+        "make_lifted_reduction_ckernel: cannot specify"
+        " both a dst_initialization kernel and a reduction_identity");
+  }
+  if (reduction_identity.is_null()) {
+    // Get the function pointer for the first_call, for the case with
+    // no reduction identity
+    if (kernreq == kernel_request_single) {
+      e->ckpbase.set_first_call_function(
+          &strided_inner_broadcast_kernel_extra::single_first);
+    } else if (kernreq == kernel_request_strided) {
+      e->ckpbase.set_first_call_function(
+          &strided_inner_broadcast_kernel_extra::strided_first);
     } else {
-        // Get the function pointer for the first_call, for the case with
-        // a reduction identity
-        if (kernreq == kernel_request_single) {
-            e->ckpbase.set_first_call_function(&strided_inner_broadcast_kernel_extra::single_first_with_ident);
-        } else if (kernreq == kernel_request_strided) {
-            e->ckpbase.set_first_call_function(&strided_inner_broadcast_kernel_extra::strided_first_with_ident);
-        } else {
-            stringstream ss;
-            ss << "make_lifted_reduction_ckernel: unrecognized request " << (int)kernreq;
-            throw runtime_error(ss.str());
-        }
-        if (reduction_identity.get_type() != dst_tp) {
-            stringstream ss;
-            ss << "make_lifted_reduction_ckernel: reduction identity type ";
-            ss << reduction_identity.get_type() << " does not match dst type ";
-            ss << dst_tp;
-            throw runtime_error(ss.str());
-        }
-        e->ident_data = reduction_identity.get_readonly_originptr();
-        e->ident_ref = reduction_identity.get_memblock().release();
+      stringstream ss;
+      ss << "make_lifted_reduction_ckernel: unrecognized request "
+         << (int)kernreq;
+      throw runtime_error(ss.str());
     }
-    // The function pointer for followup accumulation calls
-    e->ckpbase.set_followup_call_function(&strided_inner_broadcast_kernel_extra::strided_followup);
-    // The striding parameters
-    e->dst_stride = dst_stride;
-    e->src_stride = src_stride;
-    e->size = src_size;
-    // Validate that the provided arrfuncs are unary operations,
-    // and have the correct types
-    if (elwise_reduction->get_param_count() != 1 &&
-            elwise_reduction->get_param_count() != 2) {
-        stringstream ss;
-        ss << "make_lifted_reduction_ckernel: elwise reduction ckernel ";
-        ss << "funcproto must be unary or a binary expr with all equal types";
-        throw runtime_error(ss.str());
-    }
-    if (elwise_reduction->get_return_type() != dst_tp) {
-        stringstream ss;
-        ss << "make_lifted_reduction_ckernel: elwise reduction ckernel ";
-        ss << "dst type is " << elwise_reduction->get_return_type();
-        ss << ", expected " << dst_tp;
-        throw type_error(ss.str());
-    }
-    if (elwise_reduction->get_param_type(0) != src_tp) {
-        stringstream ss;
-        ss << "make_lifted_reduction_ckernel: elwise reduction ckernel ";
-        ss << "src type is " << elwise_reduction->get_return_type();
-        ss << ", expected " << src_tp;
-        throw type_error(ss.str());
-    }
-    if (dst_initialization != NULL) {
-        check_dst_initialization(dst_initialization, dst_tp, src_tp);
-    }
-    if (elwise_reduction->get_param_count() == 2) {
-        ckb_end = kernels::wrap_binary_as_unary_reduction_ckernel(
-            out_ckb, ckb_end, right_associative, kernel_request_strided);
-        ndt::type src_tp_doubled[2] = {src_tp, src_tp};
-        const char *src_arrmeta_doubled[2] = {src_arrmeta, src_arrmeta};
-        ckb_end = elwise_reduction->instantiate(
-            elwise_reduction, out_ckb, ckb_end, dst_tp, dst_arrmeta,
-            src_tp_doubled, src_arrmeta_doubled, kernel_request_strided, ectx);
+  } else {
+    // Get the function pointer for the first_call, for the case with
+    // a reduction identity
+    if (kernreq == kernel_request_single) {
+      e->ckpbase.set_first_call_function(
+          &strided_inner_broadcast_kernel_extra::single_first_with_ident);
+    } else if (kernreq == kernel_request_strided) {
+      e->ckpbase.set_first_call_function(
+          &strided_inner_broadcast_kernel_extra::strided_first_with_ident);
     } else {
-        ckb_end = elwise_reduction->instantiate(
-            elwise_reduction, out_ckb, ckb_end, dst_tp, dst_arrmeta, &src_tp,
-            &src_arrmeta, kernel_request_strided, ectx);
+      stringstream ss;
+      ss << "make_lifted_reduction_ckernel: unrecognized request "
+         << (int)kernreq;
+      throw runtime_error(ss.str());
     }
-    // Make sure there's capacity for the next ckernel
-    out_ckb->ensure_capacity(ckb_end);
-    // Need to retrieve 'e' again because it may have moved
-    e = out_ckb->get_at<strided_inner_broadcast_kernel_extra>(ckb_offset);
-    e->dst_init_kernel_offset = ckb_end - ckb_offset;
-    if (dst_initialization != NULL) {
-        ckb_end = dst_initialization->instantiate(
-            dst_initialization, out_ckb, ckb_end, dst_tp, dst_arrmeta, &src_tp,
-            &src_arrmeta, kernel_request_strided, ectx);
-    } else if (reduction_identity.is_null()) {
-        ckb_end = make_assignment_kernel(out_ckb, ckb_end, dst_tp, dst_arrmeta,
-                                         src_tp, src_arrmeta,
-                                         kernel_request_strided, ectx);
-    } else {
-        ckb_end = make_assignment_kernel(out_ckb, ckb_end, dst_tp, dst_arrmeta,
-                                         reduction_identity.get_type(),
-                                         reduction_identity.get_arrmeta(),
-                                         kernel_request_strided, ectx);
+    if (reduction_identity.get_type() != dst_tp) {
+      stringstream ss;
+      ss << "make_lifted_reduction_ckernel: reduction identity type ";
+      ss << reduction_identity.get_type() << " does not match dst type ";
+      ss << dst_tp;
+      throw runtime_error(ss.str());
     }
+    e->ident_data = reduction_identity.get_readonly_originptr();
+    e->ident_ref = reduction_identity.get_memblock().release();
+  }
+  // The function pointer for followup accumulation calls
+  e->ckpbase.set_followup_call_function(
+      &strided_inner_broadcast_kernel_extra::strided_followup);
+  // The striding parameters
+  e->dst_stride = dst_stride;
+  e->src_stride = src_stride;
+  e->size = src_size;
+  // Validate that the provided arrfuncs are unary operations,
+  // and have the correct types
+  if (elwise_reduction->get_param_count() != 1 &&
+      elwise_reduction->get_param_count() != 2) {
+    stringstream ss;
+    ss << "make_lifted_reduction_ckernel: elwise reduction ckernel ";
+    ss << "funcproto must be unary or a binary expr with all equal types";
+    throw runtime_error(ss.str());
+  }
+  if (elwise_reduction->get_return_type() != dst_tp) {
+    stringstream ss;
+    ss << "make_lifted_reduction_ckernel: elwise reduction ckernel ";
+    ss << "dst type is " << elwise_reduction->get_return_type();
+    ss << ", expected " << dst_tp;
+    throw type_error(ss.str());
+  }
+  if (elwise_reduction->get_param_type(0) != src_tp) {
+    stringstream ss;
+    ss << "make_lifted_reduction_ckernel: elwise reduction ckernel ";
+    ss << "src type is " << elwise_reduction->get_return_type();
+    ss << ", expected " << src_tp;
+    throw type_error(ss.str());
+  }
+  if (dst_initialization != NULL) {
+    check_dst_initialization(dst_initialization, dst_tp, src_tp);
+  }
+  if (elwise_reduction->get_param_count() == 2) {
+    ckb_offset = kernels::wrap_binary_as_unary_reduction_ckernel(
+        ckb, ckb_offset, right_associative, kernel_request_strided);
+    ndt::type src_tp_doubled[2] = {src_tp, src_tp};
+    const char *src_arrmeta_doubled[2] = {src_arrmeta, src_arrmeta};
+    ckb_offset = elwise_reduction->instantiate(
+        elwise_reduction, ckb, ckb_offset, dst_tp, dst_arrmeta, src_tp_doubled,
+        src_arrmeta_doubled, kernel_request_strided, ectx);
+  } else {
+    ckb_offset = elwise_reduction->instantiate(
+        elwise_reduction, ckb, ckb_offset, dst_tp, dst_arrmeta, &src_tp,
+        &src_arrmeta, kernel_request_strided, ectx);
+  }
+  // Make sure there's capacity for the next ckernel
+  ckb->ensure_capacity(ckb_offset);
+  // Need to retrieve 'e' again because it may have moved
+  e = ckb->get_at<strided_inner_broadcast_kernel_extra>(root_ckb_offset);
+  e->dst_init_kernel_offset = ckb_offset - root_ckb_offset;
+  if (dst_initialization != NULL) {
+    ckb_offset = dst_initialization->instantiate(
+        dst_initialization, ckb, ckb_offset, dst_tp, dst_arrmeta, &src_tp,
+        &src_arrmeta, kernel_request_strided, ectx);
+  } else if (reduction_identity.is_null()) {
+    ckb_offset =
+        make_assignment_kernel(ckb, ckb_offset, dst_tp, dst_arrmeta, src_tp,
+                               src_arrmeta, kernel_request_strided, ectx);
+  } else {
+    ckb_offset = make_assignment_kernel(
+        ckb, ckb_offset, dst_tp, dst_arrmeta, reduction_identity.get_type(),
+        reduction_identity.get_arrmeta(), kernel_request_strided, ectx);
+  }
 
-    return ckb_end;
+  return ckb_offset;
 }
 
 size_t dynd::make_lifted_reduction_ckernel(

--- a/src/dynd/kernels/option_kernels.cpp
+++ b/src/dynd/kernels/option_kernels.cpp
@@ -368,9 +368,9 @@ struct nafunc {
             ss << "Expected destination type bool, got " << dst_tp;
             throw type_error(ss.str());
         }
-        ckernel_prefix *ckp = ckb->get_at<ckernel_prefix>(ckb_offset);
-        ckp->set_expr_function< ::is_avail<T> >((kernel_request_t)kernreq);
-        return ckb_offset + sizeof(ckernel_prefix);
+        ckernel_prefix *ckp = ckb->alloc_ck_leaf<ckernel_prefix>(ckb_offset);
+        ckp->set_expr_function< ::is_avail<T> >(kernreq);
+        return ckb_offset;
     }
 
     static int resolve_is_avail_dst_type(
@@ -395,9 +395,9 @@ struct nafunc {
                << ", got " << dst_tp;
             throw type_error(ss.str());
         }
-        ckernel_prefix *ckp = ckb->get_at<ckernel_prefix>(ckb_offset);
-        ckp->set_expr_function< ::assign_na<T> >((kernel_request_t)kernreq);
-        return ckb_offset + sizeof(ckernel_prefix);
+        ckernel_prefix *ckp = ckb->alloc_ck_leaf<ckernel_prefix>(ckb_offset);
+        ckp->set_expr_function< ::assign_na<T> >(kernreq);
+        return ckb_offset;
     }
 
     static nd::array get()

--- a/src/dynd/kernels/reduction_kernels.cpp
+++ b/src/dynd/kernels/reduction_kernels.cpp
@@ -49,11 +49,11 @@ namespace {
 
 
 intptr_t kernels::make_builtin_sum_reduction_ckernel(
-                dynd::ckernel_builder *out_ckb, intptr_t ckb_offset,
+                dynd::ckernel_builder *ckb, intptr_t ckb_offset,
                 type_id_t tid,
                 kernel_request_t kernreq)
 {
-    ckernel_prefix *ckp = out_ckb->get_at<ckernel_prefix>(ckb_offset);
+    ckernel_prefix *ckp = ckb->alloc_ck_leaf<ckernel_prefix>(ckb_offset);
     switch (tid) {
         case int32_type_id:
             ckp->set_expr_function<sum_reduction<int32_t, int32_t> >(kernreq);
@@ -85,7 +85,7 @@ intptr_t kernels::make_builtin_sum_reduction_ckernel(
         }
     }
 
-    return ckb_offset + sizeof(ckernel_prefix);
+    return ckb_offset;
 }
 
 static intptr_t instantiate_builtin_sum_reduction_arrfunc(
@@ -102,7 +102,7 @@ static intptr_t instantiate_builtin_sum_reduction_arrfunc(
         throw type_error(ss.str());
     }
     return kernels::make_builtin_sum_reduction_ckernel(
-        ckb, ckb_offset, dst_tp.get_type_id(), (kernel_request_t)kernreq);
+        ckb, ckb_offset, dst_tp.get_type_id(), kernreq);
 }
 
 void kernels::make_builtin_sum_reduction_arrfunc(
@@ -176,8 +176,7 @@ namespace {
         {
             typedef double_mean1d_ck self_type;
             mean1d_arrfunc_data *data = *af_self->get_data_as<mean1d_arrfunc_data *>();
-            self_type *self = self_type::create_leaf(ckb, ckb_offset,
-                                                     (kernel_request_t)kernreq);
+            self_type *self = self_type::create_leaf(ckb, kernreq, ckb_offset);
             intptr_t src_dim_size, src_stride;
             ndt::type src_el_tp;
             const char *src_el_arrmeta;
@@ -205,7 +204,7 @@ namespace {
             }
             self->m_src_dim_size = src_dim_size;
             self->m_src_stride = src_stride;
-            return ckb_offset + sizeof(self_type);
+            return ckb_offset;
         }
     };
 } // anonymous namespace

--- a/src/dynd/kernels/string_assignment_kernels.cpp
+++ b/src/dynd/kernels/string_assignment_kernels.cpp
@@ -55,7 +55,7 @@ namespace {
 } // anonymous namespace
 
 size_t dynd::make_fixedstring_assignment_kernel(
-                ckernel_builder *out_ckb, size_t ckb_offset,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 intptr_t dst_data_size, string_encoding_t dst_encoding,
                 intptr_t src_data_size, string_encoding_t src_encoding,
                 kernel_request_t kernreq,
@@ -63,13 +63,13 @@ size_t dynd::make_fixedstring_assignment_kernel(
 {
     typedef fixedstring_assign_ck self_type;
     assign_error_mode errmode = ectx->errmode;
-    self_type *self = self_type::create_leaf(out_ckb, ckb_offset, kernreq);
+    self_type *self = self_type::create_leaf(ckb, kernreq, ckb_offset);
     self->m_next_fn = get_next_unicode_codepoint_function(src_encoding, errmode);
     self->m_append_fn = get_append_unicode_codepoint_function(dst_encoding, errmode);
     self->m_dst_data_size = dst_data_size;
     self->m_src_data_size = src_data_size;
     self->m_overflow_check = (errmode != assign_error_nocheck);
-    return ckb_offset + sizeof(self_type);
+    return ckb_offset;
 }
 
 /////////////////////////////////////////
@@ -147,21 +147,21 @@ namespace {
 } // anonymous namespace
 
 size_t dynd::make_blockref_string_assignment_kernel(
-    ckernel_builder *out_ckb, size_t ckb_offset, const char *dst_arrmeta,
+    ckernel_builder *ckb, intptr_t ckb_offset, const char *dst_arrmeta,
     string_encoding_t dst_encoding, const char *src_arrmeta,
     string_encoding_t src_encoding, kernel_request_t kernreq,
     const eval::eval_context *ectx)
 {
     typedef blockref_string_assign_ck self_type;
     assign_error_mode errmode = ectx->errmode;
-    self_type *self = self_type::create_leaf(out_ckb, ckb_offset, kernreq);
+    self_type *self = self_type::create_leaf(ckb, kernreq, ckb_offset);
     self->m_dst_encoding = dst_encoding;
     self->m_src_encoding = src_encoding;
     self->m_next_fn = get_next_unicode_codepoint_function(src_encoding, errmode);
     self->m_append_fn = get_append_unicode_codepoint_function(dst_encoding, errmode);
     self->m_dst_arrmeta = reinterpret_cast<const string_type_arrmeta *>(dst_arrmeta);
     self->m_src_arrmeta = reinterpret_cast<const string_type_arrmeta *>(src_arrmeta);
-    return ckb_offset + sizeof(self_type);
+    return ckb_offset;
 }
 
 /////////////////////////////////////////
@@ -230,21 +230,21 @@ namespace {
 } // anonymous namespace
 
 size_t dynd::make_fixedstring_to_blockref_string_assignment_kernel(
-    ckernel_builder *out_ckb, size_t ckb_offset, const char *dst_arrmeta,
+    ckernel_builder *ckb, intptr_t ckb_offset, const char *dst_arrmeta,
     string_encoding_t dst_encoding, intptr_t src_element_size,
     string_encoding_t src_encoding, kernel_request_t kernreq,
     const eval::eval_context *ectx)
 {
     typedef fixedstring_to_blockref_string_assign_ck self_type;
     assign_error_mode errmode = ectx->errmode;
-    self_type *self = self_type::create_leaf(out_ckb, ckb_offset, kernreq);
+    self_type *self = self_type::create_leaf(ckb, kernreq, ckb_offset);
     self->m_dst_encoding = dst_encoding;
     self->m_src_encoding = src_encoding;
     self->m_src_element_size = src_element_size;
     self->m_next_fn = get_next_unicode_codepoint_function(src_encoding, errmode);
     self->m_append_fn = get_append_unicode_codepoint_function(dst_encoding, errmode);
     self->m_dst_arrmeta = reinterpret_cast<const string_type_arrmeta *>(dst_arrmeta);
-    return ckb_offset + sizeof(self_type);
+    return ckb_offset;
 }
 
 /////////////////////////////////////////
@@ -285,16 +285,16 @@ namespace {
 } // anonymous namespace
 
 size_t dynd::make_blockref_string_to_fixedstring_assignment_kernel(
-    ckernel_builder *out_ckb, size_t ckb_offset, intptr_t dst_data_size,
+    ckernel_builder *ckb, intptr_t ckb_offset, intptr_t dst_data_size,
     string_encoding_t dst_encoding, string_encoding_t src_encoding,
     kernel_request_t kernreq, const eval::eval_context *ectx)
 {
     typedef blockref_string_to_fixedstring_assign_ck self_type;
     assign_error_mode errmode = ectx->errmode;
-    self_type *self = self_type::create_leaf(out_ckb, ckb_offset, kernreq);
+    self_type *self = self_type::create_leaf(ckb, kernreq, ckb_offset);
     self->m_next_fn = get_next_unicode_codepoint_function(src_encoding, errmode);
     self->m_append_fn = get_append_unicode_codepoint_function(dst_encoding, errmode);
     self->m_dst_data_size = dst_data_size;
     self->m_overflow_check = (errmode != assign_error_nocheck);
-    return ckb_offset + sizeof(self_type);
+    return ckb_offset;
 }

--- a/src/dynd/kernels/string_numeric_assignment_kernels.cpp
+++ b/src/dynd/kernels/string_numeric_assignment_kernels.cpp
@@ -424,7 +424,7 @@ static expr_single_t static_string_to_builtin_kernels[builtin_type_id_count-2] =
     };
 
 size_t dynd::make_string_to_builtin_assignment_kernel(
-    ckernel_builder *out, size_t offset_out, type_id_t dst_type_id,
+    ckernel_builder *ckb, intptr_t ckb_offset, type_id_t dst_type_id,
     const ndt::type &src_string_tp, const char *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx)
 {
@@ -436,21 +436,19 @@ size_t dynd::make_string_to_builtin_assignment_kernel(
     }
 
     if (dst_type_id >= bool_type_id && dst_type_id <= complex_float64_type_id) {
-        offset_out =
-            make_kernreq_to_single_kernel_adapter(out, offset_out, 1, kernreq);
-        out->ensure_capacity_leaf(offset_out +
-                                  sizeof(string_to_builtin_kernel_extra));
+        ckb_offset =
+            make_kernreq_to_single_kernel_adapter(ckb, ckb_offset, 1, kernreq);
         string_to_builtin_kernel_extra *e =
-            out->get_at<string_to_builtin_kernel_extra>(offset_out);
+            ckb->alloc_ck<string_to_builtin_kernel_extra>(ckb_offset);
         e->base.set_function<expr_single_t>(
             static_string_to_builtin_kernels[dst_type_id - bool_type_id]);
-        e->base.destructor = string_to_builtin_kernel_extra::destruct;
+        e->base.destructor = &string_to_builtin_kernel_extra::destruct;
         // The kernel data owns this reference
         e->src_string_tp = static_cast<const base_string_type *>(
             ndt::type(src_string_tp).release());
         e->errmode = ectx->errmode;
         e->src_arrmeta = src_arrmeta;
-        return offset_out + sizeof(string_to_builtin_kernel_extra);
+        return ckb_offset;
     } else {
         stringstream ss;
         ss << "make_string_to_builtin_assignment_kernel: destination type id "
@@ -498,7 +496,7 @@ namespace {
 } // anonymous namespace
 
 size_t dynd::make_builtin_to_string_assignment_kernel(
-    ckernel_builder *out, size_t offset_out, const ndt::type &dst_string_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_string_tp,
     const char *dst_arrmeta, type_id_t src_type_id, kernel_request_t kernreq,
     const eval::eval_context *ectx)
 {
@@ -509,9 +507,9 @@ size_t dynd::make_builtin_to_string_assignment_kernel(
     }
 
     if (src_type_id >= 0 && src_type_id < builtin_type_id_count) {
-        offset_out = make_kernreq_to_single_kernel_adapter(out, offset_out, 1, kernreq);
-        out->ensure_capacity_leaf(offset_out + sizeof(builtin_to_string_kernel_extra));
-        builtin_to_string_kernel_extra *e = out->get_at<builtin_to_string_kernel_extra>(offset_out);
+        ckb_offset = make_kernreq_to_single_kernel_adapter(ckb, ckb_offset, 1, kernreq);
+        builtin_to_string_kernel_extra *e =
+            ckb->alloc_ck_leaf<builtin_to_string_kernel_extra>(ckb_offset);
         e->base.set_function<expr_single_t>(builtin_to_string_kernel_extra::single);
         e->base.destructor = builtin_to_string_kernel_extra::destruct;
         // The kernel data owns this reference
@@ -519,7 +517,7 @@ size_t dynd::make_builtin_to_string_assignment_kernel(
         e->src_type_id = src_type_id;
         e->ectx = *ectx;
         e->dst_arrmeta = dst_arrmeta;
-        return offset_out + sizeof(builtin_to_string_kernel_extra);
+        return ckb_offset;
     } else {
         stringstream ss;
         ss << "make_builtin_to_string_assignment_kernel: source type id " << src_type_id << " is not builtin";

--- a/src/dynd/kernels/time_assignment_kernels.cpp
+++ b/src/dynd/kernels/time_assignment_kernels.cpp
@@ -36,7 +36,7 @@ namespace {
 } // anonymous namespace
 
 size_t dynd::make_string_to_time_assignment_kernel(
-    ckernel_builder *out_ckb, size_t ckb_offset,
+    ckernel_builder *ckb, intptr_t ckb_offset,
     const ndt::type &DYND_UNUSED(dst_time_tp), const ndt::type &src_string_tp,
     const char *src_arrmeta, kernel_request_t kernreq,
     const eval::eval_context *ectx)
@@ -49,11 +49,11 @@ size_t dynd::make_string_to_time_assignment_kernel(
         throw runtime_error(ss.str());
     }
 
-    self_type *self = self_type::create_leaf(out_ckb, ckb_offset, kernreq);
+    self_type *self = self_type::create_leaf(ckb, kernreq, ckb_offset);
     self->m_src_string_tp = src_string_tp;
     self->m_src_arrmeta = src_arrmeta;
     self->m_errmode = ectx->errmode;
-    return ckb_offset + sizeof(self_type);
+    return ckb_offset;
 }
 
 /////////////////////////////////////////
@@ -80,7 +80,7 @@ namespace {
 } // anonymous namespace
 
 size_t dynd::make_time_to_string_assignment_kernel(
-    ckernel_builder *out_ckb, size_t ckb_offset, const ndt::type &dst_string_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_string_tp,
     const char *dst_arrmeta, const ndt::type &DYND_UNUSED(src_time_tp),
     kernel_request_t kernreq, const eval::eval_context *ectx)
 {
@@ -92,10 +92,10 @@ size_t dynd::make_time_to_string_assignment_kernel(
         throw runtime_error(ss.str());
     }
 
-    self_type *self = self_type::create_leaf(out_ckb, ckb_offset, kernreq);
+    self_type *self = self_type::create_leaf(ckb, kernreq, ckb_offset);
     self->m_dst_string_tp = dst_string_tp;
     self->m_dst_arrmeta = dst_arrmeta;
     self->m_ectx = *ectx;
-    return ckb_offset + sizeof(self_type);
+    return ckb_offset;
 }
 

--- a/src/dynd/kernels/var_dim_assignment_kernels.cpp
+++ b/src/dynd/kernels/var_dim_assignment_kernels.cpp
@@ -71,7 +71,7 @@ namespace {
 } // anonymous namespace
 
 size_t dynd::make_broadcast_to_var_dim_assignment_kernel(
-    ckernel_builder *ckb, size_t ckb_offset, const ndt::type &dst_var_dim_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_var_dim_tp,
     const char *dst_arrmeta, const ndt::type &src_tp, const char *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx)
 {
@@ -86,11 +86,11 @@ size_t dynd::make_broadcast_to_var_dim_assignment_kernel(
     const var_dim_type_arrmeta *dst_md =
                     reinterpret_cast<const var_dim_type_arrmeta *>(dst_arrmeta);
 
-    self_type *self = self_type::create(ckb, ckb_offset, kernreq);
+    self_type *self = self_type::create(ckb, kernreq, ckb_offset);
     self->m_dst_target_alignment = dst_vad->get_target_alignment();
     self->m_dst_md = dst_md;
     return ::make_assignment_kernel(
-        ckb, ckb_offset + sizeof(self_type), dst_vad->get_element_type(),
+        ckb, ckb_offset, dst_vad->get_element_type(),
         dst_arrmeta + sizeof(var_dim_type_arrmeta), src_tp, src_arrmeta,
         kernel_request_strided, ectx);
 }
@@ -170,7 +170,7 @@ namespace {
 } // anonymous namespace
 
 size_t dynd::make_var_dim_assignment_kernel(
-    ckernel_builder *ckb, size_t ckb_offset, const ndt::type &dst_var_dim_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_var_dim_tp,
     const char *dst_arrmeta, const ndt::type &src_var_dim_tp,
     const char *src_arrmeta, kernel_request_t kernreq,
     const eval::eval_context *ectx)
@@ -195,12 +195,12 @@ size_t dynd::make_var_dim_assignment_kernel(
     const var_dim_type_arrmeta *src_md =
         reinterpret_cast<const var_dim_type_arrmeta *>(src_arrmeta);
 
-    self_type *self = self_type::create(ckb, ckb_offset, kernreq);
+    self_type *self = self_type::create(ckb, kernreq, ckb_offset);
     self->m_dst_target_alignment = dst_vad->get_target_alignment();
     self->m_dst_md = dst_md;
     self->m_src_md = src_md;
     return ::make_assignment_kernel(
-        ckb, ckb_offset + sizeof(self_type), dst_vad->get_element_type(),
+        ckb, ckb_offset, dst_vad->get_element_type(),
         dst_arrmeta + sizeof(var_dim_type_arrmeta), src_vad->get_element_type(),
         src_arrmeta + sizeof(var_dim_type_arrmeta), kernel_request_strided,
         ectx);
@@ -271,7 +271,7 @@ namespace {
 } // anonymous namespace
 
 size_t dynd::make_strided_to_var_dim_assignment_kernel(
-    ckernel_builder *ckb, size_t ckb_offset, const ndt::type &dst_var_dim_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_var_dim_tp,
     const char *dst_arrmeta, intptr_t src_dim_size, intptr_t src_stride,
     const ndt::type &src_el_tp, const char *src_el_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx)
@@ -287,14 +287,14 @@ size_t dynd::make_strided_to_var_dim_assignment_kernel(
     const var_dim_type_arrmeta *dst_md =
                     reinterpret_cast<const var_dim_type_arrmeta *>(dst_arrmeta);
 
-    self_type *self = self_type::create(ckb, ckb_offset, kernreq);
+    self_type *self = self_type::create(ckb, kernreq, ckb_offset);
     self->m_dst_target_alignment = dst_vad->get_target_alignment();
     self->m_dst_md = dst_md;
     self->m_src_stride = src_stride;
     self->m_src_dim_size = src_dim_size;
 
     return ::make_assignment_kernel(
-        ckb, ckb_offset + sizeof(self_type), dst_vad->get_element_type(),
+        ckb, ckb_offset, dst_vad->get_element_type(),
         dst_arrmeta + sizeof(var_dim_type_arrmeta), src_el_tp, src_el_arrmeta,
         kernel_request_strided, ectx);
 }
@@ -340,7 +340,7 @@ namespace {
 } // anonymous namespace
 
 size_t dynd::make_var_to_strided_dim_assignment_kernel(
-    ckernel_builder *ckb, size_t ckb_offset,
+    ckernel_builder *ckb, intptr_t ckb_offset,
     const ndt::type &dst_strided_dim_tp, const char *dst_arrmeta,
     const ndt::type &src_var_dim_tp, const char *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx)
@@ -355,7 +355,7 @@ size_t dynd::make_var_to_strided_dim_assignment_kernel(
     const var_dim_type_arrmeta *src_md =
         reinterpret_cast<const var_dim_type_arrmeta *>(src_arrmeta);
 
-    self_type *self = self_type::create(ckb, ckb_offset, kernreq);
+    self_type *self = self_type::create(ckb, kernreq, ckb_offset);
     ndt::type dst_element_tp;
     const char *dst_element_arrmeta;
     if (!dst_strided_dim_tp.get_as_strided_dim(
@@ -369,7 +369,7 @@ size_t dynd::make_var_to_strided_dim_assignment_kernel(
     }
 
     self->m_src_md = src_md;
-    return ::make_assignment_kernel(ckb, ckb_offset + sizeof(self_type),
+    return ::make_assignment_kernel(ckb, ckb_offset,
                                     dst_element_tp, dst_element_arrmeta,
                                     src_vad->get_element_type(),
                                     src_arrmeta + sizeof(var_dim_type_arrmeta),

--- a/src/dynd/types/adapt_type.cpp
+++ b/src/dynd/types/adapt_type.cpp
@@ -90,7 +90,7 @@ ndt::type adapt_type::with_replaced_storage_type(const ndt::type& replacement_ty
 }
 
 size_t adapt_type::make_operand_to_value_assignment_kernel(
-    ckernel_builder *ckb, size_t ckb_offset, const char *dst_arrmeta,
+    ckernel_builder *ckb, intptr_t ckb_offset, const char *dst_arrmeta,
     const char *src_arrmeta, kernel_request_t kernreq,
     const eval::eval_context *ectx) const
 {
@@ -108,7 +108,7 @@ size_t adapt_type::make_operand_to_value_assignment_kernel(
 }
 
 size_t adapt_type::make_value_to_operand_assignment_kernel(
-    ckernel_builder *ckb, size_t ckb_offset, const char *dst_arrmeta,
+    ckernel_builder *ckb, intptr_t ckb_offset, const char *dst_arrmeta,
     const char *src_arrmeta, kernel_request_t kernreq,
     const eval::eval_context *ectx) const
 {

--- a/src/dynd/types/base_expression_type.cpp
+++ b/src/dynd/types/base_expression_type.cpp
@@ -64,7 +64,7 @@ size_t base_expression_type::get_iterdata_size(intptr_t DYND_UNUSED(ndim)) const
 }
 
 size_t base_expression_type::make_operand_to_value_assignment_kernel(
-                ckernel_builder *DYND_UNUSED(out), size_t DYND_UNUSED(offset_out),
+                ckernel_builder *DYND_UNUSED(ckb), intptr_t DYND_UNUSED(ckb_offset),
                 const char *DYND_UNUSED(dst_arrmeta), const char *DYND_UNUSED(src_arrmeta),
                 kernel_request_t DYND_UNUSED(kernreq), const eval::eval_context *DYND_UNUSED(ectx)) const
 {
@@ -74,7 +74,7 @@ size_t base_expression_type::make_operand_to_value_assignment_kernel(
 }
 
 size_t base_expression_type::make_value_to_operand_assignment_kernel(
-                ckernel_builder *DYND_UNUSED(out), size_t DYND_UNUSED(offset_out),
+                ckernel_builder *DYND_UNUSED(ckb), intptr_t DYND_UNUSED(ckb_offset),
                 const char *DYND_UNUSED(dst_arrmeta), const char *DYND_UNUSED(src_arrmeta),
                 kernel_request_t DYND_UNUSED(kernreq), const eval::eval_context *DYND_UNUSED(ectx)) const
 {
@@ -84,23 +84,23 @@ size_t base_expression_type::make_value_to_operand_assignment_kernel(
 }
 
 size_t base_expression_type::make_assignment_kernel(
-    ckernel_builder *out, size_t offset_out, const ndt::type &dst_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_tp,
     const char *dst_arrmeta, const ndt::type &src_tp, const char *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx) const
 {
-    return make_expression_assignment_kernel(out, offset_out,
+    return make_expression_assignment_kernel(ckb, ckb_offset,
                     dst_tp, dst_arrmeta, src_tp, src_arrmeta,
                     kernreq, ectx);
 }
 
 size_t base_expression_type::make_comparison_kernel(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 const ndt::type& src0_dt, const char *src0_arrmeta,
                 const ndt::type& src1_dt, const char *src1_arrmeta,
                 comparison_type_t comptype,
                 const eval::eval_context *ectx) const
 {
-    return make_expression_comparison_kernel(out, offset_out,
+    return make_expression_comparison_kernel(ckb, ckb_offset,
                     src0_dt, src0_arrmeta,
                     src1_dt, src1_arrmeta,
                     comptype, ectx);

--- a/src/dynd/types/base_string_type.cpp
+++ b/src/dynd/types/base_string_type.cpp
@@ -71,7 +71,7 @@ namespace {
         }
 
         size_t make_expr_kernel(
-                    ckernel_builder *out, size_t offset_out,
+                    ckernel_builder *ckb, intptr_t ckb_offset,
                     const ndt::type& dst_tp, const char *dst_arrmeta,
                     size_t src_count, const ndt::type *src_tp, const char *const*src_arrmeta,
                     kernel_request_t kernreq, const eval::eval_context *ectx) const
@@ -88,14 +88,14 @@ namespace {
                 // call the elementwise dimension handler to handle one dimension
                 // or handle input/output buffering, giving 'this' as the next
                 // kernel generator to call
-                return make_elwise_dimension_expr_kernel(out, offset_out,
+                return make_elwise_dimension_expr_kernel(ckb, ckb_offset,
                                 dst_tp, dst_arrmeta,
                                 src_count, src_tp, src_arrmeta,
                                 kernreq, ectx,
                                 this);
             }
             // This is a leaf kernel, so no additional allocation is needed
-            extra_type *e = out->get_at<extra_type>(offset_out);
+            extra_type *e = ckb->alloc_ck_leaf<extra_type>(ckb_offset);
             switch (kernreq) {
                 case kernel_request_single:
                     e->base().set_function(m_op_pair.single);
@@ -110,7 +110,7 @@ namespace {
                 }
             }
             e->init(src_tp, src_arrmeta);
-            return offset_out + sizeof(extra_type);
+            return ckb_offset;
         }
 
 

--- a/src/dynd/types/base_struct_type.cpp
+++ b/src/dynd/types/base_struct_type.cpp
@@ -266,7 +266,7 @@ struct struct_property_getter_ck
 } // anonymous namespace
 
 size_t base_struct_type::make_elwise_property_getter_kernel(
-    ckernel_builder *ckb, size_t ckb_offset, const char *dst_arrmeta,
+    ckernel_builder *ckb, intptr_t ckb_offset, const char *dst_arrmeta,
     const char *src_arrmeta, size_t src_elwise_property_index,
     kernel_request_t kernreq, const eval::eval_context *ectx) const
 {
@@ -275,8 +275,7 @@ size_t base_struct_type::make_elwise_property_getter_kernel(
     if (src_elwise_property_index < field_count) {
         const uintptr_t *arrmeta_offsets = get_arrmeta_offsets_raw();
         const ndt::type& field_type = get_field_type(src_elwise_property_index);
-        self_type *self = self_type::create(ckb, ckb_offset, kernreq);
-        ckb_offset += sizeof(self_type);
+        self_type *self = self_type::create(ckb, kernreq, ckb_offset);
         self->m_field_offset = get_data_offsets(src_arrmeta)[src_elwise_property_index];
         return ::make_assignment_kernel(
             ckb, ckb_offset, field_type.value_type(), dst_arrmeta, field_type,
@@ -291,7 +290,7 @@ size_t base_struct_type::make_elwise_property_getter_kernel(
 }
 
 size_t base_struct_type::make_elwise_property_setter_kernel(
-                ckernel_builder *DYND_UNUSED(out), size_t DYND_UNUSED(offset_out),
+                ckernel_builder *DYND_UNUSED(ckb), intptr_t DYND_UNUSED(ckb_offset),
                 const char *DYND_UNUSED(dst_arrmeta), size_t dst_elwise_property_index,
                 const char *DYND_UNUSED(src_arrmeta),
                 kernel_request_t DYND_UNUSED(kernreq), const eval::eval_context *DYND_UNUSED(ectx)) const

--- a/src/dynd/types/base_type.cpp
+++ b/src/dynd/types/base_type.cpp
@@ -268,7 +268,7 @@ size_t base_type::iterdata_destruct(iterdata_common *DYND_UNUSED(iterdata),
 }
 
 size_t base_type::make_assignment_kernel(
-    ckernel_builder *DYND_UNUSED(out), size_t DYND_UNUSED(offset_out),
+    ckernel_builder *DYND_UNUSED(ckb), intptr_t DYND_UNUSED(ckb_offset),
     const ndt::type &dst_tp, const char *DYND_UNUSED(dst_arrmeta),
     const ndt::type &src_tp, const char *DYND_UNUSED(src_arrmeta),
     kernel_request_t DYND_UNUSED(kernreq),
@@ -285,7 +285,7 @@ size_t base_type::make_assignment_kernel(
 }
 
 size_t base_type::make_comparison_kernel(
-    ckernel_builder *DYND_UNUSED(out), size_t DYND_UNUSED(offset_out),
+    ckernel_builder *DYND_UNUSED(ckb), intptr_t DYND_UNUSED(ckb_offset),
     const ndt::type &src0_dt, const char *DYND_UNUSED(src0_arrmeta),
     const ndt::type &src1_dt, const char *DYND_UNUSED(src1_arrmeta),
     comparison_type_t comptype, const eval::eval_context *DYND_UNUSED(ectx))
@@ -410,7 +410,7 @@ base_type::get_elwise_property_type(size_t DYND_UNUSED(elwise_property_index),
 }
 
 size_t base_type::make_elwise_property_getter_kernel(
-    ckernel_builder *DYND_UNUSED(out), size_t DYND_UNUSED(offset_out),
+    ckernel_builder *DYND_UNUSED(ckb), intptr_t DYND_UNUSED(ckb_offset),
     const char *DYND_UNUSED(dst_arrmeta), const char *DYND_UNUSED(src_arrmeta),
     size_t DYND_UNUSED(src_elwise_property_index),
     kernel_request_t DYND_UNUSED(kernreq),
@@ -423,7 +423,7 @@ size_t base_type::make_elwise_property_getter_kernel(
 }
 
 size_t base_type::make_elwise_property_setter_kernel(
-    ckernel_builder *DYND_UNUSED(out), size_t DYND_UNUSED(offset_out),
+    ckernel_builder *DYND_UNUSED(ckb), intptr_t DYND_UNUSED(ckb_offset),
     const char *DYND_UNUSED(dst_arrmeta),
     size_t DYND_UNUSED(dst_elwise_property_index),
     const char *DYND_UNUSED(src_arrmeta), kernel_request_t DYND_UNUSED(kernreq),

--- a/src/dynd/types/builtin_type_properties.cpp
+++ b/src/dynd/types/builtin_type_properties.cpp
@@ -170,94 +170,92 @@ static void get_or_set_property_kernel_complex_float64_conj(
 }
 
 size_t dynd::make_builtin_type_elwise_property_getter_kernel(
-    ckernel_builder *out, size_t offset_out, type_id_t builtin_type_id,
+    ckernel_builder *ckb, intptr_t ckb_offset, type_id_t builtin_type_id,
     const char *DYND_UNUSED(dst_arrmeta), const char *DYND_UNUSED(src_arrmeta),
     size_t src_elwise_property_index, kernel_request_t kernreq,
     const eval::eval_context *DYND_UNUSED(ectx))
 {
-    offset_out =
-        make_kernreq_to_single_kernel_adapter(out, offset_out, 1, kernreq);
-    ckernel_prefix *e = out->get_at<ckernel_prefix>(offset_out);
-    switch (builtin_type_id) {
-        case complex_float32_type_id:
-            switch (src_elwise_property_index) {
-                case 0:
-                    e->set_function<expr_single_t>(
-                                    &get_property_kernel_complex_float32_real);
-                    return offset_out + sizeof(ckernel_prefix);
-                case 1:
-                    e->set_function<expr_single_t>(
-                                    &get_property_kernel_complex_float32_imag);
-                    return offset_out + sizeof(ckernel_prefix);
-                case 2:
-                    e->set_function<expr_single_t>(
-                                    &get_or_set_property_kernel_complex_float32_conj);
-                    return offset_out + sizeof(ckernel_prefix);
-                default:
-                    break;
-            }
-            break;
-        case complex_float64_type_id:
-            switch (src_elwise_property_index) {
-                case 0:
-                    e->set_function<expr_single_t>(
-                                    &get_property_kernel_complex_float64_real);
-                    return offset_out + sizeof(ckernel_prefix);
-                case 1:
-                    e->set_function<expr_single_t>(
-                                    &get_property_kernel_complex_float64_imag);
-                    return offset_out + sizeof(ckernel_prefix);
-                case 2:
-                    e->set_function<expr_single_t>(
-                                    &get_or_set_property_kernel_complex_float64_conj);
-                    return offset_out + sizeof(ckernel_prefix);
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
+  ckb_offset =
+      make_kernreq_to_single_kernel_adapter(ckb, ckb_offset, 1, kernreq);
+  ckernel_prefix *e = ckb->alloc_ck_leaf<ckernel_prefix>(ckb_offset);
+  switch (builtin_type_id) {
+  case complex_float32_type_id:
+    switch (src_elwise_property_index) {
+    case 0:
+      e->set_function<expr_single_t>(&get_property_kernel_complex_float32_real);
+      return ckb_offset;
+    case 1:
+      e->set_function<expr_single_t>(&get_property_kernel_complex_float32_imag);
+      return ckb_offset;
+    case 2:
+      e->set_function<expr_single_t>(
+          &get_or_set_property_kernel_complex_float32_conj);
+      return ckb_offset;
+    default:
+      break;
     }
-    stringstream ss;
-    ss << "dynd type " << ndt::type(builtin_type_id) << " given an invalid property index " << src_elwise_property_index;
-    throw runtime_error(ss.str());
+    break;
+  case complex_float64_type_id:
+    switch (src_elwise_property_index) {
+    case 0:
+      e->set_function<expr_single_t>(&get_property_kernel_complex_float64_real);
+      return ckb_offset;
+    case 1:
+      e->set_function<expr_single_t>(&get_property_kernel_complex_float64_imag);
+      return ckb_offset;
+    case 2:
+      e->set_function<expr_single_t>(
+          &get_or_set_property_kernel_complex_float64_conj);
+      return ckb_offset;
+    default:
+      break;
+    }
+    break;
+  default:
+    break;
+  }
+  stringstream ss;
+  ss << "dynd type " << ndt::type(builtin_type_id)
+     << " given an invalid property index " << src_elwise_property_index;
+  throw runtime_error(ss.str());
 }
 
 size_t dynd::make_builtin_type_elwise_property_setter_kernel(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 type_id_t builtin_type_id,
                 const char *DYND_UNUSED(dst_arrmeta), size_t dst_elwise_property_index,
                 const char *DYND_UNUSED(src_arrmeta),
                 kernel_request_t kernreq, const eval::eval_context *DYND_UNUSED(ectx))
 {
-    offset_out =
-        make_kernreq_to_single_kernel_adapter(out, offset_out, 1, kernreq);
-    ckernel_prefix *e = out->get_at<ckernel_prefix>(offset_out);
-    switch (builtin_type_id) {
-        case complex_float32_type_id:
-            switch (dst_elwise_property_index) {
-                case 2:
-                    e->set_function<expr_single_t>(
-                                    &get_or_set_property_kernel_complex_float32_conj);
-                    return offset_out + sizeof(ckernel_prefix);
-                default:
-                    break;
-            }
-            break;
-        case complex_float64_type_id:
-            switch (dst_elwise_property_index) {
-                case 2:
-                    e->set_function<expr_single_t>(
-                                    &get_or_set_property_kernel_complex_float64_conj);
-                    return offset_out + sizeof(ckernel_prefix);
-                default:
-                    break;
-            }
-            break;
-        default:
-            break;
+  ckb_offset =
+      make_kernreq_to_single_kernel_adapter(ckb, ckb_offset, 1, kernreq);
+  ckernel_prefix *e = ckb->alloc_ck_leaf<ckernel_prefix>(ckb_offset);
+  switch (builtin_type_id) {
+  case complex_float32_type_id:
+    switch (dst_elwise_property_index) {
+    case 2:
+      e->set_function<expr_single_t>(
+          &get_or_set_property_kernel_complex_float32_conj);
+      return ckb_offset;
+    default:
+      break;
     }
-    stringstream ss;
-    ss << "dynd type " << ndt::type(builtin_type_id) << " given an invalid property index " << dst_elwise_property_index;
-    throw runtime_error(ss.str());
+    break;
+  case complex_float64_type_id:
+    switch (dst_elwise_property_index) {
+    case 2:
+      e->set_function<expr_single_t>(
+          &get_or_set_property_kernel_complex_float64_conj);
+      return ckb_offset;
+    default:
+      break;
+    }
+    break;
+  default:
+    break;
+  }
+  stringstream ss;
+  ss << "dynd type " << ndt::type(builtin_type_id)
+     << " given an invalid property index " << dst_elwise_property_index;
+  throw runtime_error(ss.str());
 }

--- a/src/dynd/types/bytes_type.cpp
+++ b/src/dynd/types/bytes_type.cpp
@@ -125,20 +125,20 @@ bool bytes_type::is_lossless_assignment(const ndt::type& dst_tp, const ndt::type
 }
 
 size_t bytes_type::make_assignment_kernel(
-    ckernel_builder *out, size_t offset_out, const ndt::type &dst_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_tp,
     const char *dst_arrmeta, const ndt::type &src_tp, const char *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx) const
 {
     if (this == dst_tp.extended()) {
         switch (src_tp.get_type_id()) {
             case bytes_type_id: {
-                return make_blockref_bytes_assignment_kernel(out, offset_out,
+                return make_blockref_bytes_assignment_kernel(ckb, ckb_offset,
                                 get_data_alignment(), dst_arrmeta,
                                 src_tp.get_data_alignment(), src_arrmeta,
                                 kernreq, ectx);
             }
             case fixedbytes_type_id: {
-                return make_fixedbytes_to_blockref_bytes_assignment_kernel(out, offset_out,
+                return make_fixedbytes_to_blockref_bytes_assignment_kernel(ckb, ckb_offset,
                                 get_data_alignment(), dst_arrmeta,
                                 src_tp.get_data_size(), src_tp.get_data_alignment(),
                                 kernreq, ectx);
@@ -146,7 +146,7 @@ size_t bytes_type::make_assignment_kernel(
             default: {
                 if (!src_tp.is_builtin()) {
                     src_tp.extended()->make_assignment_kernel(
-                        out, offset_out, dst_tp, dst_arrmeta, src_tp,
+                        ckb, ckb_offset, dst_tp, dst_arrmeta, src_tp,
                         src_arrmeta, kernreq, ectx);
                 }
                 break;

--- a/src/dynd/types/byteswap_type.cpp
+++ b/src/dynd/types/byteswap_type.cpp
@@ -93,32 +93,32 @@ ndt::type byteswap_type::with_replaced_storage_type(const ndt::type& replacement
 }
 
 size_t byteswap_type::make_operand_to_value_assignment_kernel(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 const char *DYND_UNUSED(dst_arrmeta), const char *DYND_UNUSED(src_arrmeta),
                 kernel_request_t kernreq, const eval::eval_context *DYND_UNUSED(ectx)) const
 {
     if(m_value_type.get_kind() != complex_kind) {
-        return make_byteswap_assignment_function(out, offset_out,
+        return make_byteswap_assignment_function(ckb, ckb_offset,
                         m_value_type.get_data_size(), m_value_type.get_data_alignment(),
                         kernreq);
     } else {
-        return make_pairwise_byteswap_assignment_function(out, offset_out,
+        return make_pairwise_byteswap_assignment_function(ckb, ckb_offset,
                         m_value_type.get_data_size(), m_value_type.get_data_alignment(),
                         kernreq);
     }
 }
 
 size_t byteswap_type::make_value_to_operand_assignment_kernel(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 const char *DYND_UNUSED(dst_arrmeta), const char *DYND_UNUSED(src_arrmeta),
                 kernel_request_t kernreq, const eval::eval_context *DYND_UNUSED(ectx)) const
 {
     if(m_value_type.get_kind() != complex_kind) {
-        return make_byteswap_assignment_function(out, offset_out,
+        return make_byteswap_assignment_function(ckb, ckb_offset,
                         m_value_type.get_data_size(), m_value_type.get_data_alignment(),
                         kernreq);
     } else {
-        return make_pairwise_byteswap_assignment_function(out, offset_out,
+        return make_pairwise_byteswap_assignment_function(ckb, ckb_offset,
                         m_value_type.get_data_size(), m_value_type.get_data_alignment(),
                         kernreq);
     }

--- a/src/dynd/types/char_type.cpp
+++ b/src/dynd/types/char_type.cpp
@@ -103,14 +103,14 @@ bool char_type::operator==(const base_type& rhs) const
 }
 
 size_t char_type::make_assignment_kernel(
-    ckernel_builder *out, size_t offset_out, const ndt::type &dst_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_tp,
     const char *dst_arrmeta, const ndt::type &src_tp, const char *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx) const
 {
     if (this == dst_tp.extended()) {
         if (dst_tp == src_tp) {
             // If the types are the same, it's a POD assignment
-            return make_pod_typed_data_assignment_kernel(out, offset_out,
+            return make_pod_typed_data_assignment_kernel(ckb, ckb_offset,
                         m_members.data_size, m_members.data_alignment,
                         kernreq);
         }
@@ -119,27 +119,27 @@ size_t char_type::make_assignment_kernel(
                 // Use the fixedstring assignment to do this conversion
                 const char_type *src_fs = src_tp.tcast<char_type>();
                 return make_fixedstring_assignment_kernel(
-                    out, offset_out, get_data_size(), m_encoding,
+                    ckb, ckb_offset, get_data_size(), m_encoding,
                     src_fs->get_data_size(), src_fs->m_encoding, kernreq, ectx);
             }
             case fixedstring_type_id: {
                 // Use the fixedstring assignment to do this conversion
                 const base_string_type *src_fs = src_tp.tcast<base_string_type>();
                 return make_fixedstring_assignment_kernel(
-                    out, offset_out, get_data_size(), m_encoding,
+                    ckb, ckb_offset, get_data_size(), m_encoding,
                     src_fs->get_data_size(), src_fs->get_encoding(), kernreq,
                     ectx);
             }
             case string_type_id: {
                 const base_string_type *src_fs = src_tp.tcast<base_string_type>();
                 return make_blockref_string_to_fixedstring_assignment_kernel(
-                    out, offset_out, get_data_size(), m_encoding,
+                    ckb, ckb_offset, get_data_size(), m_encoding,
                     src_fs->get_encoding(), kernreq, ectx);
             }
             default: {
                 if (!src_tp.is_builtin()) {
                     return src_tp.extended()->make_assignment_kernel(
-                        out, offset_out, dst_tp, dst_arrmeta, src_tp,
+                        ckb, ckb_offset, dst_tp, dst_arrmeta, src_tp,
                         src_arrmeta, kernreq, ectx);
                 }
                 break;
@@ -152,14 +152,14 @@ size_t char_type::make_assignment_kernel(
                 // Use the fixedstring assignment to do this conversion
                 const base_string_type *dst_fs = dst_tp.tcast<base_string_type>();
                 return make_fixedstring_assignment_kernel(
-                    out, offset_out, dst_fs->get_data_size(),
+                    ckb, ckb_offset, dst_fs->get_data_size(),
                     dst_fs->get_encoding(), get_data_size(), m_encoding,
                     kernreq, ectx);
             }
             case string_type_id: {
                 const base_string_type *dst_fs = dst_tp.tcast<base_string_type>();
                 return make_fixedstring_to_blockref_string_assignment_kernel(
-                    out, offset_out, dst_arrmeta, dst_fs->get_encoding(),
+                    ckb, ckb_offset, dst_arrmeta, dst_fs->get_encoding(),
                     get_data_size(), m_encoding, kernreq, ectx);
             }
             default: {
@@ -174,7 +174,7 @@ size_t char_type::make_assignment_kernel(
 }
 
 size_t char_type::make_comparison_kernel(
-    ckernel_builder *out, size_t offset_out,
+    ckernel_builder *ckb, intptr_t ckb_offset,
     const ndt::type& src0_dt, const char *src0_arrmeta,
     const ndt::type& src1_dt, const char *src1_arrmeta,
     comparison_type_t comptype,
@@ -182,18 +182,18 @@ size_t char_type::make_comparison_kernel(
 {
     if (this == src0_dt.extended()) {
         if (*this == *src1_dt.extended()) {
-            return make_string_comparison_kernel(out, offset_out,
+            return make_string_comparison_kernel(ckb, ckb_offset,
                 m_encoding,
                 comptype, ectx);
         }
         else if (src1_dt.get_kind() == string_kind) {
-            return make_general_string_comparison_kernel(out, offset_out,
+            return make_general_string_comparison_kernel(ckb, ckb_offset,
                 src0_dt, src0_arrmeta,
                 src1_dt, src1_arrmeta,
                 comptype, ectx);
         }
         else if (!src1_dt.is_builtin()) {
-            return src1_dt.extended()->make_comparison_kernel(out, offset_out,
+            return src1_dt.extended()->make_comparison_kernel(ckb, ckb_offset,
                 src0_dt, src0_arrmeta,
                 src1_dt, src1_arrmeta,
                 comptype, ectx);

--- a/src/dynd/types/convert_type.cpp
+++ b/src/dynd/types/convert_type.cpp
@@ -107,21 +107,21 @@ ndt::type convert_type::with_replaced_storage_type(const ndt::type& replacement_
 }
 
 size_t convert_type::make_operand_to_value_assignment_kernel(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 const char *dst_arrmeta, const char *src_arrmeta,
                 kernel_request_t kernreq, const eval::eval_context *ectx) const
 {
-    return ::make_assignment_kernel(out, offset_out, m_value_type, dst_arrmeta,
+    return ::make_assignment_kernel(ckb, ckb_offset, m_value_type, dst_arrmeta,
                                     m_operand_type.value_type(), src_arrmeta,
                                     kernreq, ectx);
 }
 
 size_t convert_type::make_value_to_operand_assignment_kernel(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 const char *dst_arrmeta, const char *src_arrmeta,
                 kernel_request_t kernreq, const eval::eval_context *ectx) const
 {
-    return ::make_assignment_kernel(out, offset_out,
+    return ::make_assignment_kernel(ckb, ckb_offset,
                                     m_operand_type.value_type(), dst_arrmeta,
                                     m_value_type, src_arrmeta, kernreq, ectx);
 }

--- a/src/dynd/types/cstruct_type.cpp
+++ b/src/dynd/types/cstruct_type.cpp
@@ -170,26 +170,26 @@ bool cstruct_type::is_lossless_assignment(const ndt::type& dst_tp, const ndt::ty
 }
 
 size_t cstruct_type::make_assignment_kernel(
-    ckernel_builder *out_ckb, size_t ckb_offset, const ndt::type &dst_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_tp,
     const char *dst_arrmeta, const ndt::type &src_tp, const char *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx) const
 {
     if (this == dst_tp.extended()) {
         if (*this == *src_tp.extended()) {
             return make_struct_identical_assignment_kernel(
-                out_ckb, ckb_offset, dst_tp, dst_arrmeta, src_arrmeta, kernreq,
+                ckb, ckb_offset, dst_tp, dst_arrmeta, src_arrmeta, kernreq,
                 ectx);
         } else if (src_tp.get_kind() == struct_kind) {
-            return make_struct_assignment_kernel(out_ckb, ckb_offset, dst_tp,
+            return make_struct_assignment_kernel(ckb, ckb_offset, dst_tp,
                                                  dst_arrmeta, src_tp,
                                                  src_arrmeta, kernreq, ectx);
         } else if (src_tp.is_builtin()) {
             return make_broadcast_to_struct_assignment_kernel(
-                out_ckb, ckb_offset, dst_tp, dst_arrmeta, src_tp, src_arrmeta,
+                ckb, ckb_offset, dst_tp, dst_arrmeta, src_tp, src_arrmeta,
                 kernreq, ectx);
         } else {
             return src_tp.extended()->make_assignment_kernel(
-                out_ckb, ckb_offset, dst_tp, dst_arrmeta, src_tp, src_arrmeta,
+                ckb, ckb_offset, dst_tp, dst_arrmeta, src_tp, src_arrmeta,
                 kernreq, ectx);
         }
     }
@@ -200,18 +200,18 @@ size_t cstruct_type::make_assignment_kernel(
 }
 
 size_t cstruct_type::make_comparison_kernel(
-    ckernel_builder *out, size_t offset_out, const ndt::type &src0_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &src0_tp,
     const char *src0_arrmeta, const ndt::type &src1_tp,
     const char *src1_arrmeta, comparison_type_t comptype,
     const eval::eval_context *ectx) const
 {
     if (this == src0_tp.extended()) {
         if (*this == *src1_tp.extended()) {
-            return make_struct_comparison_kernel(out, offset_out,
+            return make_struct_comparison_kernel(ckb, ckb_offset,
                             src0_tp, src0_arrmeta, src1_arrmeta,
                             comptype, ectx);
         } else if (src1_tp.get_kind() == struct_kind) {
-            return make_general_struct_comparison_kernel(out, offset_out,
+            return make_general_struct_comparison_kernel(ckb, ckb_offset,
                             src0_tp, src0_arrmeta,
                             src1_tp, src1_arrmeta,
                             comptype, ectx);

--- a/src/dynd/types/ctuple_type.cpp
+++ b/src/dynd/types/ctuple_type.cpp
@@ -127,7 +127,7 @@ bool ctuple_type::is_lossless_assignment(const ndt::type& dst_tp, const ndt::typ
 }
 
 size_t ctuple_type::make_assignment_kernel(
-    ckernel_builder *DYND_UNUSED(out_ckb), size_t DYND_UNUSED(ckb_offset),
+    ckernel_builder *DYND_UNUSED(ckb), intptr_t DYND_UNUSED(ckb_offset),
     const ndt::type &dst_tp, const char *DYND_UNUSED(dst_arrmeta),
     const ndt::type &src_tp, const char *DYND_UNUSED(src_arrmeta),
     kernel_request_t DYND_UNUSED(kernreq),
@@ -137,20 +137,20 @@ size_t ctuple_type::make_assignment_kernel(
     if (this == dst_tp.extended()) {
         if (this == src_tp.extended()) {
             return make_tuple_identical_assignment_kernel(
-                out_ckb, ckb_offset, dst_tp, dst_arrmeta, src_arrmeta,
+                ckb, ckb_offset, dst_tp, dst_arrmeta, src_arrmeta,
                 kernreq, errmode, ectx);
         } else if (src_tp.get_kind() == struct_kind) {
-            return make_tuple_assignment_kernel(out_ckb, ckb_offset,
+            return make_tuple_assignment_kernel(ckb, ckb_offset,
                             dst_tp, dst_arrmeta,
                             src_tp, src_arrmeta,
                             kernreq, errmode, ectx);
         } else if (src_tp.is_builtin()) {
-            return make_broadcast_to_tuple_assignment_kernel(out_ckb, ckb_offset,
+            return make_broadcast_to_tuple_assignment_kernel(ckb, ckb_offset,
                             dst_tp, dst_arrmeta,
                             src_tp, src_arrmeta,
                             kernreq, errmode, ectx);
         } else {
-            return src_tp.extended()->make_assignment_kernel(out_ckb, ckb_offset,
+            return src_tp.extended()->make_assignment_kernel(ckb, ckb_offset,
                             dst_tp, dst_arrmeta,
                             src_tp, src_arrmeta,
                             kernreq, errmode, ectx);
@@ -164,7 +164,7 @@ size_t ctuple_type::make_assignment_kernel(
 }
 
 size_t ctuple_type::make_comparison_kernel(
-                ckernel_builder *DYND_UNUSED(out), size_t DYND_UNUSED(offset_out),
+                ckernel_builder *DYND_UNUSED(ckb), intptr_t DYND_UNUSED(ckb_offset),
                 const ndt::type& src0_tp, const char *DYND_UNUSED(src0_arrmeta),
                 const ndt::type& src1_tp, const char *DYND_UNUSED(src1_arrmeta),
                 comparison_type_t comptype,
@@ -173,11 +173,11 @@ size_t ctuple_type::make_comparison_kernel(
     /*
     if (this == src0_tp.extended()) {
         if (*this == *src1_tp.extended()) {
-            return make_tuple_comparison_kernel(out, offset_out,
+            return make_tuple_comparison_kernel(ckb, ckb_offset,
                             src0_tp, src0_arrmeta, src1_arrmeta,
                             comptype, ectx);
         } else if (src1_tp.get_kind() == struct_kind) {
-            return make_general_tuple_comparison_kernel(out, offset_out,
+            return make_general_tuple_comparison_kernel(ckb, ckb_offset,
                             src0_tp, src0_arrmeta,
                             src1_tp, src1_arrmeta,
                             comptype, ectx);

--- a/src/dynd/types/cuda_device_type.cpp
+++ b/src/dynd/types/cuda_device_type.cpp
@@ -62,11 +62,11 @@ void cuda_device_type::data_free(char *data) const
 }
 
 size_t cuda_device_type::make_assignment_kernel(
-    ckernel_builder *out, size_t offset_out, const ndt::type &dst_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_tp,
     const char *dst_arrmeta, const ndt::type &src_tp, const char *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx) const
 {
-    return make_cuda_assignment_kernel(out, offset_out,
+    return make_cuda_assignment_kernel(ckb, ckb_offset,
                         dst_tp, dst_arrmeta,
                         src_tp, src_arrmeta,
                         kernreq, ectx);

--- a/src/dynd/types/cuda_host_type.cpp
+++ b/src/dynd/types/cuda_host_type.cpp
@@ -60,11 +60,11 @@ void cuda_host_type::data_free(char *data) const
 }
 
 size_t cuda_host_type::make_assignment_kernel(
-    ckernel_builder *out, size_t offset_out, const ndt::type &dst_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_tp,
     const char *dst_arrmeta, const ndt::type &src_tp, const char *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx) const
 {
-    return make_cuda_assignment_kernel(out, offset_out, dst_tp, dst_arrmeta,
+    return make_cuda_assignment_kernel(ckb, ckb_offset, dst_tp, dst_arrmeta,
                                        src_tp, src_arrmeta, kernreq, ectx);
 }
 

--- a/src/dynd/types/datashape_formatter.cpp
+++ b/src/dynd/types/datashape_formatter.cpp
@@ -94,7 +94,7 @@ static void format_uniform_dim_datashape(std::ostream& o,
         }
         case fixed_dim_type_id: {
             const fixed_dim_type *fad = dt.tcast<fixed_dim_type>();
-            size_t dim_size = fad->get_fixed_dim_size();
+            intptr_t dim_size = fad->get_fixed_dim_size();
             o << dim_size << " * ";
             // Allow data to keep going only if the dimension size is 1
             if (dim_size != 1) {
@@ -105,7 +105,7 @@ static void format_uniform_dim_datashape(std::ostream& o,
         }
         case cfixed_dim_type_id: {
             const cfixed_dim_type *fad = dt.tcast<cfixed_dim_type>();
-            size_t dim_size = fad->get_fixed_dim_size();
+            intptr_t dim_size = fad->get_fixed_dim_size();
             o << dim_size << " * ";
             // Allow data to keep going only if the dimension size is 1
             if (dim_size != 1) {

--- a/src/dynd/types/expr_type.cpp
+++ b/src/dynd/types/expr_type.cpp
@@ -270,47 +270,47 @@ namespace {
 } // anonymous namespace
 
 static size_t make_expr_type_offset_applier(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 size_t src_count, const intptr_t *src_data_offsets)
 {
     // A few specializations with fixed size, and a general case version
     // NOTE: src_count == 1 must never happen here, it is handled by the unary_expr type
     switch (src_count) {
         case 2: {
-            out->ensure_capacity(offset_out + sizeof(expr_type_offset_applier_extra<2>));
-            expr_type_offset_applier_extra<2> *e = out->get_at<expr_type_offset_applier_extra<2> >(offset_out);
+            expr_type_offset_applier_extra<2> *e = ckb->alloc_ck_leaf<expr_type_offset_applier_extra<2> >(ckb_offset);
             memcpy(e->offsets, src_data_offsets, sizeof(e->offsets));
             e->base.set_function<expr_single_t>(&expr_type_offset_applier_extra<2>::single);
             e->base.destructor = &expr_type_offset_applier_extra<2>::destruct;
-            return offset_out + sizeof(expr_type_offset_applier_extra<2>);
+            return ckb_offset;
         }
         case 3: {
-            out->ensure_capacity(offset_out + sizeof(expr_type_offset_applier_extra<3>));
-            expr_type_offset_applier_extra<3> *e = out->get_at<expr_type_offset_applier_extra<3> >(offset_out);
+            expr_type_offset_applier_extra<3> *e = ckb->alloc_ck_leaf<expr_type_offset_applier_extra<3> >(ckb_offset);
             memcpy(e->offsets, src_data_offsets, sizeof(e->offsets));
             e->base.set_function<expr_single_t>(&expr_type_offset_applier_extra<3>::single);
             e->base.destructor = &expr_type_offset_applier_extra<3>::destruct;
-            return offset_out + sizeof(expr_type_offset_applier_extra<3>);
+            return ckb_offset;
         }
         case 4: {
-            out->ensure_capacity(offset_out + sizeof(expr_type_offset_applier_extra<4>));
-            expr_type_offset_applier_extra<4> *e = out->get_at<expr_type_offset_applier_extra<4> >(offset_out);
+            expr_type_offset_applier_extra<4> *e = ckb->alloc_ck_leaf<expr_type_offset_applier_extra<4> >(ckb_offset);
             memcpy(e->offsets, src_data_offsets, sizeof(e->offsets));
             e->base.set_function<expr_single_t>(&expr_type_offset_applier_extra<4>::single);
             e->base.destructor = &expr_type_offset_applier_extra<4>::destruct;
-            return offset_out + sizeof(expr_type_offset_applier_extra<4>);
+            return ckb_offset;
         }
         default: {
-            size_t extra_size = sizeof(expr_type_offset_applier_general_extra) +
-                            src_count * sizeof(size_t);
-            out->ensure_capacity(offset_out + extra_size);
-            expr_type_offset_applier_general_extra *e = out->get_at<expr_type_offset_applier_general_extra>(offset_out);
+            intptr_t root_ckb_offset = ckb_offset;
+            kernels::inc_ckb_offset(
+                ckb_offset, sizeof(expr_type_offset_applier_general_extra) +
+                                src_count * sizeof(size_t));
+            ckb->ensure_capacity(ckb_offset);
+            expr_type_offset_applier_general_extra *e =
+                ckb->get_at<expr_type_offset_applier_general_extra>(root_ckb_offset);
             e->src_count = src_count;
             size_t *out_offsets = reinterpret_cast<size_t *>(e + 1);
             memcpy(out_offsets, src_data_offsets, src_count * sizeof(size_t));
             e->base.set_function<expr_single_t>(&expr_type_offset_applier_general_extra::single);
             e->base.destructor = &expr_type_offset_applier_general_extra::destruct;
-            return offset_out + extra_size;
+            return ckb_offset;
         }
     }   
 }
@@ -323,16 +323,15 @@ static void src_deref_single(char *dst, const char *const *src,
     child_fn(dst, reinterpret_cast<const char *const *>(*src), child);
 }
 
-static size_t make_src_deref_ckernel(ckernel_builder *ckb, size_t ckb_offset) {
-    ckb->ensure_capacity(ckb_offset + sizeof(ckernel_prefix));
-    ckernel_prefix *self = ckb->get_at<ckernel_prefix>(ckb_offset);
+static size_t make_src_deref_ckernel(ckernel_builder *ckb, intptr_t ckb_offset) {
+    ckernel_prefix *self = ckb->alloc_ck_leaf<ckernel_prefix>(ckb_offset);
     self->set_function<expr_single_t>(&src_deref_single);
     self->destructor = &kernels::destroy_trivial_parent_ckernel;
-    return ckb_offset + sizeof(ckernel_prefix);
+    return ckb_offset;
 }
 
 size_t expr_type::make_operand_to_value_assignment_kernel(
-                ckernel_builder *ckb, size_t ckb_offset,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 const char *dst_arrmeta, const char *src_arrmeta,
                 kernel_request_t kernreq, const eval::eval_context *ectx) const
 {
@@ -375,7 +374,7 @@ size_t expr_type::make_operand_to_value_assignment_kernel(
 }
 
 size_t expr_type::make_value_to_operand_assignment_kernel(
-                ckernel_builder *DYND_UNUSED(out), size_t DYND_UNUSED(offset_out),
+                ckernel_builder *DYND_UNUSED(ckb), intptr_t DYND_UNUSED(ckb_offset),
                 const char *DYND_UNUSED(dst_arrmeta), const char *DYND_UNUSED(src_arrmeta),
                 kernel_request_t DYND_UNUSED(kernreq), const eval::eval_context *DYND_UNUSED(ectx)) const
 {

--- a/src/dynd/types/fixed_dim_type.cpp
+++ b/src/dynd/types/fixed_dim_type.cpp
@@ -16,7 +16,7 @@
 using namespace std;
 using namespace dynd;
 
-fixed_dim_type::fixed_dim_type(size_t dim_size, const ndt::type &element_tp)
+fixed_dim_type::fixed_dim_type(intptr_t dim_size, const ndt::type &element_tp)
     : base_uniform_dim_type(fixed_dim_type_id, element_tp, 0,
                             element_tp.get_data_alignment(),
                             sizeof(fixed_dim_type_arrmeta), type_flag_none),
@@ -481,55 +481,61 @@ void fixed_dim_type::data_destruct_strided(const char *arrmeta, char *data,
 }
 
 size_t fixed_dim_type::make_assignment_kernel(
-    ckernel_builder *out_ckb, size_t ckb_offset, const ndt::type &dst_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_tp,
     const char *dst_arrmeta, const ndt::type &src_tp, const char *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx) const
 {
-    if (this == dst_tp.extended()) {
-        const fixed_dim_type_arrmeta *dst_md =
-                        reinterpret_cast<const fixed_dim_type_arrmeta *>(dst_arrmeta);
-        kernels::strided_assign_ck *self =
-            kernels::strided_assign_ck::create(out_ckb, ckb_offset, kernreq);
-        intptr_t ckb_end = ckb_offset + sizeof(kernels::strided_assign_ck);
-        self->m_size = m_dim_size;
-        self->m_dst_stride = dst_md->stride;
+  if (this == dst_tp.extended()) {
+    const fixed_dim_type_arrmeta *dst_md =
+        reinterpret_cast<const fixed_dim_type_arrmeta *>(dst_arrmeta);
+    intptr_t src_size, src_stride;
+    ndt::type src_el_tp;
+    const char *src_el_arrmeta;
 
-        intptr_t src_size;
-        ndt::type src_el_tp;
-        const char *src_el_arrmeta;
-
-        if (src_tp.get_ndim() < dst_tp.get_ndim()) {
-            // If the src has fewer dimensions, broadcast it across this one
-            self->m_src_stride = 0;
-            return ::make_assignment_kernel(out_ckb, ckb_end,
-                            m_element_tp, dst_arrmeta + sizeof(fixed_dim_type_arrmeta),
-                            src_tp, src_arrmeta,
-                            kernel_request_strided, ectx);
-        } else if (src_tp.get_as_strided_dim(src_arrmeta, src_size,
-                                             self->m_src_stride, src_el_tp,
-                                             src_el_arrmeta)) {
-            // Check for a broadcasting error
-            if (src_size != 1 && (intptr_t)m_dim_size != src_size) {
-                throw broadcast_error(dst_tp, dst_arrmeta, src_tp, src_arrmeta);
-            }
-
-            return ::make_assignment_kernel(
-                out_ckb, ckb_end, m_element_tp,
-                dst_arrmeta + sizeof(fixed_dim_type_arrmeta), src_el_tp,
-                src_el_arrmeta, kernel_request_strided, ectx);
-        } else if (!src_tp.is_builtin()) {
-            // Give the src type a chance to make a kernel
-            return src_tp.extended()->make_assignment_kernel(
-                out_ckb, ckb_offset, dst_tp, dst_arrmeta, src_tp, src_arrmeta,
-                kernreq, ectx);
-        }
-    } else if (dst_tp.get_ndim() < src_tp.get_ndim()) {
+    if (src_tp.get_ndim() < dst_tp.get_ndim()) {
+      kernels::strided_assign_ck *self =
+          kernels::strided_assign_ck::create(ckb, kernreq, ckb_offset);
+      self->m_size = get_fixed_dim_size();
+      self->m_dst_stride = dst_md->stride;
+      // If the src has fewer dimensions, broadcast it across this one
+      self->m_src_stride = 0;
+      return ::make_assignment_kernel(
+          ckb, ckb_offset, m_element_tp,
+          dst_arrmeta + sizeof(fixed_dim_type_arrmeta), src_tp, src_arrmeta,
+          kernel_request_strided, ectx);
+    } else if (src_tp.get_as_strided_dim(src_arrmeta, src_size, src_stride,
+                                         src_el_tp, src_el_arrmeta)) {
+      kernels::strided_assign_ck *self =
+          kernels::strided_assign_ck::create(ckb, kernreq, ckb_offset);
+      self->m_size = get_fixed_dim_size();
+      self->m_dst_stride = dst_md->stride;
+      self->m_src_stride = src_stride;
+      // Check for a broadcasting error
+      if (src_size != 1 && get_fixed_dim_size() != src_size) {
         throw broadcast_error(dst_tp, dst_arrmeta, src_tp, src_arrmeta);
-    }
+      }
 
+      return ::make_assignment_kernel(
+          ckb, ckb_offset, m_element_tp,
+          dst_arrmeta + sizeof(fixed_dim_type_arrmeta), src_el_tp,
+          src_el_arrmeta, kernel_request_strided, ectx);
+    } else if (!src_tp.is_builtin()) {
+      // Give the src type a chance to make a kernel
+      return src_tp.extended()->make_assignment_kernel(
+          ckb, ckb_offset, dst_tp, dst_arrmeta, src_tp, src_arrmeta,
+          kernreq, ectx);
+    } else {
+      stringstream ss;
+      ss << "Cannot assign from " << src_tp << " to " << dst_tp;
+      throw dynd::type_error(ss.str());
+    }
+  } else if (dst_tp.get_ndim() < src_tp.get_ndim()) {
+    throw broadcast_error(dst_tp, dst_arrmeta, src_tp, src_arrmeta);
+  } else {
     stringstream ss;
     ss << "Cannot assign from " << src_tp << " to " << dst_tp;
     throw dynd::type_error(ss.str());
+  }
 }
 
 void fixed_dim_type::foreach_leading(const char *arrmeta, char *data,
@@ -560,7 +566,7 @@ void fixed_dim_type::reorder_default_constructed_strides(char *DYND_UNUSED(dst_a
     throw runtime_error("TODO: fixed_dim_type::reorder_default_constructed_strides");
 }
 
-static size_t get_fixed_dim_size(const ndt::type& dt) {
+static intptr_t get_fixed_dim_size(const ndt::type& dt) {
     return  dt.tcast<fixed_dim_type>()->get_fixed_dim_size();
 }
 

--- a/src/dynd/types/fixedbytes_type.cpp
+++ b/src/dynd/types/fixedbytes_type.cpp
@@ -93,7 +93,7 @@ bool fixedbytes_type::operator==(const base_type& rhs) const
 }
 
 size_t fixedbytes_type::make_assignment_kernel(
-    ckernel_builder *out, size_t offset_out, const ndt::type &dst_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_tp,
     const char *dst_arrmeta, const ndt::type &src_tp, const char *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx) const
 {
@@ -104,13 +104,13 @@ size_t fixedbytes_type::make_assignment_kernel(
                 if (get_data_size() != src_fs->get_data_size()) {
                     throw runtime_error("cannot assign to a fixedbytes type of a different size");
                 }
-                return ::make_pod_typed_data_assignment_kernel(out, offset_out,
+                return ::make_pod_typed_data_assignment_kernel(ckb, ckb_offset,
                                 get_data_size(), std::min(get_data_alignment(), src_fs->get_data_alignment()),
                                 kernreq);
             }
             default: {
                 return src_tp.extended()->make_assignment_kernel(
-                    out, offset_out, dst_tp, dst_arrmeta, src_tp, src_arrmeta,
+                    ckb, ckb_offset, dst_tp, dst_arrmeta, src_tp, src_arrmeta,
                     kernreq, ectx);
             }
         }

--- a/src/dynd/types/fixedstring_type.cpp
+++ b/src/dynd/types/fixedstring_type.cpp
@@ -171,7 +171,7 @@ bool fixedstring_type::operator==(const base_type& rhs) const
 }
 
 size_t fixedstring_type::make_assignment_kernel(
-    ckernel_builder *out, size_t offset_out, const ndt::type &dst_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_tp,
     const char *dst_arrmeta, const ndt::type &src_tp, const char *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx) const
 {
@@ -180,23 +180,23 @@ size_t fixedstring_type::make_assignment_kernel(
             case fixedstring_type_id: {
                 const fixedstring_type *src_fs = src_tp.tcast<fixedstring_type>();
                 return make_fixedstring_assignment_kernel(
-                    out, offset_out, get_data_size(), m_encoding,
+                    ckb, ckb_offset, get_data_size(), m_encoding,
                     src_fs->get_data_size(), src_fs->m_encoding, kernreq, ectx);
             }
             case string_type_id: {
                 const base_string_type *src_fs = src_tp.tcast<base_string_type>();
                 return make_blockref_string_to_fixedstring_assignment_kernel(
-                    out, offset_out, get_data_size(), m_encoding,
+                    ckb, ckb_offset, get_data_size(), m_encoding,
                     src_fs->get_encoding(), kernreq, ectx);
             }
             default: {
                 if (!src_tp.is_builtin()) {
                     return src_tp.extended()->make_assignment_kernel(
-                        out, offset_out, dst_tp, dst_arrmeta, src_tp,
+                        ckb, ckb_offset, dst_tp, dst_arrmeta, src_tp,
                         src_arrmeta, kernreq, ectx);
                 } else {
                     return make_builtin_to_string_assignment_kernel(
-                        out, offset_out, dst_tp, dst_arrmeta,
+                        ckb, ckb_offset, dst_tp, dst_arrmeta,
                         src_tp.get_type_id(), kernreq, ectx);
                 }
             }
@@ -204,7 +204,7 @@ size_t fixedstring_type::make_assignment_kernel(
     } else {
         if (dst_tp.is_builtin()) {
             return make_string_to_builtin_assignment_kernel(
-                out, offset_out, dst_tp.get_type_id(), src_tp, src_arrmeta,
+                ckb, ckb_offset, dst_tp.get_type_id(), src_tp, src_arrmeta,
                 kernreq, ectx);
         } else {
             stringstream ss;
@@ -215,23 +215,23 @@ size_t fixedstring_type::make_assignment_kernel(
 }
 
 size_t fixedstring_type::make_comparison_kernel(
-    ckernel_builder *out, size_t offset_out, const ndt::type &src0_dt,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &src0_dt,
     const char *src0_arrmeta, const ndt::type &src1_dt,
     const char *src1_arrmeta, comparison_type_t comptype,
     const eval::eval_context *ectx) const
 {
     if (this == src0_dt.extended()) {
         if (*this == *src1_dt.extended()) {
-            return make_fixedstring_comparison_kernel(out, offset_out,
+            return make_fixedstring_comparison_kernel(ckb, ckb_offset,
                             m_stringsize, m_encoding,
                             comptype, ectx);
         } else if (src1_dt.get_kind() == string_kind) {
-            return make_general_string_comparison_kernel(out, offset_out,
+            return make_general_string_comparison_kernel(ckb, ckb_offset,
                             src0_dt, src0_arrmeta,
                             src1_dt, src1_arrmeta,
                             comptype, ectx);
         } else if (!src1_dt.is_builtin()) {
-            return src1_dt.extended()->make_comparison_kernel(out, offset_out,
+            return src1_dt.extended()->make_comparison_kernel(ckb, ckb_offset,
                             src0_dt, src0_arrmeta,
                             src1_dt, src1_arrmeta,
                             comptype, ectx);

--- a/src/dynd/types/funcproto_type.cpp
+++ b/src/dynd/types/funcproto_type.cpp
@@ -121,7 +121,7 @@ bool funcproto_type::is_lossless_assignment(const ndt::type& dst_tp, const ndt::
 
 /*
 size_t funcproto_type::make_assignment_kernel(
-                ckernel_builder *DYND_UNUSED(out_ckb), size_t DYND_UNUSED(ckb_offset),
+                ckernel_builder *DYND_UNUSED(ckb), size_t DYND_UNUSED(ckb_offset),
                 const ndt::type& dst_tp, const char *DYND_UNUSED(dst_arrmeta),
                 const ndt::type& src_tp, const char *DYND_UNUSED(src_arrmeta),
                 kernel_request_t DYND_UNUSED(kernreq), assign_error_mode DYND_UNUSED(errmode),
@@ -131,7 +131,7 @@ size_t funcproto_type::make_assignment_kernel(
 }
 
 size_t funcproto_type::make_comparison_kernel(
-                ckernel_builder *DYND_UNUSED(out), size_t DYND_UNUSED(offset_out),
+                ckernel_builder *DYND_UNUSED(ckb), intptr_t DYND_UNUSED(ckb_offset),
                 const ndt::type& src0_tp, const char *DYND_UNUSED(src0_arrmeta),
                 const ndt::type& src1_tp, const char *DYND_UNUSED(src1_arrmeta),
                 comparison_type_t comptype,

--- a/src/dynd/types/json_type.cpp
+++ b/src/dynd/types/json_type.cpp
@@ -240,7 +240,7 @@ struct string_to_json_ck
 } // anonymous namespace
 
 size_t json_type::make_assignment_kernel(
-    ckernel_builder *ckb, size_t ckb_offset, const ndt::type &dst_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_tp,
     const char *dst_arrmeta, const ndt::type &src_tp, const char *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx) const
 {
@@ -255,8 +255,7 @@ size_t json_type::make_assignment_kernel(
             case string_type_id:
             case fixedstring_type_id: {
                 string_to_json_ck *self =
-                    string_to_json_ck::create(ckb, ckb_offset, kernreq);
-                ckb_offset += sizeof(string_to_json_ck);
+                    string_to_json_ck::create(ckb, kernreq, ckb_offset);
                 self->m_dst_arrmeta = dst_arrmeta;
                 self->m_validate = (ectx->errmode != assign_error_nocheck);
                 if (src_tp.get_type_id() == string_type_id) {

--- a/src/dynd/types/ndarrayarg_type.cpp
+++ b/src/dynd/types/ndarrayarg_type.cpp
@@ -54,14 +54,14 @@ namespace {
 } // anonymous namespace
 
 size_t ndarrayarg_type::make_assignment_kernel(
-    ckernel_builder *ckb, size_t ckb_offset, const ndt::type &dst_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_tp,
     const char *DYND_UNUSED(dst_arrmeta), const ndt::type &src_tp,
     const char *DYND_UNUSED(src_arrmeta), kernel_request_t kernreq,
     const eval::eval_context *DYND_UNUSED(ectx)) const
 {
     if (this == dst_tp.extended() && src_tp.get_type_id() == ndarrayarg_type_id) {
-        ndarrayarg_assign_ck::create_leaf(ckb, ckb_offset, kernreq);
-        return ckb_offset + sizeof(ndarrayarg_assign_ck);
+        ndarrayarg_assign_ck::create_leaf(ckb, kernreq, ckb_offset);
+        return ckb_offset;
     }
 
     stringstream ss;
@@ -70,7 +70,7 @@ size_t ndarrayarg_type::make_assignment_kernel(
 }
 
 size_t ndarrayarg_type::make_comparison_kernel(
-    ckernel_builder *DYND_UNUSED(ckb), size_t DYND_UNUSED(ckb_offset), const ndt::type &src0_tp,
+    ckernel_builder *DYND_UNUSED(ckb), intptr_t DYND_UNUSED(ckb_offset), const ndt::type &src0_tp,
     const char *DYND_UNUSED(src0_arrmeta), const ndt::type &src1_tp,
     const char *DYND_UNUSED(src1_arrmeta), comparison_type_t comptype,
     const eval::eval_context *DYND_UNUSED(ectx)) const

--- a/src/dynd/types/option_type.cpp
+++ b/src/dynd/types/option_type.cpp
@@ -333,7 +333,7 @@ void option_type::arrmeta_debug_print(const char *arrmeta, std::ostream& o, cons
 }
 
 size_t option_type::make_assignment_kernel(
-    ckernel_builder *ckb, size_t ckb_offset, const ndt::type &dst_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_tp,
     const char *dst_arrmeta, const ndt::type &src_tp, const char *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx) const
 {

--- a/src/dynd/types/property_type.cpp
+++ b/src/dynd/types/property_type.cpp
@@ -147,7 +147,7 @@ bool property_type::operator==(const base_type& rhs) const
 }
 
 size_t property_type::make_operand_to_value_assignment_kernel(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 const char *dst_arrmeta, const char *src_arrmeta,
                 kernel_request_t kernreq, const eval::eval_context *ectx) const
 {
@@ -156,13 +156,13 @@ size_t property_type::make_operand_to_value_assignment_kernel(
             const ndt::type& ovdt = m_operand_tp.value_type();
             if (!ovdt.is_builtin()) {
                 return ovdt.extended()->make_elwise_property_getter_kernel(
-                                out, offset_out,
+                                ckb, ckb_offset,
                                 dst_arrmeta,
                                 src_arrmeta, m_property_index,
                                 kernreq, ectx);
             } else {
                 return make_builtin_type_elwise_property_getter_kernel(
-                                out, offset_out,
+                                ckb, ckb_offset,
                                 ovdt.get_type_id(),
                                 dst_arrmeta,
                                 src_arrmeta, m_property_index,
@@ -178,13 +178,13 @@ size_t property_type::make_operand_to_value_assignment_kernel(
         if (m_readable) {
             if (!m_value_tp.is_builtin()) {
                 return m_value_tp.extended()->make_elwise_property_setter_kernel(
-                                out, offset_out,
+                                ckb, ckb_offset,
                                 dst_arrmeta, m_property_index,
                                 src_arrmeta,
                                 kernreq, ectx);
             } else {
                 return make_builtin_type_elwise_property_setter_kernel(
-                                out, offset_out,
+                                ckb, ckb_offset,
                                 m_value_tp.get_type_id(),
                                 dst_arrmeta, m_property_index,
                                 src_arrmeta,
@@ -200,7 +200,7 @@ size_t property_type::make_operand_to_value_assignment_kernel(
 }
 
 size_t property_type::make_value_to_operand_assignment_kernel(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 const char *dst_arrmeta, const char *src_arrmeta,
                 kernel_request_t kernreq, const eval::eval_context *ectx) const
 {
@@ -209,13 +209,13 @@ size_t property_type::make_value_to_operand_assignment_kernel(
             const ndt::type& ovdt = m_operand_tp.value_type();
             if (!ovdt.is_builtin()) {
                 return ovdt.extended()->make_elwise_property_setter_kernel(
-                                out, offset_out,
+                                ckb, ckb_offset,
                                 dst_arrmeta, m_property_index,
                                 src_arrmeta,
                                 kernreq, ectx);
             } else {
                 return make_builtin_type_elwise_property_setter_kernel(
-                                out, offset_out,
+                                ckb, ckb_offset,
                                 ovdt.get_type_id(),
                                 dst_arrmeta, m_property_index,
                                 src_arrmeta,
@@ -231,13 +231,13 @@ size_t property_type::make_value_to_operand_assignment_kernel(
         if (m_writable) {
             if (!m_value_tp.is_builtin()) {
                 return m_value_tp.extended()->make_elwise_property_getter_kernel(
-                                out, offset_out,
+                                ckb, ckb_offset,
                                 dst_arrmeta,
                                 src_arrmeta, m_property_index,
                                 kernreq, ectx);
             } else {
                 return make_builtin_type_elwise_property_getter_kernel(
-                                out, offset_out,
+                                ckb, ckb_offset,
                                 m_value_tp.get_type_id(),
                                 dst_arrmeta,
                                 src_arrmeta, m_property_index,

--- a/src/dynd/types/strided_dim_type.cpp
+++ b/src/dynd/types/strided_dim_type.cpp
@@ -530,59 +530,61 @@ void strided_dim_type::data_destruct_strided(const char *arrmeta, char *data,
 }
 
 size_t strided_dim_type::make_assignment_kernel(
-    ckernel_builder *out_ckb, size_t ckb_offset, const ndt::type &dst_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_tp,
     const char *dst_arrmeta, const ndt::type &src_tp, const char *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx) const
 {
-    if (this == dst_tp.extended()) {
-        const strided_dim_type_arrmeta *dst_md =
-                        reinterpret_cast<const strided_dim_type_arrmeta *>(dst_arrmeta);
-        kernels::strided_assign_ck *self =
-            kernels::strided_assign_ck::create(out_ckb, ckb_offset, kernreq);
-        intptr_t ckb_end = ckb_offset + sizeof(kernels::strided_assign_ck);
-        self->m_size = dst_md->size;
-        self->m_dst_stride = dst_md->stride;
+  if (this == dst_tp.extended()) {
+    const strided_dim_type_arrmeta *dst_md =
+        reinterpret_cast<const strided_dim_type_arrmeta *>(dst_arrmeta);
+    intptr_t src_size, src_stride;
+    ndt::type src_el_tp;
+    const char *src_el_arrmeta;
 
-        intptr_t src_size;
-        ndt::type src_el_tp;
-        const char *src_el_arrmeta;
-
-        if (src_tp.get_ndim() < dst_tp.get_ndim()) {
-            // If the src has fewer dimensions, broadcast it across this one
-            self->m_src_stride = 0;
-            return ::make_assignment_kernel(
-                out_ckb, ckb_end, m_element_tp,
-                dst_arrmeta + sizeof(strided_dim_type_arrmeta), src_tp,
-                src_arrmeta, kernel_request_strided, ectx);
-        } else if (src_tp.get_as_strided_dim(src_arrmeta, src_size,
-                                             self->m_src_stride, src_el_tp,
-                                             src_el_arrmeta)) {
-            // Check for a broadcasting error
-            if (src_size != 1 && dst_md->size != src_size) {
-                throw broadcast_error(dst_tp, dst_arrmeta, src_tp, src_arrmeta);
-            }
-
-            return ::make_assignment_kernel(
-                out_ckb, ckb_end, m_element_tp,
-                dst_arrmeta + sizeof(strided_dim_type_arrmeta), src_el_tp,
-                src_el_arrmeta, kernel_request_strided, ectx);
-        } else if (!src_tp.is_builtin()) {
-            // Give the src type a chance to make a kernel
-            return src_tp.extended()->make_assignment_kernel(
-                out_ckb, ckb_offset, dst_tp, dst_arrmeta, src_tp, src_arrmeta,
-                kernreq, ectx);
-        } else {
-            stringstream ss;
-            ss << "Cannot assign from " << src_tp << " to " << dst_tp;
-            throw dynd::type_error(ss.str());
-        }
-    } else if (dst_tp.get_ndim() < src_tp.get_ndim()) {
+    if (src_tp.get_ndim() < dst_tp.get_ndim()) {
+      kernels::strided_assign_ck *self =
+          kernels::strided_assign_ck::create(ckb, kernreq, ckb_offset);
+      self->m_size = dst_md->size;
+      self->m_dst_stride = dst_md->stride;
+      // If the src has fewer dimensions, broadcast it across this one
+      self->m_src_stride = 0;
+      return ::make_assignment_kernel(
+          ckb, ckb_offset, m_element_tp,
+          dst_arrmeta + sizeof(strided_dim_type_arrmeta), src_tp, src_arrmeta,
+          kernel_request_strided, ectx);
+    } else if (src_tp.get_as_strided_dim(src_arrmeta, src_size, src_stride,
+                                         src_el_tp, src_el_arrmeta)) {
+      kernels::strided_assign_ck *self =
+          kernels::strided_assign_ck::create(ckb, kernreq, ckb_offset);
+      self->m_size = dst_md->size;
+      self->m_dst_stride = dst_md->stride;
+      self->m_src_stride = src_stride;
+      // Check for a broadcasting error
+      if (src_size != 1 && dst_md->size != src_size) {
         throw broadcast_error(dst_tp, dst_arrmeta, src_tp, src_arrmeta);
+      }
+
+      return ::make_assignment_kernel(
+          ckb, ckb_offset, m_element_tp,
+          dst_arrmeta + sizeof(strided_dim_type_arrmeta), src_el_tp,
+          src_el_arrmeta, kernel_request_strided, ectx);
+    } else if (!src_tp.is_builtin()) {
+      // Give the src type a chance to make a kernel
+      return src_tp.extended()->make_assignment_kernel(
+          ckb, ckb_offset, dst_tp, dst_arrmeta, src_tp, src_arrmeta,
+          kernreq, ectx);
     } else {
-        stringstream ss;
-        ss << "Cannot assign from " << src_tp << " to " << dst_tp;
-        throw dynd::type_error(ss.str());
+      stringstream ss;
+      ss << "Cannot assign from " << src_tp << " to " << dst_tp;
+      throw dynd::type_error(ss.str());
     }
+  } else if (dst_tp.get_ndim() < src_tp.get_ndim()) {
+    throw broadcast_error(dst_tp, dst_arrmeta, src_tp, src_arrmeta);
+  } else {
+    stringstream ss;
+    ss << "Cannot assign from " << src_tp << " to " << dst_tp;
+    throw dynd::type_error(ss.str());
+  }
 }
 
 void strided_dim_type::foreach_leading(const char *arrmeta, char *data,

--- a/src/dynd/types/struct_type.cpp
+++ b/src/dynd/types/struct_type.cpp
@@ -109,26 +109,26 @@ bool struct_type::is_lossless_assignment(const ndt::type& dst_tp, const ndt::typ
 }
 
 size_t struct_type::make_assignment_kernel(
-    ckernel_builder *out_ckb, size_t ckb_offset, const ndt::type &dst_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_tp,
     const char *dst_arrmeta, const ndt::type &src_tp, const char *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx) const
 {
     if (this == dst_tp.extended()) {
         if (this == src_tp.extended()) {
             return make_struct_identical_assignment_kernel(
-                out_ckb, ckb_offset, dst_tp, dst_arrmeta, src_arrmeta, kernreq,
+                ckb, ckb_offset, dst_tp, dst_arrmeta, src_arrmeta, kernreq,
                 ectx);
         } else if (src_tp.get_kind() == struct_kind) {
-            return make_struct_assignment_kernel(out_ckb, ckb_offset, dst_tp,
+            return make_struct_assignment_kernel(ckb, ckb_offset, dst_tp,
                                                  dst_arrmeta, src_tp,
                                                  src_arrmeta, kernreq, ectx);
         } else if (src_tp.is_builtin()) {
             return make_broadcast_to_struct_assignment_kernel(
-                out_ckb, ckb_offset, dst_tp, dst_arrmeta, src_tp, src_arrmeta,
+                ckb, ckb_offset, dst_tp, dst_arrmeta, src_tp, src_arrmeta,
                 kernreq, ectx);
         } else {
             return src_tp.extended()->make_assignment_kernel(
-                out_ckb, ckb_offset, dst_tp, dst_arrmeta, src_tp, src_arrmeta,
+                ckb, ckb_offset, dst_tp, dst_arrmeta, src_tp, src_arrmeta,
                 kernreq, ectx);
         }
     }
@@ -139,19 +139,19 @@ size_t struct_type::make_assignment_kernel(
 }
 
 size_t struct_type::make_comparison_kernel(
-    ckernel_builder *out, size_t offset_out, const ndt::type &src0_dt,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &src0_dt,
     const char *src0_arrmeta, const ndt::type &src1_dt,
     const char *src1_arrmeta, comparison_type_t comptype,
     const eval::eval_context *ectx) const
 {
     if (this == src0_dt.extended()) {
         if (*this == *src1_dt.extended()) {
-            return make_struct_comparison_kernel(out, offset_out, src0_dt,
+            return make_struct_comparison_kernel(ckb, ckb_offset, src0_dt,
                                                  src0_arrmeta, src1_arrmeta,
                                                  comptype, ectx);
         } else if (src1_dt.get_kind() == struct_kind) {
             return make_general_struct_comparison_kernel(
-                out, offset_out, src0_dt, src0_arrmeta, src1_dt, src1_arrmeta,
+                ckb, ckb_offset, src0_dt, src0_arrmeta, src1_dt, src1_arrmeta,
                 comptype, ectx);
         }
     }

--- a/src/dynd/types/tuple_type.cpp
+++ b/src/dynd/types/tuple_type.cpp
@@ -82,7 +82,7 @@ bool tuple_type::is_lossless_assignment(const ndt::type& dst_tp, const ndt::type
 }
 
 size_t tuple_type::make_assignment_kernel(
-    ckernel_builder *DYND_UNUSED(out_ckb), size_t DYND_UNUSED(ckb_offset),
+    ckernel_builder *DYND_UNUSED(ckb), intptr_t DYND_UNUSED(ckb_offset),
     const ndt::type &dst_tp, const char *DYND_UNUSED(dst_arrmeta),
     const ndt::type &src_tp, const char *DYND_UNUSED(src_arrmeta),
     kernel_request_t DYND_UNUSED(kernreq),
@@ -91,22 +91,22 @@ size_t tuple_type::make_assignment_kernel(
     /*
     if (this == dst_tp.extended()) {
         if (this == src_tp.extended()) {
-            return make_tuple_identical_assignment_kernel(out_ckb, ckb_offset,
+            return make_tuple_identical_assignment_kernel(ckb, ckb_offset,
                             dst_tp,
                             dst_arrmeta, src_arrmeta,
                             kernreq, errmode, ectx);
         } else if (src_tp.get_kind() == struct_kind) {
-            return make_tuple_assignment_kernel(out_ckb, ckb_offset,
+            return make_tuple_assignment_kernel(ckb, ckb_offset,
                             dst_tp, dst_arrmeta,
                             src_tp, src_arrmeta,
                             kernreq, errmode, ectx);
         } else if (src_tp.is_builtin()) {
-            return make_broadcast_to_struct_assignment_kernel(out_ckb, ckb_offset,
+            return make_broadcast_to_struct_assignment_kernel(ckb, ckb_offset,
                             dst_tp, dst_arrmeta,
                             src_tp, src_arrmeta,
                             kernreq, errmode, ectx);
         } else {
-            return src_tp.extended()->make_assignment_kernel(out_ckb, ckb_offset,
+            return src_tp.extended()->make_assignment_kernel(ckb, ckb_offset,
                             dst_tp, dst_arrmeta,
                             src_tp, src_arrmeta,
                             kernreq, errmode, ectx);
@@ -120,7 +120,7 @@ size_t tuple_type::make_assignment_kernel(
 }
 
 size_t tuple_type::make_comparison_kernel(
-                ckernel_builder *DYND_UNUSED(out), size_t DYND_UNUSED(offset_out),
+                ckernel_builder *DYND_UNUSED(ckb), intptr_t DYND_UNUSED(ckb_offset),
                 const ndt::type& src0_tp, const char *DYND_UNUSED(src0_arrmeta),
                 const ndt::type& src1_tp, const char *DYND_UNUSED(src1_arrmeta),
                 comparison_type_t comptype,
@@ -129,11 +129,11 @@ size_t tuple_type::make_comparison_kernel(
     /*
     if (this == src0_dt.extended()) {
         if (*this == *src1_dt.extended()) {
-            return make_tuple_comparison_kernel(out, offset_out,
+            return make_tuple_comparison_kernel(ckb, ckb_offset,
                             src0_dt, src0_arrmeta, src1_arrmeta,
                             comptype, ectx);
         } else if (src1_dt.get_kind() == struct_kind) {
-            return make_general_tuple_comparison_kernel(out, offset_out,
+            return make_general_tuple_comparison_kernel(ckb, ckb_offset,
                             src0_dt, src0_arrmeta,
                             src1_dt, src1_arrmeta,
                             comptype, ectx);

--- a/src/dynd/types/unary_expr_type.cpp
+++ b/src/dynd/types/unary_expr_type.cpp
@@ -103,14 +103,14 @@ bool unary_expr_type::operator==(const base_type& rhs) const
 }
 
 size_t unary_expr_type::make_operand_to_value_assignment_kernel(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 const char *dst_arrmeta, const char *src_arrmeta,
                 kernel_request_t kernreq, const eval::eval_context *ectx) const
 {
     // As a special case, when src_count == 1, the kernel generated
     // is a expr_single_t/expr_strided_t instead of
     // expr_single_t/expr_strided_t
-    return m_kgen->make_expr_kernel(out, offset_out,
+    return m_kgen->make_expr_kernel(ckb, ckb_offset,
                     m_value_type, dst_arrmeta,
                     1, &m_operand_type.value_type(),
                     &src_arrmeta,
@@ -118,7 +118,7 @@ size_t unary_expr_type::make_operand_to_value_assignment_kernel(
 }
 
 size_t unary_expr_type::make_value_to_operand_assignment_kernel(
-                ckernel_builder *DYND_UNUSED(out), size_t DYND_UNUSED(offset_out),
+                ckernel_builder *DYND_UNUSED(ckb), intptr_t DYND_UNUSED(ckb_offset),
                 const char *DYND_UNUSED(dst_arrmeta), const char *DYND_UNUSED(src_arrmeta),
                 kernel_request_t DYND_UNUSED(kernreq), const eval::eval_context *DYND_UNUSED(ectx)) const
 {

--- a/src/dynd/types/var_dim_type.cpp
+++ b/src/dynd/types/var_dim_type.cpp
@@ -576,7 +576,7 @@ size_t var_dim_type::iterdata_destruct(iterdata_common *DYND_UNUSED(iterdata), i
 }
 
 size_t var_dim_type::make_assignment_kernel(
-    ckernel_builder *out, size_t offset_out, const ndt::type &dst_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_tp,
     const char *dst_arrmeta, const ndt::type &src_tp, const char *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx) const
 {
@@ -588,11 +588,11 @@ size_t var_dim_type::make_assignment_kernel(
         if (src_tp.get_ndim() < dst_tp.get_ndim()) {
             // If the src has fewer dimensions, broadcast it across this one
             return make_broadcast_to_var_dim_assignment_kernel(
-                out, offset_out, dst_tp, dst_arrmeta, src_tp, src_arrmeta,
+                ckb, ckb_offset, dst_tp, dst_arrmeta, src_tp, src_arrmeta,
                 kernreq, ectx);
         } else if (src_tp.get_type_id() == var_dim_type_id) {
             // var_dim to var_dim
-            return make_var_dim_assignment_kernel(out, offset_out, dst_tp,
+            return make_var_dim_assignment_kernel(ckb, ckb_offset, dst_tp,
                                                   dst_arrmeta, src_tp,
                                                   src_arrmeta, kernreq, ectx);
         } else if (src_tp.get_as_strided_dim(src_arrmeta, src_size,
@@ -600,12 +600,12 @@ size_t var_dim_type::make_assignment_kernel(
                                              src_el_arrmeta)) {
             // strided_dim to var_dim
             return make_strided_to_var_dim_assignment_kernel(
-                out, offset_out, dst_tp, dst_arrmeta, src_size, src_stride,
+                ckb, ckb_offset, dst_tp, dst_arrmeta, src_size, src_stride,
                 src_el_tp, src_el_arrmeta, kernreq, ectx);
         } else if (!src_tp.is_builtin()) {
             // Give the src type a chance to make a kernel
             return src_tp.extended()->make_assignment_kernel(
-                out, offset_out, dst_tp, dst_arrmeta, src_tp, src_arrmeta,
+                ckb, ckb_offset, dst_tp, dst_arrmeta, src_tp, src_arrmeta,
                 kernreq, ectx);
         } else {
             stringstream ss;
@@ -619,7 +619,7 @@ size_t var_dim_type::make_assignment_kernel(
                         dst_tp.get_type_id() == cfixed_dim_type_id) {
             // var_dim to strided_dim
             return make_var_to_strided_dim_assignment_kernel(
-                out, offset_out, dst_tp, dst_arrmeta, src_tp, src_arrmeta,
+                ckb, ckb_offset, dst_tp, dst_arrmeta, src_tp, src_arrmeta,
                 kernreq, ectx);
         } else {
             stringstream ss;

--- a/src/dynd/types/view_type.cpp
+++ b/src/dynd/types/view_type.cpp
@@ -138,22 +138,22 @@ ndt::type view_type::with_replaced_storage_type(const ndt::type& replacement_typ
 }
 
 size_t view_type::make_operand_to_value_assignment_kernel(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 const char *DYND_UNUSED(dst_arrmeta), const char *DYND_UNUSED(src_arrmeta),
                 kernel_request_t kernreq, const eval::eval_context *DYND_UNUSED(ectx)) const
 {
-    return ::make_pod_typed_data_assignment_kernel(out, offset_out,
+    return ::make_pod_typed_data_assignment_kernel(ckb, ckb_offset,
                     m_value_type.get_data_size(),
                     std::min(m_value_type.get_data_alignment(), m_operand_type.get_data_alignment()),
                     kernreq);
 }
 
 size_t view_type::make_value_to_operand_assignment_kernel(
-                ckernel_builder *out, size_t offset_out,
+                ckernel_builder *ckb, intptr_t ckb_offset,
                 const char *DYND_UNUSED(dst_arrmeta), const char *DYND_UNUSED(src_arrmeta),
                 kernel_request_t kernreq, const eval::eval_context *DYND_UNUSED(ectx)) const
 {
-    return ::make_pod_typed_data_assignment_kernel(out, offset_out,
+    return ::make_pod_typed_data_assignment_kernel(ckb, ckb_offset,
                     m_value_type.get_data_size(),
                     std::min(m_value_type.get_data_alignment(), m_operand_type.get_data_alignment()),
                     kernreq);

--- a/src/dynd/types/void_pointer_type.cpp
+++ b/src/dynd/types/void_pointer_type.cpp
@@ -35,18 +35,18 @@ bool void_pointer_type::operator==(const base_type& rhs) const
 }
 
 size_t void_pointer_type::make_assignment_kernel(
-    ckernel_builder *out, size_t offset_out, const ndt::type &dst_tp,
+    ckernel_builder *ckb, intptr_t ckb_offset, const ndt::type &dst_tp,
     const char *dst_arrmeta, const ndt::type &src_tp, const char *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx) const
 {
     if (this == dst_tp.extended()) {
         if (src_tp.get_type_id() == void_pointer_type_id) {
-            return ::make_pod_typed_data_assignment_kernel(out, offset_out,
+            return ::make_pod_typed_data_assignment_kernel(ckb, ckb_offset,
                     get_data_size(), get_data_alignment(),
                     kernreq);
         } else if (!src_tp.is_builtin()) {
             src_tp.extended()->make_assignment_kernel(
-                out, offset_out, dst_tp, dst_arrmeta, src_tp, src_arrmeta,
+                ckb, ckb_offset, dst_tp, dst_arrmeta, src_tp, src_arrmeta,
                 kernreq, ectx);
         }
     }

--- a/src/dynd/view.cpp
+++ b/src/dynd/view.cpp
@@ -59,7 +59,7 @@ static bool try_view(const ndt::type &tp, const char *arrmeta,
         case fixed_dim_type_id: { // strided as fixed
             const fixed_dim_type *view_fdt = view_tp.tcast<fixed_dim_type>();
             // The size must match exactly in this case
-            if (md->size != (intptr_t)view_fdt->get_fixed_dim_size()) {
+            if (md->size != view_fdt->get_fixed_dim_size()) {
                 return false;
             }
             fixed_dim_type_arrmeta *view_md =
@@ -79,7 +79,7 @@ static bool try_view(const ndt::type &tp, const char *arrmeta,
             const cfixed_dim_type *view_fdt =
                 view_tp.tcast<cfixed_dim_type>();
             // The size and stride must match exactly in this case
-            if (md->size != (intptr_t)view_fdt->get_fixed_dim_size() ||
+            if (md->size != view_fdt->get_fixed_dim_size() ||
                     md->stride != view_fdt->get_fixed_stride()) {
                 return false;
             }

--- a/tests/types/test_cfixed_dim_type.cpp
+++ b/tests/types/test_cfixed_dim_type.cpp
@@ -38,7 +38,7 @@ TEST(CFixedDimType, Create) {
     EXPECT_EQ(ndt::make_type<int32_t>(), d.at(2));
     fad = d.tcast<cfixed_dim_type>();
     EXPECT_EQ(4, fad->get_fixed_stride());
-    EXPECT_EQ(3u, fad->get_fixed_dim_size());
+    EXPECT_EQ(3, fad->get_fixed_dim_size());
     // Roundtripping through a string
     EXPECT_EQ(d, ndt::type(d.str()));
 
@@ -50,7 +50,7 @@ TEST(CFixedDimType, Create) {
     EXPECT_FALSE(d.is_expression());
     fad = d.tcast<cfixed_dim_type>();
     EXPECT_EQ(0, fad->get_fixed_stride());
-    EXPECT_EQ(1u, fad->get_fixed_dim_size());
+    EXPECT_EQ(1, fad->get_fixed_dim_size());
     // Roundtripping through a string
     EXPECT_EQ(d, ndt::type(d.str()));
 
@@ -63,7 +63,7 @@ TEST(CFixedDimType, Create) {
     EXPECT_FALSE(d.is_expression());
     fad = d.tcast<cfixed_dim_type>();
     EXPECT_EQ(8, fad->get_fixed_stride());
-    EXPECT_EQ(3u, fad->get_fixed_dim_size());
+    EXPECT_EQ(3, fad->get_fixed_dim_size());
     // Roundtripping through a string
     EXPECT_EQ(d, ndt::type(d.str()));
 }
@@ -76,11 +76,11 @@ TEST(CFixedDimType, CreateCOrder) {
     EXPECT_EQ(ndt::make_cfixed_dim(1, shape+2, ndt::make_type<int16_t>(), NULL), d.at(0,0));
     EXPECT_EQ(ndt::make_type<int16_t>(), d.at(0,0,0));
     // Check that the shape is right and the strides are in F-order
-    EXPECT_EQ(2u, d.tcast<cfixed_dim_type>()->get_fixed_dim_size());
+    EXPECT_EQ(2, d.tcast<cfixed_dim_type>()->get_fixed_dim_size());
     EXPECT_EQ(24, d.tcast<cfixed_dim_type>()->get_fixed_stride());
-    EXPECT_EQ(3u, static_cast<const cfixed_dim_type *>(d.at(0).extended())->get_fixed_dim_size());
+    EXPECT_EQ(3, static_cast<const cfixed_dim_type *>(d.at(0).extended())->get_fixed_dim_size());
     EXPECT_EQ(8, static_cast<const cfixed_dim_type *>(d.at(0).extended())->get_fixed_stride());
-    EXPECT_EQ(4u, static_cast<const cfixed_dim_type *>(d.at(0,0).extended())->get_fixed_dim_size());
+    EXPECT_EQ(4, static_cast<const cfixed_dim_type *>(d.at(0,0).extended())->get_fixed_dim_size());
     EXPECT_EQ(2, static_cast<const cfixed_dim_type *>(d.at(0,0).extended())->get_fixed_stride());
 }
 
@@ -94,11 +94,11 @@ TEST(CFixedDimType, CreateFOrder) {
     EXPECT_EQ(cfixed_dim_type_id, d.at(0,0).get_type_id());
     EXPECT_EQ(int16_type_id, d.at(0,0,0).get_type_id());
     // Check that the shape is right and the strides are in F-order
-    EXPECT_EQ(2u, d.tcast<cfixed_dim_type>()->get_fixed_dim_size());
+    EXPECT_EQ(2, d.tcast<cfixed_dim_type>()->get_fixed_dim_size());
     EXPECT_EQ(2, d.tcast<cfixed_dim_type>()->get_fixed_stride());
-    EXPECT_EQ(3u, static_cast<const cfixed_dim_type *>(d.at(0).extended())->get_fixed_dim_size());
+    EXPECT_EQ(3, static_cast<const cfixed_dim_type *>(d.at(0).extended())->get_fixed_dim_size());
     EXPECT_EQ(4, static_cast<const cfixed_dim_type *>(d.at(0).extended())->get_fixed_stride());
-    EXPECT_EQ(4u, static_cast<const cfixed_dim_type *>(d.at(0,0).extended())->get_fixed_dim_size());
+    EXPECT_EQ(4, static_cast<const cfixed_dim_type *>(d.at(0,0).extended())->get_fixed_dim_size());
     EXPECT_EQ(12, static_cast<const cfixed_dim_type *>(d.at(0,0).extended())->get_fixed_stride());
 }
 

--- a/tests/types/test_fixed_dim_type.cpp
+++ b/tests/types/test_fixed_dim_type.cpp
@@ -37,7 +37,7 @@ TEST(FixedDimType, Create) {
     EXPECT_EQ(ndt::make_type<int32_t>(), d.at(1));
     EXPECT_EQ(ndt::make_type<int32_t>(), d.at(2));
     fad = d.tcast<fixed_dim_type>();
-    EXPECT_EQ(3u, fad->get_fixed_dim_size());
+    EXPECT_EQ(3, fad->get_fixed_dim_size());
     // Roundtripping through a string
     EXPECT_EQ(d, ndt::type(d.str()));
 
@@ -48,7 +48,7 @@ TEST(FixedDimType, Create) {
     EXPECT_EQ(0u, d.get_data_size());
     EXPECT_FALSE(d.is_expression());
     fad = d.tcast<fixed_dim_type>();
-    EXPECT_EQ(1u, fad->get_fixed_dim_size());
+    EXPECT_EQ(1, fad->get_fixed_dim_size());
     // Roundtripping through a string
     EXPECT_EQ(d, ndt::type(d.str()));
 }


### PR DESCRIPTION
This changes the usual pattern to be repeatedly updating
ckb_offset. It moves this update to a single function where
64-bit alignment can be performed.
