### PR TITLE
[WIP] constructed typevar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,6 +211,7 @@ set(libdynd_SRC
     src/dynd/types/ndarrayarg_type.cpp
     src/dynd/types/option_type.cpp
     src/dynd/types/pointer_type.cpp
+    src/dynd/types/pow_dimsym_type.cpp
     src/dynd/types/property_type.cpp
     src/dynd/types/static_type_instances.cpp
     src/dynd/types/string_type.cpp
@@ -225,8 +226,8 @@ set(libdynd_SRC
     src/dynd/types/type_id.cpp
     src/dynd/types/type_pattern_match.cpp
     src/dynd/types/type_type.cpp
+    src/dynd/types/typevar_constructed_type.cpp
     src/dynd/types/typevar_dim_type.cpp
-    src/dynd/types/pow_dimsym_type.cpp
     src/dynd/types/typevar_type.cpp
     src/dynd/types/unary_expr_type.cpp
     src/dynd/types/var_dim_type.cpp
@@ -284,6 +285,7 @@ set(libdynd_SRC
     include/dynd/types/ndarrayarg_type.hpp
     include/dynd/types/option_type.hpp
     include/dynd/types/pointer_type.hpp
+    include/dynd/types/pow_dimsym_type.hpp
     include/dynd/types/string_type.hpp
     include/dynd/types/struct_type.hpp
     include/dynd/types/cstruct_type.hpp
@@ -295,8 +297,8 @@ set(libdynd_SRC
     include/dynd/types/tuple_type.hpp
     include/dynd/types/type_id.hpp
     include/dynd/types/type_pattern_match.hpp
+    include/dynd/types/typevar_constructed_type.hpp
     include/dynd/types/typevar_dim_type.hpp
-    include/dynd/types/pow_dimsym_type.hpp
     include/dynd/types/typevar_type.hpp
     include/dynd/types/unary_expr_type.hpp
     include/dynd/types/var_dim_type.hpp

--- a/include/dynd/type.hpp
+++ b/include/dynd/type.hpp
@@ -348,6 +348,9 @@ public:
         return at_array(4, i);
     }
 
+    /** Returns true if this type matches the pattern type provided */
+    bool matches(const ndt::type &pattern) const;
+
     /**
      * Accesses a dynamic property of the type.
      *

--- a/include/dynd/types/type_id.hpp
+++ b/include/dynd/types/type_id.hpp
@@ -169,6 +169,7 @@ enum type_id_t {
   arrfunc_type_id,
   typevar_type_id,
   typevar_dim_type_id,
+  typevar_constructed_type_id,
   pow_dimsym_type_id,
   ellipsis_dim_type_id,
   // A special type which holds a fragment of canonical dimensions

--- a/include/dynd/types/typevar_constructed_type.hpp
+++ b/include/dynd/types/typevar_constructed_type.hpp
@@ -1,0 +1,68 @@
+//
+// Copyright (C) 2011-15 DyND Developers
+// BSD 2-Clause License, see LICENSE.txt
+//
+
+#pragma once
+
+#include <vector>
+#include <string>
+
+#include <dynd/array.hpp>
+#include <dynd/string.hpp>
+
+namespace dynd {
+
+class typevar_constructed_type : public base_type {
+  nd::string m_name;
+  nd::array m_args;
+
+public:
+  typevar_constructed_type(const nd::string &name, const nd::array &args);
+
+  virtual ~typevar_constructed_type() {}
+
+  inline const nd::string &get_name() const { return m_name; }
+
+  inline std::string get_name_str() const { return m_name.str(); }
+
+  void print_data(std::ostream &o, const char *arrmeta, const char *data) const;
+
+  void print_type(std::ostream &o) const;
+
+  ndt::type apply_linear_index(intptr_t nindices, const irange *indices,
+                               size_t current_i, const ndt::type &root_tp,
+                               bool leading_dimension) const;
+  intptr_t apply_linear_index(intptr_t nindices, const irange *indices,
+                              const char *arrmeta, const ndt::type &result_tp,
+                              char *out_arrmeta,
+                              memory_block_data *embedded_reference,
+                              size_t current_i, const ndt::type &root_tp,
+                              bool leading_dimension, char **inout_data,
+                              memory_block_data **inout_dataref) const;
+
+  bool is_lossless_assignment(const ndt::type &dst_tp,
+                              const ndt::type &src_tp) const;
+
+  bool operator==(const base_type &rhs) const;
+
+  void arrmeta_default_construct(char *arrmeta, bool blockref_alloc) const;
+  void arrmeta_copy_construct(char *dst_arrmeta, const char *src_arrmeta,
+                              memory_block_data *embedded_reference) const;
+  void arrmeta_destruct(char *arrmeta) const;
+
+  void get_dynamic_type_properties(
+      const std::pair<std::string, gfunc::callable> **out_properties,
+      size_t *out_count) const;
+}; // class typevar_type
+
+namespace ndt {
+  /** Makes a typevar_constructed type with the specified types */
+  inline ndt::type make_typevar_constructed(const nd::string &name,
+                                            const nd::array &args)
+  {
+    return ndt::type(new typevar_constructed_type(name, args), false);
+  }
+} // namespace ndt
+
+} // namespace dynd

--- a/src/dynd/type.cpp
+++ b/src/dynd/type.cpp
@@ -8,6 +8,7 @@
 #include <dynd/types/base_memory_type.hpp>
 #include <dynd/types/fixed_dim_type.hpp>
 #include <dynd/types/var_dim_type.hpp>
+#include <dynd/types/type_pattern_match.hpp>
 #include <dynd/exceptions.hpp>
 #include <dynd/typed_data_assign.hpp>
 #include <dynd/buffer_storage.hpp>
@@ -98,6 +99,11 @@ ndt::type ndt::type::at_array(int nindices, const irange *indices) const
     } else {
         return m_extended->apply_linear_index(nindices, indices, 0, *this, true);
     }
