### PR TITLE
Dereference

### DIFF
--- a/include/dynd/types/pointer_type.hpp
+++ b/include/dynd/types/pointer_type.hpp
@@ -105,6 +105,9 @@ public:
     void get_dynamic_type_properties(
                     const std::pair<std::string, gfunc::callable> **out_properties,
                     size_t *out_count) const;
+    void get_dynamic_array_functions(
+                    const std::pair<std::string, gfunc::callable> **out_functions,
+                    size_t *out_count) const;
 };
 
 namespace ndt {

--- a/src/dynd/array.cpp
+++ b/src/dynd/array.cpp
@@ -2138,35 +2138,3 @@ nd::array nd::combine_into_tuple(size_t field_count, const array *field_values)
     }
     return result;
 }
-
-/*
-static array follow_array_pointers(const array& n)
-{
-    // Follow the pointers to eliminate them
-    ndt::type dt = n.get_type();
-    const char *arrmeta = n.get_arrmeta();
-    char *data = n.get_ndo()->m_data_pointer;
-    memory_block_data *dataref = NULL;
-    uint64_t flags = n.get_ndo()->m_flags;
-    while (dt.get_type_id() == pointer_type_id) {
-        const pointer_type_arrmeta *md = reinterpret_cast<const pointer_type_arrmeta *>(arrmeta);
-        const pointer_type *pd = dt.tcast<pointer_type>();
-        dt = pd->get_target_type();
-        arrmeta += sizeof(pointer_type_arrmeta);
-        data = *reinterpret_cast<char **>(data) + md->offset;
-        dataref = md->blockref;
-    }
-    // Create an array without the pointers
-    array result(make_array_memory_block(dt.is_builtin() ? 0 : dt.extended()->get_arrmeta_size()));
-    if (!dt.is_builtin()) {
-        dt.extended()->arrmeta_copy_construct(result.get_arrmeta(), arrmeta, &n.get_ndo()->m_memblockdata);
-    }
-    result.get_ndo()->m_type = dt.release();
-    result.get_ndo()->m_data_pointer = data;
-    result.get_ndo()->m_data_reference = dataref ? dataref : &n.get_ndo()->m_memblockdata;
-    memory_block_incref(result.get_ndo()->m_data_reference);
-    result.get_ndo()->m_flags = flags;
-    return result;
-}
-*/
-

--- a/tests/types/test_pointer_type.cpp
+++ b/tests/types/test_pointer_type.cpp
@@ -55,3 +55,16 @@ TEST(PointerType, IsTypeSubarray) {
     EXPECT_TRUE(ndt::type("pointer[int32]").is_type_subarray(ndt::make_type<int32_t>()));
     EXPECT_FALSE(ndt::make_type<int32_t>().is_type_subarray(ndt::type("pointer[int32]")));
 }
+
+TEST(PointerType, Dereference) {
+    int vals[4] = {5, -1, 7, 3};
+
+    nd::array a(vals);
+    a = combine_into_tuple(1, &a)(0);
+
+    nd::array b = a.f("dereference");
+    EXPECT_EQ(b(0).as<int>(), 5);
+    EXPECT_EQ(b(1).as<int>(), -1);
+    EXPECT_EQ(b(2).as<int>(), 7);
+    EXPECT_EQ(b(3).as<int>(), 3);
+}


### PR DESCRIPTION
This adds a new dynamic function, dereference, to pointer_type that can remove the pointer layer of an array.
