### PR TITLE
Add blockref_alloc param to default_arrmeta_construct

### DIFF
--- a/include/dynd/arrmeta_holder.hpp
+++ b/include/dynd/arrmeta_holder.hpp
@@ -78,11 +78,14 @@ public:
             reinterpret_cast<char *>(m_arrmeta) + sizeof(ndt::type) + offset);
     }
 
-    void arrmeta_default_construct(intptr_t ndim, const intptr_t *shape) {
-        const ndt::type& tp = get_type();
-        if (!tp.is_builtin()) {
-            tp.extended()->arrmeta_default_construct(get(), ndim, shape);
-        }
+    void arrmeta_default_construct(intptr_t ndim, const intptr_t *shape,
+                                   bool blockref_alloc)
+    {
+      const ndt::type &tp = get_type();
+      if (!tp.is_builtin()) {
+        tp.extended()->arrmeta_default_construct(get(), ndim, shape,
+                                                 blockref_alloc);
+      }
     }
 };
 

--- a/include/dynd/buffer_storage.hpp
+++ b/include/dynd/buffer_storage.hpp
@@ -58,7 +58,7 @@ class buffer_storage {
       try
       {
         m_arrmeta = new char[metasize];
-        m_type.extended()->arrmeta_default_construct(m_arrmeta, 0, NULL);
+        m_type.extended()->arrmeta_default_construct(m_arrmeta, 0, NULL, true);
       }
       catch (const std::exception &)
       {

--- a/include/dynd/types/arrfunc_type.hpp
+++ b/include/dynd/types/arrfunc_type.hpp
@@ -27,7 +27,9 @@ public:
 
     bool operator==(const base_type& rhs) const;
 
-    void arrmeta_default_construct(char *arrmeta, intptr_t ndim, const intptr_t* shape) const;
+    void arrmeta_default_construct(char *arrmeta, intptr_t ndim,
+                                   const intptr_t *shape,
+                                   bool blockref_alloc) const;
     void arrmeta_copy_construct(char *dst_arrmeta, const char *src_arrmeta, memory_block_data *embedded_reference) const;
     void arrmeta_reset_buffers(char *arrmeta) const;
     void arrmeta_finalize_buffers(char *arrmeta) const;

--- a/include/dynd/types/base_expr_type.hpp
+++ b/include/dynd/types/base_expr_type.hpp
@@ -62,7 +62,8 @@ public:
 
     // Expression types use the values from their operand type.
     void arrmeta_default_construct(char *arrmeta, intptr_t ndim,
-                                   const intptr_t *shape) const;
+                                   const intptr_t *shape,
+                                   bool blockref_alloc) const;
     void arrmeta_copy_construct(char *dst_arrmeta, const char *src_arrmeta,
                                 memory_block_data *embedded_reference) const;
     void arrmeta_destruct(char *arrmeta) const;

--- a/include/dynd/types/base_memory_type.hpp
+++ b/include/dynd/types/base_memory_type.hpp
@@ -71,7 +71,9 @@ public:
 
     virtual ndt::type with_replaced_storage_type(const ndt::type& storage_tp) const = 0;
 
-    virtual void arrmeta_default_construct(char *arrmeta, intptr_t ndim, const intptr_t* shape) const;
+    virtual void arrmeta_default_construct(char *arrmeta, intptr_t ndim,
+                                           const intptr_t *shape,
+                                           bool blockref_alloc) const;
     virtual void arrmeta_copy_construct(char *dst_arrmeta, const char *src_arrmeta, memory_block_data *embedded_reference) const;
     virtual void arrmeta_destruct(char *arrmeta) const;
 

--- a/include/dynd/types/base_tuple_type.hpp
+++ b/include/dynd/types/base_tuple_type.hpp
@@ -85,7 +85,8 @@ public:
                     memory_block_data **inout_dataref) const;
 
     void arrmeta_default_construct(char *arrmeta, intptr_t ndim,
-                                    const intptr_t *shape) const;
+                                   const intptr_t *shape,
+                                   bool blockref_alloc) const;
     void arrmeta_copy_construct(char *dst_arrmeta, const char *src_arrmeta,
                                  memory_block_data *embedded_reference) const;
     void arrmeta_reset_buffers(char *arrmeta) const;

