### PR TITLE
Fix for CMake handling of preprocessor definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -533,9 +533,6 @@ if (DYND_CUDA)
         src/dynd/kernels/assignment_kernels.cu
         )
 
-    # Add a preprocessor definition to indicate we're building with CUDA
-    add_definitions(-DDYND_CUDA)
-
     # Disable warnings about "controlling expression is constant"
     set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-Xcudafe;--diag_suppress=boolean_controlling_expr_is_constant)
 
@@ -546,14 +543,7 @@ if (DYND_FFTW)
     find_path(FFTW_PATH fftw3.h)
     include_directories(${FFTW_PATH})
     set(DYND_LINK_LIBS ${DYND_LINK_LIBS} fftw3 fftw3f)
-
-    # Add a preprocessor definition to indicate we're building with FFTW
-    add_definitions(-DDYND_FFTW)
 endif()
-
-# Add a preprocessor definition for the maximum number
-# of arguments that elwise will support
-add_definitions(-DDYND_ELWISE_MAX=${DYND_ELWISE_MAX})
 
 if ((NOT DYND_SHARED_LIB) AND (DYND_INSTALL_LIB))
     # If we're making an installable static library,
@@ -606,6 +596,9 @@ else()
         PREFIX "${CMAKE_STATIC_LIBRARY_PREFIX}"
         )
 endif()
+
+# Add preprocessor definitions from CMake
+configure_file("include/dynd/cmake_config.hpp.in" "${CMAKE_CURRENT_BINARY_DIR}/include/dynd/cmake_config.hpp")
 
 # Special build targets that generate part of the library
 execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/include/dynd/pp)

--- a/include/dynd/cmake_config.hpp.in
+++ b/include/dynd/cmake_config.hpp.in
@@ -1,0 +1,3 @@
+#cmakedefine DYND_CUDA
+#define DYND_ELWISE_MAX @DYND_ELWISE_MAX@
+#cmakedefine DYND_FFTW

--- a/include/dynd/config.hpp
+++ b/include/dynd/config.hpp
@@ -10,6 +10,8 @@
 #include <stdint.h>
 #include <limits>
 
+#include <dynd/cmake_config.hpp>
+
 /** The number of elements to process at once when doing chunking/buffering */
 #define DYND_BUFFER_CHUNK_SIZE 128
 

--- a/include/dynd/fft.hpp
+++ b/include/dynd/fft.hpp
@@ -6,6 +6,9 @@
 #ifndef _DYND__FFT_HPP_
 #define _DYND__FFT_HPP_
 
+#include <dynd/array.hpp>
+#include <dynd/array_range.hpp>
+
 #ifdef DYND_FFTW
 
 #include <fftw3.h>
@@ -17,9 +20,6 @@ FFTW_EXTERN int fftw_alignment_of(double *p);
 }
 
 #endif // DYND_FFTW
-
-#include <dynd/array.hpp>
-#include <dynd/array_range.hpp>
 
 namespace dynd {
 


### PR DESCRIPTION
There is an issue with how we are handling CMake preprocessor definitions like DYND_FFTW and DYND_ELWISE_MAX. They would work only for the initial compilation, but not when the headers were included afterwards.

This patch fixes that.