+}
+
+bool ndt::type::matches(const ndt::type &pattern)
+{
+  return pattern_match(*this, pattern);
 }
 
 nd::array ndt::type::p(const char *property_name) const

--- a/src/dynd/types/type_id.cpp
+++ b/src/dynd/types/type_id.cpp
@@ -163,6 +163,8 @@ std::ostream &dynd::operator<<(std::ostream &o, type_id_t tid)
     return (o << "typevar");
   case typevar_dim_type_id:
     return (o << "typevar_dim");
+  case typevar_constructed_type_id:
+    return (o << "typevar_constructed");
   case ellipsis_dim_type_id:
     return (o << "ellipsis_dim");
   default:

--- a/src/dynd/types/typevar_constructed_type.cpp
+++ b/src/dynd/types/typevar_constructed_type.cpp
@@ -1,0 +1,136 @@
+//
+// Copyright (C) 2011-15 DyND Developers
+// BSD 2-Clause License, see LICENSE.txt
+//
+
+#include <dynd/types/typevar_constructed_type.hpp>
+#include <dynd/types/typevar_type.hpp>
+#include <dynd/func/make_callable.hpp>
+
+using namespace std;
+using namespace dynd;
+
+typevar_constructed_type::typevar_constructed_type(const nd::string &name,
+                                                   const nd::array &args)
+    : base_type(typevar_constructed_type_id, symbolic_kind, 0, 1,
+                type_flag_symbolic, 0, 0, 0),
+      m_name(name), m_args(args.eval_immutable())
+{
+  static ndt::type args_pattern("((...), {...})");
+  if (m_name.is_null()) {
+    throw type_error("dynd typevar name cannot be null");
+  }
+  else if (!is_valid_typevar_name(m_name.begin(), m_name.end())) {
+    stringstream ss;
+    ss << "dynd typevar name ";
+    print_escaped_utf8_string(ss, m_name.begin(), m_name.end());
+    ss << " is not valid, it must be alphanumeric and begin with a capital";
+    throw type_error(ss.str());
+  }
+  else if (!args.get_type().matches(args_pattern)) {
+    stringstream ss;
+    ss << "dynd constructed typevar must have args matching " << args_pattern
+       << ", which " << args.get_type() << " does not";
+    throw type_error(ss.str());
+  }
+}
+
+void typevar_constructed_type::print_data(std::ostream &DYND_UNUSED(o),
+                                          const char *DYND_UNUSED(arrmeta),
+                                          const char *DYND_UNUSED(data)) const
+{
+  throw type_error("Cannot store data of typevar_constructed type");
+}
+
+void typevar_constructed_type::print_type(std::ostream &o) const
+{
+  // Type variables are barewords starting with a capital letter
+  o << m_name.str();
+}
+
+ndt::type typevar_constructed_type::apply_linear_index(
+    intptr_t DYND_UNUSED(nindices), const irange *DYND_UNUSED(indices),
+    size_t DYND_UNUSED(current_i), const ndt::type &DYND_UNUSED(root_tp),
+    bool DYND_UNUSED(leading_dimension)) const
+{
+  throw type_error("Cannot store data of typevar_constructed type");
+}
+
+intptr_t typevar_constructed_type::apply_linear_index(
+    intptr_t DYND_UNUSED(nindices), const irange *DYND_UNUSED(indices),
+    const char *DYND_UNUSED(arrmeta), const ndt::type &DYND_UNUSED(result_tp),
+    char *DYND_UNUSED(out_arrmeta),
+    memory_block_data *DYND_UNUSED(embedded_reference),
+    size_t DYND_UNUSED(current_i), const ndt::type &DYND_UNUSED(root_tp),
+    bool DYND_UNUSED(leading_dimension), char **DYND_UNUSED(inout_data),
+    memory_block_data **DYND_UNUSED(inout_dataref)) const
+{
+  throw type_error("Cannot store data of typevar_constructed type");
+}
+
+bool typevar_constructed_type::is_lossless_assignment(
+    const ndt::type &dst_tp, const ndt::type &src_tp) const
+{
+  if (dst_tp.extended() == this) {
+    if (src_tp.extended() == this) {
+      return true;
+    }
+    else if (src_tp.get_type_id() == typevar_constructed_type_id) {
+      return *dst_tp.extended() == *src_tp.extended();
+    }
+  }
+
+  return false;
+}
+
+bool typevar_constructed_type::operator==(const base_type &rhs) const
+{
+  if (this == &rhs) {
+    return true;
+  }
+  else if (rhs.get_type_id() != typevar_constructed_type_id) {
+    return false;
+  }
+  else {
+    const typevar_constructed_type *tvt =
+        static_cast<const typevar_constructed_type *>(&rhs);
+    return m_name == tvt->m_name;
+  }
+}
+
+void typevar_constructed_type::arrmeta_default_construct(
+    char *DYND_UNUSED(arrmeta), bool DYND_UNUSED(blockref_alloc)) const
+{
+  throw type_error("Cannot store data of typevar_constructed type");
+}
+
+void typevar_constructed_type::arrmeta_copy_construct(
+    char *DYND_UNUSED(dst_arrmeta), const char *DYND_UNUSED(src_arrmeta),
+    memory_block_data *DYND_UNUSED(embedded_reference)) const
+{
+  throw type_error("Cannot store data of typevar_constructed type");
+}
+
+void typevar_constructed_type::arrmeta_destruct(
+    char *DYND_UNUSED(arrmeta)) const
+{
+  throw type_error("Cannot store data of typevar_constructed type");
+}
+
+static nd::array property_get_name(const ndt::type &tp)
+{
+  return tp.extended<typevar_constructed_type>()->get_name();
+}
+
+void typevar_constructed_type::get_dynamic_type_properties(
+    const std::pair<std::string, gfunc::callable> **out_properties,
+    size_t *out_count) const
+{
+  static pair<string, gfunc::callable> type_properties[] = {
+      pair<string, gfunc::callable>(
+          "name", gfunc::make_callable(&property_get_name, "self")),
+  };
+
+  *out_properties = type_properties;
+  *out_count = sizeof(type_properties) / sizeof(type_properties[0]);
+}