--- a/include/dynd/types/base_type.hpp
+++ b/include/dynd/types/base_type.hpp
@@ -427,11 +427,23 @@ public:
         return m_members.arrmeta_size;
     }
     /**
-     * Constructs the nd::array arrmeta for this type, prepared for writing.
-     * The element size of the result must match that from get_default_data_size().
+     * Constructs the nd::array arrmeta for this type using default settings.
+     * The element size of the result must match that from
+     * get_default_data_size().
+     *
+     * \param arrmeta  The arrmeta to default construct.
+     * \param ndim  Number of dimensions in the provided shape.
+     * \param shape  The array shape to use when shape is not from the type.
+     * \param blockref_alloc  If ``true``, blockref types should allocate
+     *                        writable memory blocks, and if ``false``, they
+     *                        should set their blockrefs to NULL. The latter
+     *                        indicates the blockref memory is owned by
+     *                        the parent nd::array, and is useful for viewing
+     *                        external memory with compatible layout.
      */
     virtual void arrmeta_default_construct(char *arrmeta, intptr_t ndim,
-                                           const intptr_t *shape) const;
+                                           const intptr_t *shape,
+                                           bool blockref_alloc) const;
     /**
      * Constructs the nd::array arrmeta for this type, copying everything exactly from
      * input arrmeta for the same type.

--- a/include/dynd/types/busdate_type.hpp
+++ b/include/dynd/types/busdate_type.hpp
@@ -78,7 +78,11 @@ public:
 
     bool operator==(const base_type& rhs) const;
 
-    void arrmeta_default_construct(char *DYND_UNUSED(arrmeta), intptr_t DYND_UNUSED(ndim), const intptr_t* DYND_UNUSED(shape)) const {
+    void arrmeta_default_construct(char *DYND_UNUSED(arrmeta),
+                                   intptr_t DYND_UNUSED(ndim),
+                                   const intptr_t *DYND_UNUSED(shape),
+                                   bool DYND_UNUSED(blockref_alloc)) const
+    {
     }
     void arrmeta_copy_construct(char *DYND_UNUSED(dst_arrmeta), const char *DYND_UNUSED(src_arrmeta), memory_block_data *DYND_UNUSED(embedded_reference)) const {
     }

--- a/include/dynd/types/bytes_type.hpp
+++ b/include/dynd/types/bytes_type.hpp
@@ -62,7 +62,8 @@ public:
     bool operator==(const base_type& rhs) const;
 
     void arrmeta_default_construct(char *arrmeta, intptr_t ndim,
-                                   const intptr_t *shape) const;
+                                   const intptr_t *shape,
+                                   bool blockref_alloc) const;
     void arrmeta_copy_construct(char *dst_arrmeta, const char *src_arrmeta,
                                 memory_block_data *embedded_reference) const;
     void arrmeta_reset_buffers(char *arrmeta) const;

--- a/include/dynd/types/categorical_type.hpp
+++ b/include/dynd/types/categorical_type.hpp
@@ -94,7 +94,8 @@ public:
     bool operator==(const base_type& rhs) const;
 
     void arrmeta_default_construct(char *arrmeta, intptr_t ndim,
-                                   const intptr_t *shape) const;
+                                   const intptr_t *shape,
+                                   bool blockref_alloc) const;
     void arrmeta_copy_construct(char *dst_arrmeta, const char *src_arrmeta,
                                 memory_block_data *embedded_reference) const;
     void arrmeta_destruct(char *arrmeta) const;

--- a/include/dynd/types/cfixed_dim_type.hpp
+++ b/include/dynd/types/cfixed_dim_type.hpp
@@ -78,7 +78,8 @@ public:
     bool operator==(const base_type& rhs) const;
 
     void arrmeta_default_construct(char *arrmeta, intptr_t ndim,
-                                   const intptr_t *shape) const;
+                                   const intptr_t *shape,
+                                   bool blockref_alloc) const;
     void arrmeta_copy_construct(char *dst_arrmeta, const char *src_arrmeta,
                                 memory_block_data *embedded_reference) const;
     void arrmeta_reset_buffers(char *arrmeta) const;

--- a/include/dynd/types/char_type.hpp
+++ b/include/dynd/types/char_type.hpp
@@ -51,7 +51,11 @@ public:
 
     bool operator==(const base_type& rhs) const;
 
-    void arrmeta_default_construct(char *DYND_UNUSED(arrmeta), intptr_t DYND_UNUSED(ndim), const intptr_t* DYND_UNUSED(shape)) const {
+    void arrmeta_default_construct(char *DYND_UNUSED(arrmeta),
+                                   intptr_t DYND_UNUSED(ndim),
+                                   const intptr_t *DYND_UNUSED(shape),
+                                   bool DYND_UNUSED(blockref_alloc)) const
+    {
     }
     void arrmeta_copy_construct(char *DYND_UNUSED(dst_arrmeta), const char *DYND_UNUSED(src_arrmeta), memory_block_data *DYND_UNUSED(embedded_reference)) const {
     }

--- a/include/dynd/types/date_type.hpp
+++ b/include/dynd/types/date_type.hpp
@@ -35,8 +35,9 @@ public:
     bool operator==(const base_type& rhs) const;
 
     void arrmeta_default_construct(char *DYND_UNUSED(arrmeta),
-                                    intptr_t DYND_UNUSED(ndim),
-                                    const intptr_t *DYND_UNUSED(shape)) const
+                                   intptr_t DYND_UNUSED(ndim),
+                                   const intptr_t *DYND_UNUSED(shape),
+                                   bool DYND_UNUSED(blockref_alloc)) const
     {
     }
     void arrmeta_copy_construct(

--- a/include/dynd/types/datetime_type.hpp
+++ b/include/dynd/types/datetime_type.hpp
@@ -57,7 +57,11 @@ public:
 
     bool operator==(const base_type& rhs) const;
 
-    void arrmeta_default_construct(char *DYND_UNUSED(arrmeta), intptr_t DYND_UNUSED(ndim), const intptr_t* DYND_UNUSED(shape)) const {
+    void arrmeta_default_construct(char *DYND_UNUSED(arrmeta),
+                                   intptr_t DYND_UNUSED(ndim),
+                                   const intptr_t *DYND_UNUSED(shape),
+                                   bool DYND_UNUSED(blockref_alloc)) const
+    {
     }
     void arrmeta_copy_construct(char *DYND_UNUSED(dst_arrmeta), const char *DYND_UNUSED(src_arrmeta), memory_block_data *DYND_UNUSED(embedded_reference)) const {
     }

--- a/include/dynd/types/dim_fragment_type.hpp
+++ b/include/dynd/types/dim_fragment_type.hpp
@@ -78,7 +78,8 @@ public:
     bool operator==(const base_type& rhs) const;
 
     void arrmeta_default_construct(char *arrmeta, intptr_t ndim,
-                                    const intptr_t *shape) const;
+                                   const intptr_t *shape,
+                                   bool blockref_alloc) const;
     void arrmeta_copy_construct(char *dst_arrmeta, const char *src_arrmeta,
                                  memory_block_data *embedded_reference) const;
     size_t

--- a/include/dynd/types/ellipsis_dim_type.hpp
+++ b/include/dynd/types/ellipsis_dim_type.hpp
@@ -52,7 +52,8 @@ public:
     bool operator==(const base_type& rhs) const;
 
     void arrmeta_default_construct(char *arrmeta, intptr_t ndim,
-                                    const intptr_t *shape) const;
+                                   const intptr_t *shape,
+                                   bool blockref_alloc) const;
     void arrmeta_copy_construct(char *dst_arrmeta, const char *src_arrmeta,
                                  memory_block_data *embedded_reference) const;
     size_t

--- a/include/dynd/types/fixed_dim_type.hpp
+++ b/include/dynd/types/fixed_dim_type.hpp
@@ -69,7 +69,8 @@ public:
     bool operator==(const base_type& rhs) const;
 
     void arrmeta_default_construct(char *arrmeta, intptr_t ndim,
-                                   const intptr_t *shape) const;
+                                   const intptr_t *shape,
+                                   bool blockref_alloc) const;
     void arrmeta_copy_construct(char *dst_arrmeta, const char *src_arrmeta,
                                 memory_block_data *embedded_reference) const;
     void arrmeta_reset_buffers(char *arrmeta) const;

--- a/include/dynd/types/fixedbytes_type.hpp
+++ b/include/dynd/types/fixedbytes_type.hpp
@@ -29,7 +29,11 @@ public:
 
     bool operator==(const base_type& rhs) const;
 
-    void arrmeta_default_construct(char *DYND_UNUSED(arrmeta), intptr_t DYND_UNUSED(ndim), const intptr_t* DYND_UNUSED(shape)) const {
+    void arrmeta_default_construct(char *DYND_UNUSED(arrmeta),
+                                   intptr_t DYND_UNUSED(ndim),
+                                   const intptr_t *DYND_UNUSED(shape),
+                                   bool DYND_UNUSED(blockref_alloc)) const
+    {
     }
     void arrmeta_copy_construct(char *DYND_UNUSED(dst_arrmeta), const char *DYND_UNUSED(src_arrmeta), memory_block_data *DYND_UNUSED(embedded_reference)) const {
     }

--- a/include/dynd/types/fixedstring_type.hpp
+++ b/include/dynd/types/fixedstring_type.hpp
@@ -45,7 +45,11 @@ public:
 
     bool operator==(const base_type& rhs) const;
 
-    void arrmeta_default_construct(char *DYND_UNUSED(arrmeta), intptr_t DYND_UNUSED(ndim), const intptr_t* DYND_UNUSED(shape)) const {
+    void arrmeta_default_construct(char *DYND_UNUSED(arrmeta),
+                                   intptr_t DYND_UNUSED(ndim),
+                                   const intptr_t *DYND_UNUSED(shape),
+                                   bool DYND_UNUSED(blockref_alloc)) const
+    {
     }
     void arrmeta_copy_construct(char *DYND_UNUSED(dst_arrmeta), const char *DYND_UNUSED(src_arrmeta), memory_block_data *DYND_UNUSED(embedded_reference)) const {
     }

--- a/include/dynd/types/funcproto_type.hpp
+++ b/include/dynd/types/funcproto_type.hpp
@@ -67,7 +67,9 @@ public:
 
     bool operator==(const base_type& rhs) const;
 
-    void arrmeta_default_construct(char *arrmeta, intptr_t ndim, const intptr_t* shape) const;
+    void arrmeta_default_construct(char *arrmeta, intptr_t ndim,
+                                   const intptr_t *shape,
+                                   bool blockref_alloc) const;
     void arrmeta_copy_construct(char *dst_arrmeta, const char *src_arrmeta, memory_block_data *embedded_reference) const;
     void arrmeta_destruct(char *arrmeta) const;
 

--- a/include/dynd/types/json_type.hpp
+++ b/include/dynd/types/json_type.hpp
@@ -42,7 +42,9 @@ public:
 
     bool operator==(const base_type& rhs) const;
 
-    void arrmeta_default_construct(char *arrmeta, intptr_t ndim, const intptr_t* shape) const;
+    void arrmeta_default_construct(char *arrmeta, intptr_t ndim,
+                                   const intptr_t *shape,
+                                   bool blockref_alloc) const;
     void arrmeta_copy_construct(char *dst_arrmeta, const char *src_arrmeta, memory_block_data *embedded_reference) const;
     void arrmeta_reset_buffers(char *arrmeta) const;
     void arrmeta_finalize_buffers(char *arrmeta) const;

--- a/include/dynd/types/ndarrayarg_type.hpp
+++ b/include/dynd/types/ndarrayarg_type.hpp
@@ -39,8 +39,9 @@ public:
     bool operator==(const base_type& rhs) const;
 
     void arrmeta_default_construct(char *DYND_UNUSED(arrmeta),
-                                    intptr_t DYND_UNUSED(ndim),
-                                    const intptr_t *DYND_UNUSED(shape)) const
+                                   intptr_t DYND_UNUSED(ndim),
+                                   const intptr_t *DYND_UNUSED(shape),
+                                   bool DYND_UNUSED(blockref_alloc)) const
     {
     }
     void arrmeta_copy_construct(

--- a/include/dynd/types/option_type.hpp
+++ b/include/dynd/types/option_type.hpp
@@ -93,7 +93,8 @@ public:
   bool operator==(const base_type &rhs) const;
 
   void arrmeta_default_construct(char *arrmeta, intptr_t ndim,
-                                 const intptr_t *shape) const;
+                                 const intptr_t *shape,
+                                 bool blockref_alloc) const;
   void arrmeta_copy_construct(char *dst_arrmeta, const char *src_arrmeta,
                               memory_block_data *embedded_reference) const;
   void arrmeta_reset_buffers(char *arrmeta) const;

--- a/include/dynd/types/pointer_type.hpp
+++ b/include/dynd/types/pointer_type.hpp
@@ -85,7 +85,9 @@ public:
 
     ndt::type with_replaced_storage_type(const ndt::type& replacement_type) const;
 
-    void arrmeta_default_construct(char *arrmeta, intptr_t ndim, const intptr_t* shape) const;
+    void arrmeta_default_construct(char *arrmeta, intptr_t ndim,
+                                   const intptr_t *shape,
+                                   bool blockref_alloc) const;
     void arrmeta_copy_construct(char *dst_arrmeta, const char *src_arrmeta, memory_block_data *embedded_reference) const;
     void arrmeta_reset_buffers(char *arrmeta) const;
     void arrmeta_finalize_buffers(char *arrmeta) const;

--- a/include/dynd/types/strided_dim_type.hpp
+++ b/include/dynd/types/strided_dim_type.hpp
@@ -64,7 +64,9 @@ public:
 
     bool operator==(const base_type& rhs) const;
 
-    void arrmeta_default_construct(char *arrmeta, intptr_t ndim, const intptr_t* shape) const;
+    void arrmeta_default_construct(char *arrmeta, intptr_t ndim,
+                                   const intptr_t *shape,
+                                   bool blockref_alloc) const;
     void arrmeta_copy_construct(char *dst_arrmeta, const char *src_arrmeta, memory_block_data *embedded_reference) const;
     void arrmeta_reset_buffers(char *arrmeta) const;
     void arrmeta_finalize_buffers(char *arrmeta) const;

--- a/include/dynd/types/string_type.hpp
+++ b/include/dynd/types/string_type.hpp
@@ -66,7 +66,9 @@ public:
 
     bool operator==(const base_type& rhs) const;
 
-    void arrmeta_default_construct(char *arrmeta, intptr_t ndim, const intptr_t* shape) const;
+    void arrmeta_default_construct(char *arrmeta, intptr_t ndim,
+                                   const intptr_t *shape,
+                                   bool blockref_alloc) const;
     void arrmeta_copy_construct(char *dst_arrmeta, const char *src_arrmeta, memory_block_data *embedded_reference) const;
     void arrmeta_reset_buffers(char *arrmeta) const;
     void arrmeta_finalize_buffers(char *arrmeta) const;

--- a/include/dynd/types/time_type.hpp
+++ b/include/dynd/types/time_type.hpp
@@ -41,7 +41,11 @@ public:
 
     bool operator==(const base_type& rhs) const;
 
-    void arrmeta_default_construct(char *DYND_UNUSED(arrmeta), intptr_t DYND_UNUSED(ndim), const intptr_t* DYND_UNUSED(shape)) const {
+    void arrmeta_default_construct(char *DYND_UNUSED(arrmeta),
+                                   intptr_t DYND_UNUSED(ndim),
+                                   const intptr_t *DYND_UNUSED(shape),
+                                   bool DYND_UNUSED(blockref_alloc)) const
+    {
     }
     void arrmeta_copy_construct(char *DYND_UNUSED(dst_arrmeta), const char *DYND_UNUSED(src_arrmeta), memory_block_data *DYND_UNUSED(embedded_reference)) const {
     }

--- a/include/dynd/types/type_type.hpp
+++ b/include/dynd/types/type_type.hpp
@@ -32,7 +32,9 @@ public:
 
     bool operator==(const base_type& rhs) const;
 
-    void arrmeta_default_construct(char *arrmeta, intptr_t ndim, const intptr_t* shape) const;
+    void arrmeta_default_construct(char *arrmeta, intptr_t ndim,
+                                   const intptr_t *shape,
+                                   bool blockref_alloc) const;
     void arrmeta_copy_construct(char *dst_arrmeta, const char *src_arrmeta, memory_block_data *embedded_reference) const;
     void arrmeta_reset_buffers(char *arrmeta) const;
     void arrmeta_finalize_buffers(char *arrmeta) const;

--- a/include/dynd/types/typevar_dim_type.hpp
+++ b/include/dynd/types/typevar_dim_type.hpp
@@ -51,7 +51,8 @@ public:
     bool operator==(const base_type& rhs) const;
 
     void arrmeta_default_construct(char *arrmeta, intptr_t ndim,
-                                    const intptr_t *shape) const;
+                                   const intptr_t *shape,
+                                   bool blockref_alloc) const;
     void arrmeta_copy_construct(char *dst_arrmeta, const char *src_arrmeta,
                                  memory_block_data *embedded_reference) const;
     size_t

--- a/include/dynd/types/typevar_type.hpp
+++ b/include/dynd/types/typevar_type.hpp
@@ -47,7 +47,9 @@ public:
 
     bool operator==(const base_type& rhs) const;
 
-    void arrmeta_default_construct(char *arrmeta, intptr_t ndim, const intptr_t* shape) const;
+    void arrmeta_default_construct(char *arrmeta, intptr_t ndim,
+                                   const intptr_t *shape,
+                                   bool blockref_alloc) const;
     void arrmeta_copy_construct(char *dst_arrmeta, const char *src_arrmeta, memory_block_data *embedded_reference) const;
     void arrmeta_destruct(char *arrmeta) const;
 

--- a/include/dynd/types/var_dim_type.hpp
+++ b/include/dynd/types/var_dim_type.hpp
@@ -78,7 +78,9 @@ public:
 
     bool operator==(const base_type& rhs) const;
 
-    void arrmeta_default_construct(char *arrmeta, intptr_t ndim, const intptr_t* shape) const;
+    void arrmeta_default_construct(char *arrmeta, intptr_t ndim,
+                                   const intptr_t *shape,
+                                   bool blockref_alloc) const;
     void arrmeta_copy_construct(char *dst_arrmeta, const char *src_arrmeta, memory_block_data *embedded_reference) const;
     void arrmeta_reset_buffers(char *arrmeta) const;
     void arrmeta_finalize_buffers(char *arrmeta) const;

--- a/include/dynd/types/void_pointer_type.hpp
+++ b/include/dynd/types/void_pointer_type.hpp
@@ -32,7 +32,11 @@ public:
 
     bool operator==(const base_type& rhs) const;
 
-    void arrmeta_default_construct(char *DYND_UNUSED(arrmeta), intptr_t DYND_UNUSED(ndim), const intptr_t* DYND_UNUSED(shape)) const {
+    void arrmeta_default_construct(char *DYND_UNUSED(arrmeta),
+                                   intptr_t DYND_UNUSED(ndim),
+                                   const intptr_t *DYND_UNUSED(shape),
+                                   bool DYND_UNUSED(blockref_alloc)) const
+    {
     }
     void arrmeta_copy_construct(char *DYND_UNUSED(dst_arrmeta), const char *DYND_UNUSED(src_arrmeta), memory_block_data *DYND_UNUSED(embedded_reference)) const {
     }

--- a/src/dynd/array.cpp
+++ b/src/dynd/array.cpp
@@ -113,8 +113,8 @@ nd::array nd::make_strided_array(const ndt::type &dtp, intptr_t ndim,
             stride = dtp.extended()->get_default_data_size(0, NULL);
         }
         if (!dtp.is_builtin()) {
-            dtp.extended()->arrmeta_default_construct(
-                            reinterpret_cast<char *>(meta + ndim), 0, NULL);
+          dtp.extended()->arrmeta_default_construct(
+              reinterpret_cast<char *>(meta + ndim), 0, NULL, true);
         }
         if (axis_perm == NULL) {
             for (ptrdiff_t i = (ptrdiff_t)ndim - 1; i >= 0; --i) {
@@ -139,7 +139,7 @@ nd::array nd::make_strided_array(const ndt::type &dtp, intptr_t ndim,
         }
         // Fill in the array arrmeta with strides and sizes
         char *meta = reinterpret_cast<char *>(ndo + 1);
-        ndo->m_type->arrmeta_default_construct(meta, ndim, shape);
+        ndo->m_type->arrmeta_default_construct(meta, ndim, shape, true);
     }
 
     return array(result);
@@ -1581,6 +1581,10 @@ void nd::array::debug_print(std::ostream& o, const std::string& indent) const
         o << " type:\n";
         o << "  pointer: " << (void *)ndo->m_type << "\n";
         o << "  type: " << get_type() << "\n";
+        if (!get_type().is_builtin()) {
+          o << "  type refcount: " << get_type().extended()->get_use_count()
+            << "\n";
+        }
         o << " arrmeta:\n";
         o << "  flags: " << ndo->m_flags << " (";
         if (ndo->m_flags & read_access_flag) o << "read_access ";
@@ -1718,7 +1722,7 @@ nd::array nd::typed_empty(intptr_t ndim, const intptr_t *shape,
     array_preamble *preamble = reinterpret_cast<array_preamble *>(result.get());
     preamble->m_type = ndt::type(tp).release();
     preamble->m_type->arrmeta_default_construct(
-        reinterpret_cast<char *>(preamble + 1), ndim, shape);
+        reinterpret_cast<char *>(preamble + 1), ndim, shape, true);
     preamble->m_data_pointer = data_ptr;
     preamble->m_data_reference = NULL;
     preamble->m_flags = nd::read_access_flag | nd::write_access_flag;

--- a/src/dynd/func/chain_arrfunc.cpp
+++ b/src/dynd/func/chain_arrfunc.cpp
@@ -102,7 +102,7 @@ intptr_t dynd::make_chain_buf_tp_ckernel(
     self->m_buf_tp = buf_tp;
     arrmeta_holder(buf_tp).swap(self->m_buf_arrmeta);
     if (buf_tp.get_ndim() == 0 || first->resolve_dst_shape == NULL) {
-      self->m_buf_arrmeta.arrmeta_default_construct(0, NULL);
+      self->m_buf_arrmeta.arrmeta_default_construct(0, NULL, true);
       self->m_buf_shape.push_back(DYND_BUFFER_CHUNK_SIZE);
     } else {
       intptr_t ndim = buf_tp.get_ndim();
@@ -110,7 +110,7 @@ intptr_t dynd::make_chain_buf_tp_ckernel(
       shape[0] = DYND_BUFFER_CHUNK_SIZE;
       first->resolve_dst_shape(first, &shape[0] + 1, buf_tp, src_tp,
                                src_arrmeta, NULL);
-      self->m_buf_arrmeta.arrmeta_default_construct(ndim, &shape[0] + 1);
+      self->m_buf_arrmeta.arrmeta_default_construct(ndim, &shape[0] + 1, true);
       self->m_buf_shape.swap(shape);
     }
     ckb_offset = first->instantiate(first, ckb, ckb_offset, buf_tp,

--- a/src/dynd/kernels/expression_assignment_kernels.cpp
+++ b/src/dynd/kernels/expression_assignment_kernels.cpp
@@ -55,7 +55,8 @@ namespace {
                     if (buffer_arrmeta == NULL) {
                         throw bad_alloc();
                     }
-                    buffer_tp->arrmeta_default_construct(buffer_arrmeta, 0, NULL);
+                    buffer_tp->arrmeta_default_construct(buffer_arrmeta, 0,
+                                                         NULL, true);
                 }
                 // Make sure the buffer data size is pointer size-aligned
                 buffer_stride = buffer_tp->get_default_data_size(0, NULL);

--- a/src/dynd/kernels/expression_comparison_kernels.cpp
+++ b/src/dynd/kernels/expression_comparison_kernels.cpp
@@ -41,7 +41,7 @@ namespace {
                     if (b.arrmeta == NULL) {
                         throw bad_alloc();
                     }
-                    b.tp->arrmeta_default_construct(b.arrmeta, 0, NULL);
+                    b.tp->arrmeta_default_construct(b.arrmeta, 0, NULL, true);
                 }
                 // Make sure the buffer data size is pointer size-aligned
                 b.data_size = inc_to_alignment(b.tp->get_default_data_size(0, NULL),

--- a/src/dynd/types/arrfunc_type.cpp
+++ b/src/dynd/types/arrfunc_type.cpp
@@ -60,7 +60,10 @@ bool arrfunc_type::operator==(const base_type& rhs) const
 }
 
 void arrfunc_type::arrmeta_default_construct(char *DYND_UNUSED(arrmeta),
-                intptr_t DYND_UNUSED(ndim), const intptr_t* DYND_UNUSED(shape)) const
+                                             intptr_t DYND_UNUSED(ndim),
+                                             const intptr_t *DYND_UNUSED(shape),
+                                             bool DYND_UNUSED(blockref_alloc))
+    const
 {
 }
 

--- a/src/dynd/types/base_dim_type.cpp
+++ b/src/dynd/types/base_dim_type.cpp
@@ -6,9 +6,10 @@
 #include <dynd/type.hpp>
 #include <dynd/types/base_dim_type.hpp>
 
+#include <dynd/types/string_type.hpp>
+
 using namespace std;
 using namespace dynd;
-
 
 base_dim_type::~base_dim_type() {
 }

--- a/src/dynd/types/base_expr_type.cpp
+++ b/src/dynd/types/base_expr_type.cpp
@@ -26,12 +26,16 @@ ndt::type base_expr_type::get_canonical_type() const
     return get_value_type();
 }
 
-void base_expr_type::arrmeta_default_construct(char *arrmeta, intptr_t ndim, const intptr_t* shape) const
+void base_expr_type::arrmeta_default_construct(char *arrmeta, intptr_t ndim,
+                                               const intptr_t *shape,
+                                               bool blockref_alloc)
+    const
 {
-    const ndt::type& dt = get_operand_type();
-    if (!dt.is_builtin()) {
-        dt.extended()->arrmeta_default_construct(arrmeta, ndim, shape);
-    }
+  const ndt::type &dt = get_operand_type();
+  if (!dt.is_builtin()) {
+    dt.extended()->arrmeta_default_construct(arrmeta, ndim, shape,
+                                             blockref_alloc);
+  }
 }
 
 void base_expr_type::arrmeta_copy_construct(char *dst_arrmeta, const char *src_arrmeta, memory_block_data *embedded_reference) const

--- a/src/dynd/types/base_memory_type.cpp
+++ b/src/dynd/types/base_memory_type.cpp
@@ -56,11 +56,14 @@ ndt::type base_memory_type::get_canonical_type() const
     return m_storage_tp.get_canonical_type();
 }
 
-void base_memory_type::arrmeta_default_construct(char *arrmeta, intptr_t ndim, const intptr_t* shape) const
+void base_memory_type::arrmeta_default_construct(char *arrmeta, intptr_t ndim,
+                                                 const intptr_t *shape,
+                                                 bool blockref_alloc) const
 {
-    if (!m_storage_tp.is_builtin()) {
-        m_storage_tp.extended()->arrmeta_default_construct(arrmeta + m_storage_arrmeta_offset, ndim, shape);
-    }
+  if (!m_storage_tp.is_builtin()) {
+    m_storage_tp.extended()->arrmeta_default_construct(
+        arrmeta + m_storage_arrmeta_offset, ndim, shape, blockref_alloc);
+  }
 }
 
 void base_memory_type::arrmeta_copy_construct(

--- a/src/dynd/types/base_type.cpp
+++ b/src/dynd/types/base_type.cpp
@@ -152,13 +152,14 @@ size_t base_type::get_default_data_size(intptr_t DYND_UNUSED(ndim),
 // TODO: Make this a pure virtual function eventually
 void base_type::arrmeta_default_construct(char *DYND_UNUSED(arrmeta),
                                           intptr_t DYND_UNUSED(ndim),
-                                          const intptr_t *DYND_UNUSED(shape))
+                                          const intptr_t *DYND_UNUSED(shape),
+                                          bool DYND_UNUSED(blockref_alloc))
     const
 {
-    stringstream ss;
-    ss << "TODO: arrmeta_default_construct for " << ndt::type(this, true)
-       << " is not implemented";
-    throw std::runtime_error(ss.str());
+  stringstream ss;
+  ss << "TODO: arrmeta_default_construct for " << ndt::type(this, true)
+     << " is not implemented";
+  throw std::runtime_error(ss.str());
 }
 
 void base_type::arrmeta_copy_construct(

--- a/src/dynd/types/bytes_type.cpp
+++ b/src/dynd/types/bytes_type.cpp
@@ -172,11 +172,16 @@ bool bytes_type::operator==(const base_type& rhs) const
     }
 }
 
-void bytes_type::arrmeta_default_construct(char *arrmeta, intptr_t DYND_UNUSED(ndim), const intptr_t* DYND_UNUSED(shape)) const
+void bytes_type::arrmeta_default_construct(char *arrmeta,
+                                           intptr_t DYND_UNUSED(ndim),
+                                           const intptr_t *DYND_UNUSED(shape),
+                                           bool blockref_alloc) const
 {
-    // Simply allocate a POD memory block
+  // Simply allocate a POD memory block
+  if (blockref_alloc) {
     bytes_type_arrmeta *md = reinterpret_cast<bytes_type_arrmeta *>(arrmeta);
     md->blockref = make_pod_memory_block().release();
+  }
 }
 
 void bytes_type::arrmeta_copy_construct(char *dst_arrmeta, const char *src_arrmeta, memory_block_data *embedded_reference) const

--- a/src/dynd/types/categorical_type.cpp
+++ b/src/dynd/types/categorical_type.cpp
@@ -541,10 +541,11 @@ bool categorical_type::operator==(const base_type& rhs) const
 
 }
 
-void categorical_type::arrmeta_default_construct(char *DYND_UNUSED(arrmeta),
-                intptr_t DYND_UNUSED(ndim), const intptr_t* DYND_UNUSED(shape)) const
+void categorical_type::arrmeta_default_construct(
+    char *DYND_UNUSED(arrmeta), intptr_t DYND_UNUSED(ndim),
+    const intptr_t *DYND_UNUSED(shape), bool DYND_UNUSED(blockref_alloc)) const
 {
-    // Data is stored as uint##, no arrmeta to process
+  // Data is stored as uint##, no arrmeta to process
 }
 
 void categorical_type::arrmeta_copy_construct(char *DYND_UNUSED(dst_arrmeta),

--- a/src/dynd/types/cfixed_dim_type.cpp
+++ b/src/dynd/types/cfixed_dim_type.cpp
@@ -343,7 +343,8 @@ bool cfixed_dim_type::operator==(const base_type &rhs) const
 }
 
 void cfixed_dim_type::arrmeta_default_construct(char *arrmeta, intptr_t ndim,
-                                                const intptr_t *shape) const
+                                                const intptr_t *shape,
+                                                bool blockref_alloc) const
 {
   // Validate that the shape is ok
   if (ndim > 0) {
@@ -363,7 +364,7 @@ void cfixed_dim_type::arrmeta_default_construct(char *arrmeta, intptr_t ndim,
   if (!m_element_tp.is_builtin()) {
     m_element_tp.extended()->arrmeta_default_construct(
         arrmeta + sizeof(cfixed_dim_type_arrmeta), ndim ? (ndim - 1) : 0,
-        shape + 1);
+        shape + 1, blockref_alloc);
   }
 }
 

--- a/src/dynd/types/dim_fragment_type.cpp
+++ b/src/dynd/types/dim_fragment_type.cpp
@@ -247,9 +247,9 @@ bool dim_fragment_type::operator==(const base_type& rhs) const
 
 void dim_fragment_type::arrmeta_default_construct(
     char *DYND_UNUSED(arrmeta), intptr_t DYND_UNUSED(ndim),
-    const intptr_t *DYND_UNUSED(shape)) const
+    const intptr_t *DYND_UNUSED(shape), bool DYND_UNUSED(blockref_alloc)) const
 {
-    throw type_error("Cannot store data of dim_fragment type");
+  throw type_error("Cannot store data of dim_fragment type");
 }
 
 void dim_fragment_type::arrmeta_copy_construct(

--- a/src/dynd/types/ellipsis_dim_type.cpp
+++ b/src/dynd/types/ellipsis_dim_type.cpp
@@ -101,9 +101,9 @@ bool ellipsis_dim_type::operator==(const base_type& rhs) const
 
 void ellipsis_dim_type::arrmeta_default_construct(
     char *DYND_UNUSED(arrmeta), intptr_t DYND_UNUSED(ndim),
-    const intptr_t *DYND_UNUSED(shape)) const
+    const intptr_t *DYND_UNUSED(shape), bool DYND_UNUSED(blockref_alloc)) const
 {
-    throw type_error("Cannot store data of ellipsis type");
+  throw type_error("Cannot store data of ellipsis type");
 }
 
 void ellipsis_dim_type::arrmeta_copy_construct(

--- a/src/dynd/types/fixed_dim_type.cpp
+++ b/src/dynd/types/fixed_dim_type.cpp
@@ -300,7 +300,8 @@ bool fixed_dim_type::operator==(const base_type &rhs) const
 }
 
 void fixed_dim_type::arrmeta_default_construct(char *arrmeta, intptr_t ndim,
-                                               const intptr_t *shape) const
+                                               const intptr_t *shape,
+                                               bool blockref_alloc) const
 {
   // Validate that the shape is ok
   if (ndim > 0 && shape[0] >= 0 && shape[0] != (intptr_t)m_dim_size) {
@@ -320,7 +321,8 @@ void fixed_dim_type::arrmeta_default_construct(char *arrmeta, intptr_t ndim,
   md->stride = m_dim_size > 1 ? element_size : 0;
   if (!m_element_tp.is_builtin()) {
     m_element_tp.extended()->arrmeta_default_construct(
-        arrmeta + sizeof(fixed_dim_type_arrmeta), ndim - 1, shape + 1);
+        arrmeta + sizeof(fixed_dim_type_arrmeta), ndim - 1, shape + 1,
+        blockref_alloc);
   }
 }
 

--- a/src/dynd/types/funcproto_type.cpp
+++ b/src/dynd/types/funcproto_type.cpp
@@ -155,9 +155,9 @@ bool funcproto_type::operator==(const base_type& rhs) const
 
 void funcproto_type::arrmeta_default_construct(
     char *DYND_UNUSED(arrmeta), intptr_t DYND_UNUSED(ndim),
-    const intptr_t *DYND_UNUSED(shape)) const
+    const intptr_t *DYND_UNUSED(shape), bool DYND_UNUSED(blockref_alloc)) const
 {
-    throw type_error("Cannot store data of funcproto type");
+  throw type_error("Cannot store data of funcproto type");
 }
 
 void funcproto_type::arrmeta_copy_construct(

--- a/src/dynd/types/json_type.cpp
+++ b/src/dynd/types/json_type.cpp
@@ -130,12 +130,14 @@ bool json_type::operator==(const base_type &rhs) const
 
 void json_type::arrmeta_default_construct(char *arrmeta,
                                           intptr_t DYND_UNUSED(ndim),
-                                          const intptr_t *DYND_UNUSED(shape))
-    const
+                                          const intptr_t *DYND_UNUSED(shape),
+                                          bool blockref_alloc) const
 {
-    // Simply allocate a POD memory block
+  // Simply allocate a POD memory block
+  if (blockref_alloc) {
     json_type_arrmeta *md = reinterpret_cast<json_type_arrmeta *>(arrmeta);
     md->blockref = make_pod_memory_block().release();
+  }
 }
 
 void json_type::arrmeta_copy_construct(char *dst_arrmeta,

--- a/src/dynd/types/option_type.cpp
+++ b/src/dynd/types/option_type.cpp
@@ -273,7 +273,8 @@ bool option_type::operator==(const base_type &rhs) const
 }
 
 void option_type::arrmeta_default_construct(char *arrmeta, intptr_t ndim,
-                                            const intptr_t *shape) const
+                                            const intptr_t *shape,
+                                            bool blockref_alloc) const
 {
   if (m_nafunc.is_null()) {
     stringstream ss;
@@ -282,7 +283,8 @@ void option_type::arrmeta_default_construct(char *arrmeta, intptr_t ndim,
   }
 
   if (!m_value_tp.is_builtin()) {
-    m_value_tp.extended()->arrmeta_default_construct(arrmeta, ndim, shape);
+    m_value_tp.extended()->arrmeta_default_construct(arrmeta, ndim, shape,
+                                                     blockref_alloc);
   }
 }
 

--- a/src/dynd/types/pointer_type.cpp
+++ b/src/dynd/types/pointer_type.cpp
@@ -266,17 +266,17 @@ pointer_type::with_replaced_storage_type(const ndt::type & /*replacement_tp*/)
 }
 
 void pointer_type::arrmeta_default_construct(char *arrmeta, intptr_t ndim,
-                                             const intptr_t *shape) const
+                                             const intptr_t *shape,
+                                             bool blockref_alloc) const
 {
-    // Simply allocate a POD memory block
-    // TODO: Will need a different kind of memory block if the data isn't POD.
-    pointer_type_arrmeta *md =
-        reinterpret_cast<pointer_type_arrmeta *>(arrmeta);
-    md->blockref = make_pod_memory_block().release();
-    if (!m_target_tp.is_builtin()) {
-        m_target_tp.extended()->arrmeta_default_construct(
-            arrmeta + sizeof(pointer_type_arrmeta), ndim, shape);
-    }
+  // Simply allocate a POD memory block
+  // TODO: Will need a different kind of memory block if the data isn't POD.
+  pointer_type_arrmeta *md = reinterpret_cast<pointer_type_arrmeta *>(arrmeta);
+  md->blockref = make_pod_memory_block().release();
+  if (!m_target_tp.is_builtin()) {
+    m_target_tp.extended()->arrmeta_default_construct(
+        arrmeta + sizeof(pointer_type_arrmeta), ndim, shape, blockref_alloc);
+  }
 }
 
 void pointer_type::arrmeta_copy_construct(char *dst_arrmeta,

--- a/src/dynd/types/strided_dim_type.cpp
+++ b/src/dynd/types/strided_dim_type.cpp
@@ -326,25 +326,33 @@ bool strided_dim_type::operator==(const base_type& rhs) const
     }
 }
 
