### PR TITLE
Make as<T> work with nd::arrays of type "pointer[T]"

### DIFF
--- a/include/dynd/kernels/apply_kernels.hpp
+++ b/include/dynd/kernels/apply_kernels.hpp
@@ -148,14 +148,7 @@ namespace kernels {
   struct kwd {
     T m_val;
 
-    kwd(nd::array val)
-    {
-      if (val.get_type().get_type_id() == pointer_type_id) {
-        m_val = val.f("dereference").as<T>();
-      } else {
-        m_val = val.as<T>();
-      }
-    }
+    kwd(nd::array val) { m_val = val.as<T>(); }
 
     DYND_CUDA_HOST_DEVICE T get() { return m_val; }
   };

--- a/include/dynd/types/pointer_type.hpp
+++ b/include/dynd/types/pointer_type.hpp
@@ -100,6 +100,11 @@ public:
         kernel_request_t kernreq, const eval::eval_context *ectx,
         const nd::array &kwds) const;
 
+    size_t make_operand_to_value_assignment_kernel(
+        void *ckb, intptr_t ckb_offset, const char *dst_arrmeta,
+        const char *src_arrmeta, kernel_request_t kernreq,
+        const eval::eval_context *ectx) const;
+
     nd::array get_option_nafunc() const;
 
     bool matches(const ndt::type &self_tp, const char *self_arrmeta,


### PR DESCRIPTION
This removes a special case in the kwd helper class, and fills out something that was missing in pointer.