### PR TITLE
Allow initializer_list C++11 feature to be optional for now

### DIFF
--- a/include/dynd/array.hpp
+++ b/include/dynd/array.hpp
@@ -195,6 +195,7 @@ public:
     template<class T>
     array(const T *rhs, intptr_t dim_size);
 
+#ifndef DYND_DISABLE_INIT_LIST
     /** Constructs an array from a 1D initializer list */
     template<class T>
     array(std::initializer_list<T> il);
@@ -223,6 +224,7 @@ public:
         array(il).swap(*this);
         return *this;
     }
+#endif // !defined(DYND_DISABLE_INIT_LIST)
 
     /**
      * Constructs an array from a std::vector.
@@ -1369,6 +1371,7 @@ inline array reshape(const array &a, intptr_t ndim, const intptr_t *shape)
   return reshape(a, nd::array(shape, ndim));
 }
 
+#ifndef DYND_DISABLE_INIT_LIST
 ///////////// Initializer list constructor implementation /////////////////////////
 namespace detail {
     // Computes the number of dimensions in a nested initializer list constructor
@@ -1484,6 +1487,7 @@ dynd::nd::array::array(std::initializer_list<std::initializer_list<std::initiali
     T *dataptr = reinterpret_cast<T *>(get_ndo()->m_data_pointer);
     detail::initializer_list_shape<S>::copy_data(&dataptr, il);
 }
+#endif // !defined(DYND_DISABLE_INIT_LIST)
 
 ///////////// C-style array constructor implementation /////////////////////////
 

--- a/include/dynd/config.hpp
+++ b/include/dynd/config.hpp
@@ -23,6 +23,13 @@
 //#  define DYND_RVALUE_REFS
 //#endif
 
+// On OSX build machine, there is no <initializer_list> header.
+// TODO: Remove this build workaround once this is resolved
+#if !(__has_feature(cxx_generalized_initializers) &&                           \
+      __has_include(<initializer_list>))
+#  define DYND_DISABLE_INIT_LIST
+#endif
+
 #if __has_feature(cxx_constexpr)
 #  define DYND_CONSTEXPR constexpr
 #else
@@ -152,7 +159,9 @@ public:
 #endif
 
 // If Initializer Lists are supported
+#ifndef DYND_DISABLE_INIT_LIST
 #include <initializer_list>
+#endif
 
 // If being run from the CLING C++ interpreter
 #ifdef DYND_CLING

--- a/tests/array/test_array.cpp
+++ b/tests/array/test_array.cpp
@@ -524,6 +524,7 @@ TEST(Array, ConstructorMemoryLayouts) {
     }
 }
 
+#if !defined(DYND_DISABLE_INIT_LIST)
 TEST(Array, InitFromInitializerLists) {
     nd::array a = {1, 2, 3, 4, 5};
     EXPECT_EQ(ndt::make_type<int>(), a.get_dtype());
@@ -584,6 +585,7 @@ TEST(Array, InitFromInitializerLists) {
     EXPECT_THROW((a = {{{1},{2},{3}}, {{1},{2},{3, 4}}}), runtime_error);
 #endif // DYND_NESTED_INIT_LIST_BUG
 }
+#endif // !defined(DYND_DISABLE_INIT_LIST)
 
 TEST(Array, InitFromNestedCArray) {
     int i0[2][3] = {{1,2,3}, {4,5,6}};

--- a/tests/array/test_array_views.cpp
+++ b/tests/array/test_array_views.cpp
@@ -304,6 +304,7 @@ TEST(ArrayViews, NDimPermute_BadPerms) {
   EXPECT_THROW(a.permute(ndim1 + 1, axes5), invalid_argument);
 }
 
+#if !defined(DYND_DISABLE_INIT_LIST)
 #ifndef DYND_NESTED_INIT_LIST_BUG
 TEST(ArrayViews, Reshape) {
     EXPECT_ARR_EQ(nd::array({{0, 1}, {2, 3}}),
@@ -337,3 +338,4 @@ TEST(ArrayViews, Reshape) {
         nd::reshape({{{0, 1}, {2, 3}, {4, 5}}, {{6, 7}, {8, 9}, {10, 11}}, {{12, 13}, {14, 15}, {16, 17}}, {{18, 19}, {20, 21}, {22, 23}}}, {24}));
 }
 #endif // DYND_NESTED_INIT_LIST_BUG
+#endif // !defined(DYND_DISABLE_INIT_LIST)

--- a/tests/func/test_apply.cpp
+++ b/tests/func/test_apply.cpp
@@ -92,6 +92,7 @@ DYND_CUDA_HOST_DEVICE double func7(int x, int y, double z)
   return (x % y) * z;
 }
 
+#if !defined(DYND_DISABLE_INIT_LIST)
 TEST(Apply, Function)
 {
   nd::arrfunc af;
@@ -155,6 +156,7 @@ TEST(Apply, Function)
   af = nd::make_apply_arrfunc(&func7);
   EXPECT_EQ(36.3, af(38, 5, 12.1).as<double>());
 }
+#endif // !defined(DYND_DISABLE_INIT_LIST)
 
 TEST(Apply, FunctionWithKeywords)
 {


### PR DESCRIPTION
The OSX build machine we're using does not have up to date
compiler/libraries presently, this is intended to be temporary
until those are updated.