-void strided_dim_type::arrmeta_default_construct(char *arrmeta, intptr_t ndim, const intptr_t* shape) const
+void strided_dim_type::arrmeta_default_construct(char *arrmeta, intptr_t ndim,
+                                                 const intptr_t *shape,
+                                                 bool blockref_alloc) const
 {
-    // Validate that the shape is ok
-    if (ndim == 0 || shape[0] < 0) {
-        throw std::runtime_error("the strided_dim type requires a shape be specified for default construction");
-    }
-    size_t element_size = m_element_tp.is_builtin() ? m_element_tp.get_data_size()
-                                                     : m_element_tp.extended()->get_default_data_size(ndim-1, shape+1);
+  // Validate that the shape is ok
+  if (ndim == 0 || shape[0] < 0) {
+    throw std::runtime_error("the strided_dim type requires a shape be "
+                             "specified for default construction");
+  }
+  size_t element_size =
+      m_element_tp.is_builtin()
+          ? m_element_tp.get_data_size()
+          : m_element_tp.extended()->get_default_data_size(ndim - 1, shape + 1);
 
-    strided_dim_type_arrmeta *md = reinterpret_cast<strided_dim_type_arrmeta *>(arrmeta);
-    md->dim_size = shape[0];
-    if (shape[0] > 1) {
-        md->stride = element_size;
-    } else {
-        md->stride = 0;
-    }
-    if (!m_element_tp.is_builtin()) {
-        m_element_tp.extended()->arrmeta_default_construct(arrmeta + sizeof(strided_dim_type_arrmeta), ndim-1, shape+1);
-    }
+  strided_dim_type_arrmeta *md =
+      reinterpret_cast<strided_dim_type_arrmeta *>(arrmeta);
+  md->dim_size = shape[0];
+  if (shape[0] > 1) {
+    md->stride = element_size;
+  } else {
+    md->stride = 0;
+  }
+  if (!m_element_tp.is_builtin()) {
+    m_element_tp.extended()->arrmeta_default_construct(
+        arrmeta + sizeof(strided_dim_type_arrmeta), ndim - 1, shape + 1,
+        blockref_alloc);
+  }
 }
 
 void strided_dim_type::arrmeta_copy_construct(char *dst_arrmeta, const char *src_arrmeta, memory_block_data *embedded_reference) const