### PR DESCRIPTION
Adding type to represent a typevar with constructor arguments.

See https://github.com/ContinuumIO/datashape/blob/master/docs/source/grammar.rst, in particular the part:

```
# Type Constructor (from the data type constructor symbol table)
type_constr : NAME_LOWER LBRACKET type_arg_list RBRACKET

# Type Constructor: list of arguments
type_arg_list : type_arg COMMA type_arg_list
              | type_kwarg_list
              | type_arg

# Type Constructor: list of arguments
type_kwarg_list : type_kwarg COMMA type_kwarg_list
                | type_kwarg

# Type Constructor : single argument
type_arg : datashape
         | INTEGER
         | STRING
         | list_type_arg

# Type Constructor : single keyword argument
type_kwarg : NAME_LOWER EQUAL type_arg

# Type Constructor : single list argument
list_type_arg : LBRACKET RBRACKET
              | LBRACKET datashape_list RBRACKET
              | LBRACKET integer_list RBRACKET
              | LBRACKET string_list RBRACKET

datashape_list : datashape COMMA datashape_list
               | datashape

integer_list : INTEGER COMMA integer_list
             | INTEGER

string_list : STRING COMMA string_list
            | STRING
```

This feature is incompatible with the desire for more free-form type constructor arguments, as discussed in https://github.com/ContinuumIO/datashape/issues/112.