--- a/src/dynd/types/string_type.cpp
+++ b/src/dynd/types/string_type.cpp
@@ -174,11 +174,16 @@ bool string_type::operator==(const base_type& rhs) const
     }
 }
 
-void string_type::arrmeta_default_construct(char *arrmeta, intptr_t DYND_UNUSED(ndim), const intptr_t* DYND_UNUSED(shape)) const
+void string_type::arrmeta_default_construct(char *arrmeta,
+                                            intptr_t DYND_UNUSED(ndim),
+                                            const intptr_t *DYND_UNUSED(shape),
+                                            bool blockref_alloc) const
 {
-    // Simply allocate a POD memory block
+  // Simply allocate a POD memory block
+  if (blockref_alloc) {
     string_type_arrmeta *md = reinterpret_cast<string_type_arrmeta *>(arrmeta);
     md->blockref = make_pod_memory_block().release();
+  }
 }
 
 void string_type::arrmeta_copy_construct(char *dst_arrmeta, const char *src_arrmeta, memory_block_data *embedded_reference) const

--- a/src/dynd/types/type_type.cpp
+++ b/src/dynd/types/type_type.cpp
@@ -51,7 +51,10 @@ bool type_type::operator==(const base_type& rhs) const
 }
 
 void type_type::arrmeta_default_construct(char *DYND_UNUSED(arrmeta),
-                intptr_t DYND_UNUSED(ndim), const intptr_t* DYND_UNUSED(shape)) const
+                                          intptr_t DYND_UNUSED(ndim),
+                                          const intptr_t *DYND_UNUSED(shape),
+                                          bool DYND_UNUSED(blockref_alloc))
+    const
 {
 }
 

--- a/src/dynd/types/typevar_dim_type.cpp
+++ b/src/dynd/types/typevar_dim_type.cpp
@@ -93,9 +93,9 @@ bool typevar_dim_type::operator==(const base_type& rhs) const
 
 void typevar_dim_type::arrmeta_default_construct(
     char *DYND_UNUSED(arrmeta), intptr_t DYND_UNUSED(ndim),
-    const intptr_t *DYND_UNUSED(shape)) const
+    const intptr_t *DYND_UNUSED(shape), bool DYND_UNUSED(blockref_alloc)) const
 {
-    throw type_error("Cannot store data of typevar type");
+  throw type_error("Cannot store data of typevar type");
 }
 
 void typevar_dim_type::arrmeta_copy_construct(

--- a/src/dynd/types/typevar_type.cpp
+++ b/src/dynd/types/typevar_type.cpp
@@ -81,11 +81,13 @@ bool typevar_type::operator==(const base_type& rhs) const
     }
 }
 
-void typevar_type::arrmeta_default_construct(
-    char *DYND_UNUSED(arrmeta), intptr_t DYND_UNUSED(ndim),
-    const intptr_t *DYND_UNUSED(shape)) const
+void typevar_type::arrmeta_default_construct(char *DYND_UNUSED(arrmeta),
+                                             intptr_t DYND_UNUSED(ndim),
+                                             const intptr_t *DYND_UNUSED(shape),
+                                             bool DYND_UNUSED(blockref_alloc))
+    const
 {
-    throw type_error("Cannot store data of typevar type");
+  throw type_error("Cannot store data of typevar type");
 }
 
 void typevar_type::arrmeta_copy_construct(

--- a/src/dynd/view.cpp
+++ b/src/dynd/view.cpp
@@ -114,7 +114,8 @@ static bool try_view(const ndt::type &tp, const char *arrmeta,
                tp.get_data_alignment() >= view_tp.get_data_alignment()) {
       // POD types with matching properties
       if (view_tp.get_arrmeta_size() > 0) {
-        view_tp.extended()->arrmeta_default_construct(view_arrmeta, 0, NULL);
+        view_tp.extended()->arrmeta_default_construct(view_arrmeta, 0, NULL,
+                                                      true);
       }
       return true;
     } else {
@@ -359,7 +360,8 @@ static nd::array view_from_bytes(const nd::array &arr, const ndt::type &tp)
       result.get_ndo()->m_type = ndt::type(tp).release();
       result.get_ndo()->m_flags = arr.get_ndo()->m_flags;
       if (tp.get_arrmeta_size() > 0) {
-        tp.extended()->arrmeta_default_construct(result.get_arrmeta(), 0, NULL);
+        tp.extended()->arrmeta_default_construct(result.get_arrmeta(), 0, NULL,
+                                                 true);
       }
       return result;
     }
@@ -380,7 +382,8 @@ static nd::array view_from_bytes(const nd::array &arr, const ndt::type &tp)
       result.get_ndo()->m_flags = arr.get_ndo()->m_flags;
       if (el_tp.get_arrmeta_size() > 0) {
         el_tp.extended()->arrmeta_default_construct(
-            result.get_arrmeta() + sizeof(strided_dim_type_arrmeta), 0, NULL);
+            result.get_arrmeta() + sizeof(strided_dim_type_arrmeta), 0, NULL,
+            true);
       }
       strided_dim_type_arrmeta *strided_meta =
           reinterpret_cast<strided_dim_type_arrmeta *>(result.get_arrmeta());

--- a/tests/array/test_arrmeta_holder.cpp
+++ b/tests/array/test_arrmeta_holder.cpp
@@ -31,7 +31,7 @@ TEST(ArrMetaHolder, Basic) {
     EXPECT_EQ(smeta.get_type(), ndt::type("strided * string"));
     arrmeta_holder imeta(ndt::type("3 * int"));
     EXPECT_EQ(imeta.get_type(), ndt::type("fixed[3] * int32"));
-    smeta.arrmeta_default_construct(1, &sarr_size);
+    smeta.arrmeta_default_construct(1, &sarr_size, true);
     imeta.get_at<fixed_dim_type_arrmeta>(0)->dim_size = 3;
     imeta.get_at<fixed_dim_type_arrmeta>(0)->stride = sizeof(int);
 


### PR DESCRIPTION
This allows one to choose whether blockref types should
initialize so as to create values (blockref_alloc=true),
or not (blockref_alloc=false), in which case the memory
is owned by the parent nd::array and is for viewing only.
