### PR TITLE
Rename ndt::type 'matches' to 'match', due to switched arg order

### DIFF
--- a/include/dynd/func/arrfunc.hpp
+++ b/include/dynd/func/arrfunc.hpp
@@ -89,7 +89,7 @@ namespace nd {
     {
       if (name == "dst_tp") {
         const ndt::type &expected_tp = self_tp->get_return_type();
-        if (expected_tp.matches(value, tp_vars)) {
+        if (expected_tp.match(value, tp_vars)) {
           return true;
         }
 
@@ -108,7 +108,7 @@ namespace nd {
     {
       if (name == "dst_tp") {
         const ndt::type &expected_tp = self_tp->get_return_type();
-        if (expected_tp.matches(value.as<ndt::type>(), tp_vars)) {
+        if (expected_tp.match(value.as<ndt::type>(), tp_vars)) {
           return true;
         }
 
@@ -118,7 +118,7 @@ namespace nd {
         throw std::invalid_argument(ss.str());
       } else if (name == "dst") {
         const ndt::type &expected_tp = self_tp->get_return_type();
-        if (expected_tp.matches(value.get_type(), tp_vars)) {
+        if (expected_tp.match(value.get_type(), tp_vars)) {
           dst = value;
           return true;
         }

--- a/include/dynd/type.hpp
+++ b/include/dynd/type.hpp
@@ -288,28 +288,33 @@ public:
     }
 
     /**
-     * Matches the provided type against another type, both of which may
-     * be symbolic types. It should be called with a symbolic type as 'this',
-     * although the other_tp may have symbolic types if each type matches exactly.
+     * Matches the provided candidate type against the current type. The
+     * 'this' type is the pattern to match against, and may be symbolic
+     * or concrete. If it is concrete, the candidate type must be equal
+     * for the match to succeed.
+     *
+     * The candidate type may also be symbolic.
+     *
      * Returns true if it matches, false otherwise.
      *
-     * This version may be called multiple times in a row, building up the
+     * This function may be called multiple times in a row, building up the
      * typevars dictionary which is used to enforce consistent usage of
      * type vars.
      *
      * \param arrmeta     The arrmeta for this type, maybe NULL.
-     * \param other_tp    A symbolic (or concrete) type to match against.
-     * \param other_arrmeta     The arrmeta for the other type, maybe NULL.
+     * \param candidate_tp    A type to match against this one.
+     * \param candidate_arrmeta   The arrmeta for the candidate type,
+     *                            may be NULL.
      * \param tp_vars     A map of names to matched type vars.
      */
-    bool matches(const char *arrmeta, const ndt::type &other_tp,
-                 const char *other_arrmeta,
-                 std::map<nd::string, ndt::type> &tp_vars) const;
+    bool match(const char *arrmeta, const ndt::type &candidate_tp,
+               const char *candidate_arrmeta,
+               std::map<nd::string, ndt::type> &tp_vars) const;
 
-    bool matches(const ndt::type &other_tp,
-                 std::map<nd::string, ndt::type> &tp_vars) const;
+    bool match(const ndt::type &candidate_tp,
+               std::map<nd::string, ndt::type> &tp_vars) const;
 
-    bool matches(const ndt::type &other_tp) const;
+    bool match(const ndt::type &candidate_tp) const;
 
     /**
      * Accesses a dynamic property of the type.

--- a/include/dynd/types/any_sym_type.hpp
+++ b/include/dynd/types/any_sym_type.hpp
@@ -66,9 +66,9 @@ public:
   void data_destruct_strided(const char *arrmeta, char *data, intptr_t stride,
                              size_t count) const;
 
-  bool matches(const char *arrmeta, const ndt::type &other_tp,
-               const char *other_arrmeta,
-               std::map<nd::string, ndt::type> &tp_vars) const;
+  bool match(const char *arrmeta, const ndt::type &candidate_tp,
+             const char *candidate_arrmeta,
+             std::map<nd::string, ndt::type> &tp_vars) const;
 
   void get_dynamic_type_properties(
       const std::pair<std::string, gfunc::callable> **out_properties,

--- a/include/dynd/types/arrfunc_type.hpp
+++ b/include/dynd/types/arrfunc_type.hpp
@@ -395,9 +395,9 @@ public:
       kernel_request_t kernreq, const eval::eval_context *ectx,
       const nd::array &kwds) const;
 
-  bool matches(const char *arrmeta, const ndt::type &other_tp,
-               const char *other_arrmeta,
-               std::map<nd::string, ndt::type> &tp_vars) const;
+  bool match(const char *arrmeta, const ndt::type &candidate_tp,
+             const char *candidate_arrmeta,
+             std::map<nd::string, ndt::type> &tp_vars) const;
 
   void get_dynamic_type_properties(
       const std::pair<std::string, gfunc::callable> **out_properties,

--- a/include/dynd/types/base_dim_type.hpp
+++ b/include/dynd/types/base_dim_type.hpp
@@ -100,9 +100,9 @@ public:
       char *dst_arrmeta, const char *src_arrmeta,
       memory_block_data *embedded_reference) const = 0;
 
-  virtual bool matches(const char *arrmeta, const ndt::type &other_tp,
-                       const char *other_arrmeta,
-                       std::map<nd::string, ndt::type> &tp_vars) const;
+  virtual bool match(const char *arrmeta, const ndt::type &candidate_tp,
+                     const char *candidate_arrmeta,
+                     std::map<nd::string, ndt::type> &tp_vars) const;
 };
 
 } // namespace dynd

--- a/include/dynd/types/base_memory_type.hpp
+++ b/include/dynd/types/base_memory_type.hpp
@@ -109,9 +109,9 @@ public:
   virtual void data_zeroinit(char *data, size_t size) const = 0;
   virtual void data_free(char *data) const = 0;
 
-  virtual bool matches(const char *arrmeta, const ndt::type &other_tp,
-                       const char *other_arrmeta,
-                       std::map<nd::string, ndt::type> &tp_vars) const;
+  virtual bool match(const char *arrmeta, const ndt::type &candidate_tp,
+                     const char *candidate_arrmeta,
+                     std::map<nd::string, ndt::type> &tp_vars) const;
 
   virtual void get_dynamic_type_properties(
       const std::pair<std::string, gfunc::callable> **out_properties,

--- a/include/dynd/types/base_struct_type.hpp
+++ b/include/dynd/types/base_struct_type.hpp
@@ -69,9 +69,9 @@ public:
                               bool leading_dimension, char **inout_data,
                               memory_block_data **inout_dataref) const;
 
-  virtual bool matches(const char *arrmeta, const ndt::type &other_tp,
-                       const char *other_arrmeta,
-                       std::map<nd::string, ndt::type> &tp_vars) const;
+  virtual bool match(const char *arrmeta, const ndt::type &candidate_tp,
+                     const char *candidate_arrmeta,
+                     std::map<nd::string, ndt::type> &tp_vars) const;
 
   size_t get_elwise_property_index(const std::string &property_name) const;
   ndt::type get_elwise_property_type(size_t elwise_property_index,

--- a/include/dynd/types/base_tuple_type.hpp
+++ b/include/dynd/types/base_tuple_type.hpp
@@ -112,9 +112,9 @@ public:
   void foreach_leading(const char *arrmeta, char *data, foreach_fn_t callback,
                        void *callback_data) const;
 
-  virtual bool matches(const char *arrmeta, const ndt::type &other_tp,
-                       const char *other_arrmeta,
-                       std::map<nd::string, ndt::type> &tp_vars) const;
+  virtual bool match(const char *arrmeta, const ndt::type &candidate_tp,
+                     const char *candidate_arrmeta,
+                     std::map<nd::string, ndt::type> &tp_vars) const;
 
   /**
    * Fills in the array of default data offsets based on the data sizes

--- a/include/dynd/types/base_type.hpp
+++ b/include/dynd/types/base_type.hpp
@@ -553,9 +553,9 @@ public:
                            comparison_type_t comptype,
                            const eval::eval_context *ectx) const;
 
-    virtual bool matches(const char *arrmeta, const ndt::type &other_tp,
-                         const char *other_arrmeta,
-                         std::map<nd::string, ndt::type> &tp_vars) const;
+    virtual bool match(const char *arrmeta, const ndt::type &candidate_tp,
+                       const char *candidate_arrmeta,
+                       std::map<nd::string, ndt::type> &tp_vars) const;
 
     /**
      * Call the callback on each element of the array with given data/arrmeta along the leading

--- a/include/dynd/types/cfixed_dim_type.hpp
+++ b/include/dynd/types/cfixed_dim_type.hpp
@@ -111,9 +111,9 @@ public:
     void foreach_leading(const char *arrmeta, char *data,
                          foreach_fn_t callback, void *callback_data) const;
 
-    bool matches(const char *arrmeta, const ndt::type &other_tp,
-                 const char *other_arrmeta,
-                 std::map<nd::string, ndt::type> &tp_vars) const;
+    bool match(const char *arrmeta, const ndt::type &candidate_tp,
+               const char *candidate_arrmeta,
+               std::map<nd::string, ndt::type> &tp_vars) const;
 
     void get_dynamic_type_properties(
         const std::pair<std::string, gfunc::callable> **out_properties,

--- a/include/dynd/types/ellipsis_dim_type.hpp
+++ b/include/dynd/types/ellipsis_dim_type.hpp
@@ -52,9 +52,9 @@ public:
                                    memory_block_data *embedded_reference) const;
     void arrmeta_destruct(char *arrmeta) const;
 
-    bool matches(const char *arrmeta, const ndt::type &other_tp,
-                 const char *other_arrmeta,
-                 std::map<nd::string, ndt::type> &tp_vars) const;
+    bool match(const char *arrmeta, const ndt::type &candidate_tp,
+               const char *candidate_arrmeta,
+               std::map<nd::string, ndt::type> &tp_vars) const;
 
     void get_dynamic_type_properties(
         const std::pair<std::string, gfunc::callable> **out_properties,

--- a/include/dynd/types/fixed_dim_type.hpp
+++ b/include/dynd/types/fixed_dim_type.hpp
@@ -119,9 +119,9 @@ public:
                     char *dst_arrmeta,
                     const ndt::type& src_tp, const char *src_arrmeta) const;
 
-    bool matches(const char *arrmeta, const ndt::type &other_tp,
-                 const char *other_arrmeta,
-                 std::map<nd::string, ndt::type> &tp_vars) const;
+    bool match(const char *arrmeta, const ndt::type &candidate_tp,
+               const char *candidate_arrmeta,
+               std::map<nd::string, ndt::type> &tp_vars) const;
 
     void get_dynamic_type_properties(
                     const std::pair<std::string, gfunc::callable> **out_properties,

--- a/include/dynd/types/fixed_dimsym_type.hpp
+++ b/include/dynd/types/fixed_dimsym_type.hpp
@@ -67,9 +67,9 @@ public:
   void data_destruct_strided(const char *arrmeta, char *data, intptr_t stride,
                              size_t count) const;
 
-  bool matches(const char *arrmeta, const ndt::type &other_tp,
-               const char *other_arrmeta,
-               std::map<nd::string, ndt::type> &tp_vars) const;
+  bool match(const char *arrmeta, const ndt::type &candidate_tp,
+             const char *candidate_arrmeta,
+             std::map<nd::string, ndt::type> &tp_vars) const;
 
   void get_dynamic_type_properties(
       const std::pair<std::string, gfunc::callable> **out_properties,

--- a/include/dynd/types/option_type.hpp
+++ b/include/dynd/types/option_type.hpp
@@ -130,9 +130,9 @@ public:
       kernel_request_t kernreq, const eval::eval_context *ectx,
       const nd::array &kwds) const;
 
-  bool matches(const char *arrmeta, const ndt::type &other_tp,
-               const char *other_arrmeta,
-               std::map<nd::string, ndt::type> &tp_vars) const;
+  bool match(const char *arrmeta, const ndt::type &candidate_tp,
+             const char *candidate_arrmeta,
+             std::map<nd::string, ndt::type> &tp_vars) const;
 
   void get_dynamic_type_properties(
       const std::pair<std::string, gfunc::callable> **out_properties,

--- a/include/dynd/types/pointer_type.hpp
+++ b/include/dynd/types/pointer_type.hpp
@@ -107,9 +107,9 @@ public:
 
     nd::array get_option_nafunc() const;
 
-    bool matches(const char *arrmeta, const ndt::type &other_tp,
-                 const char *other_arrmeta,
-                 std::map<nd::string, ndt::type> &tp_vars) const;
+    bool match(const char *arrmeta, const ndt::type &candidate_tp,
+               const char *candidate_arrmeta,
+               std::map<nd::string, ndt::type> &tp_vars) const;
 
     void get_dynamic_type_properties(
                     const std::pair<std::string, gfunc::callable> **out_properties,

--- a/include/dynd/types/pow_dimsym_type.hpp
+++ b/include/dynd/types/pow_dimsym_type.hpp
@@ -60,9 +60,9 @@ public:
                                 memory_block_data *embedded_reference) const;
   void arrmeta_destruct(char *arrmeta) const;
 
-  bool matches(const char *arrmeta, const ndt::type &other_tp,
-               const char *other_arrmeta,
-               std::map<nd::string, ndt::type> &tp_vars) const;
+  bool match(const char *arrmeta, const ndt::type &candidate_tp,
+             const char *candidate_arrmeta,
+             std::map<nd::string, ndt::type> &tp_vars) const;
 
 //    void get_dynamic_type_properties(
   //      const std::pair<std::string, gfunc::callable> **out_properties,

--- a/include/dynd/types/typevar_constructed_type.hpp
+++ b/include/dynd/types/typevar_constructed_type.hpp
@@ -55,9 +55,9 @@ public:
                               memory_block_data *embedded_reference) const;
   void arrmeta_destruct(char *arrmeta) const;
 
-  bool matches(const char *arrmeta, const ndt::type &other_tp,
-               const char *other_arrmeta,
-               std::map<nd::string, ndt::type> &tp_vars) const;
+  bool match(const char *arrmeta, const ndt::type &candidate_tp,
+             const char *candidate_arrmeta,
+             std::map<nd::string, ndt::type> &tp_vars) const;
 
   void get_dynamic_type_properties(
       const std::pair<std::string, gfunc::callable> **out_properties,

--- a/include/dynd/types/typevar_dim_type.hpp
+++ b/include/dynd/types/typevar_dim_type.hpp
@@ -51,9 +51,9 @@ public:
                                    memory_block_data *embedded_reference) const;
     void arrmeta_destruct(char *arrmeta) const;
 
-    bool matches(const char *arrmeta, const ndt::type &other_tp,
-                 const char *other_arrmeta,
-                 std::map<nd::string, ndt::type> &tp_vars) const;
+    bool match(const char *arrmeta, const ndt::type &candidate_tp,
+               const char *candidate_arrmeta,
+               std::map<nd::string, ndt::type> &tp_vars) const;
 
     void get_dynamic_type_properties(
         const std::pair<std::string, gfunc::callable> **out_properties,

--- a/include/dynd/types/typevar_type.hpp
+++ b/include/dynd/types/typevar_type.hpp
@@ -50,9 +50,9 @@ public:
     void arrmeta_copy_construct(char *dst_arrmeta, const char *src_arrmeta, memory_block_data *embedded_reference) const;
     void arrmeta_destruct(char *arrmeta) const;
 
-    bool matches(const char *arrmeta, const ndt::type &other_tp,
-                 const char *other_arrmeta,
-                 std::map<nd::string, ndt::type> &tp_vars) const;
+    bool match(const char *arrmeta, const ndt::type &candidate_tp,
+               const char *candidate_arrmeta,
+               std::map<nd::string, ndt::type> &tp_vars) const;
 
     void get_dynamic_type_properties(
         const std::pair<std::string, gfunc::callable> **out_properties,

--- a/src/dynd/func/arrfunc.cpp
+++ b/src/dynd/func/arrfunc.cpp
@@ -151,7 +151,7 @@ void nd::detail::validate_kwd_types(const arrfunc_type *af_tp,
       expected_tp = expected_tp.p("value_type").as<ndt::type>();
     }
 
-    if (!expected_tp.matches(actual_tp.value_type(), tp_vars)) {
+    if (!expected_tp.match(actual_tp.value_type(), tp_vars)) {
       std::stringstream ss;
       ss << "keyword \"" << af_tp->get_kwd_name(j) << "\" does not match, ";
       ss << "arrfunc expected " << expected_tp << " but passed " << actual_tp;
@@ -201,7 +201,7 @@ void nd::detail::check_arg(const arrfunc_type *af_tp, intptr_t i,
                            std::map<nd::string, ndt::type> &tp_vars)
 {
   ndt::type expected_tp = af_tp->get_pos_type(i);
-  if (!expected_tp.matches(NULL, actual_tp.value_type(), actual_arrmeta,
+  if (!expected_tp.match(NULL, actual_tp.value_type(), actual_arrmeta,
                                       tp_vars)) {
     std::stringstream ss;
     ss << "positional argument " << i << " to arrfunc does not match, ";

--- a/src/dynd/func/multidispatch.cpp
+++ b/src/dynd/func/multidispatch.cpp
@@ -61,7 +61,7 @@ static bool can_implicitly_convert(const ndt::type &src, const ndt::type &dst,
   }
   if (src.get_ndim() > 0 || dst.get_ndim() > 0) {
     ndt::type src_dtype, dst_dtype;
-    if (src.matches(dst, typevars)) {
+    if (src.match(dst, typevars)) {
       return can_implicitly_convert(src.get_dtype(), dst.get_dtype(), typevars);
     } else {
       return false;
@@ -542,7 +542,7 @@ nd::arrfunc nd::functional::multidispatch(const ndt::type &self_tp,
   std::shared_ptr<multidispatch_map_type> map(new multidispatch_map_type);
   for (const arrfunc &child : children) {
     std::map<string, ndt::type> tp_vars;
-    if (!pattern_tp.matches(child.get_array_type(), tp_vars)) {
+    if (!pattern_tp.match(child.get_array_type(), tp_vars)) {
       throw std::invalid_argument("could not match arrfuncs");
     }
 

--- a/src/dynd/func/neighborhood_arrfunc.cpp
+++ b/src/dynd/func/neighborhood_arrfunc.cpp
@@ -262,7 +262,7 @@ nd::arrfunc dynd::make_neighborhood_arrfunc(const nd::arrfunc &neighborhood_op,
                            " * OUT");
 
   map<nd::string, ndt::type> typevars;
-  if (!nhop_pattern.matches(neighborhood_op.get_array_type(), typevars)) {
+  if (!nhop_pattern.match(neighborhood_op.get_array_type(), typevars)) {
     stringstream ss;
     ss << "provided neighborhood op proto " << neighborhood_op.get_array_type()
        << " does not match pattern " << nhop_pattern;

--- a/src/dynd/kernels/option_assignment_kernels.cpp
+++ b/src/dynd/kernels/option_assignment_kernels.cpp
@@ -505,8 +505,8 @@ size_t kernels::make_option_assignment_kernel(
   map<nd::string, ndt::type> typevars;
   for (intptr_t i = 0; i < size; ++i, ++af_tp, ++af) {
     typevars.clear();
-    if ((*af_tp)->get_pos_type(0).matches(src_tp, typevars) &&
-        (*af_tp)->get_return_type().matches(dst_tp, typevars)) {
+    if ((*af_tp)->get_pos_type(0).match(src_tp, typevars) &&
+        (*af_tp)->get_return_type().match(dst_tp, typevars)) {
       return af->instantiate(af, *af_tp, ckb, ckb_offset, dst_tp, dst_arrmeta,
                              size, &src_tp, &src_arrmeta, kernreq, ectx,
                              nd::array(), std::map<nd::string, ndt::type>());

--- a/src/dynd/type.cpp
+++ b/src/dynd/type.cpp
@@ -96,11 +96,11 @@ ndt::type ndt::type::at_array(int nindices, const irange *indices) const
   }
 }
 
-bool ndt::type::matches(const char *arrmeta, const ndt::type &other_tp,
-                        const char *other_arrmeta,
-                        std::map<nd::string, ndt::type> &tp_vars) const
+bool ndt::type::match(const char *arrmeta, const ndt::type &candidate_tp,
+                      const char *candidate_arrmeta,
+                      std::map<nd::string, ndt::type> &tp_vars) const
 {
-  if (extended() == other_tp.extended()) {
+  if (extended() == candidate_tp.extended()) {
     return true;
   }
 
@@ -108,19 +108,19 @@ bool ndt::type::matches(const char *arrmeta, const ndt::type &other_tp,
     return false;
   }
 
-  return extended()->matches(arrmeta, other_tp, other_arrmeta, tp_vars);
+  return extended()->match(arrmeta, candidate_tp, candidate_arrmeta, tp_vars);
 }
 
-bool ndt::type::matches(const ndt::type &other_tp,
-                        std::map<nd::string, ndt::type> &tp_vars) const
+bool ndt::type::match(const ndt::type &candidate_tp,
+                      std::map<nd::string, ndt::type> &tp_vars) const
 {
-  return matches(NULL, other_tp, NULL, tp_vars);
+  return match(NULL, candidate_tp, NULL, tp_vars);
 }
 
-bool ndt::type::matches(const ndt::type &other_tp) const
+bool ndt::type::match(const ndt::type &candidate_tp) const
 {
   std::map<nd::string, ndt::type> tp_vars;
-  return matches(other_tp, tp_vars);
+  return match(candidate_tp, tp_vars);
 }
 
 nd::array ndt::type::p(const char *property_name) const

--- a/src/dynd/types/any_sym_type.cpp
+++ b/src/dynd/types/any_sym_type.cpp
@@ -178,11 +178,13 @@ void any_sym_type::data_destruct_strided(const char *DYND_UNUSED(arrmeta),
   throw runtime_error(ss.str());
 }
 
-bool any_sym_type::matches(
-    const char *DYND_UNUSED(arrmeta), const ndt::type &DYND_UNUSED(other_tp),
-    const char *DYND_UNUSED(other_arrmeta),
+bool any_sym_type::match(
+    const char *DYND_UNUSED(arrmeta),
+    const ndt::type &DYND_UNUSED(candidate_tp),
+    const char *DYND_UNUSED(candidate_arrmeta),
     std::map<nd::string, ndt::type> &DYND_UNUSED(tp_vars)) const
 {
+  // "Any" matches against everything
   return true;
 }
 

--- a/src/dynd/types/arrfunc_type.cpp
+++ b/src/dynd/types/arrfunc_type.cpp
@@ -324,32 +324,32 @@ intptr_t arrfunc_type::make_assignment_kernel(
   throw dynd::type_error(ss.str());
 }
 
-bool arrfunc_type::matches(const char *arrmeta, const ndt::type &other_tp,
-                           const char *other_arrmeta,
-                           std::map<nd::string, ndt::type> &tp_vars) const
+bool arrfunc_type::match(const char *arrmeta, const ndt::type &candidate_tp,
+                         const char *candidate_arrmeta,
+                         std::map<nd::string, ndt::type> &tp_vars) const
 {
-  if (other_tp.get_type_id() != arrfunc_type_id) {
+  if (candidate_tp.get_type_id() != arrfunc_type_id) {
     return false;
   }
 
   // First match the return type
-  if (!m_return_type.matches(arrmeta,
-                             other_tp.extended<arrfunc_type>()->m_return_type,
-                             other_arrmeta, tp_vars)) {
+  if (!m_return_type.match(arrmeta,
+                           candidate_tp.extended<arrfunc_type>()->m_return_type,
+                           candidate_arrmeta, tp_vars)) {
     return false;
   }
 
   // Next match all the positional parameters
-  if (!m_pos_tuple.matches(arrmeta,
-                           other_tp.extended<arrfunc_type>()->m_pos_tuple,
-                           other_arrmeta, tp_vars)) {
+  if (!m_pos_tuple.match(arrmeta,
+                         candidate_tp.extended<arrfunc_type>()->m_pos_tuple,
+                         candidate_arrmeta, tp_vars)) {
     return false;
   }
 
   // Finally match all the keyword parameters
-  if (!m_kwd_struct.matches(arrmeta,
-                            other_tp.extended<arrfunc_type>()->get_kwd_struct(),
-                            other_arrmeta, tp_vars)) {
+  if (!m_kwd_struct.match(
+          arrmeta, candidate_tp.extended<arrfunc_type>()->get_kwd_struct(),
+          candidate_arrmeta, tp_vars)) {
     return false;
   }
 

--- a/src/dynd/types/base_dim_type.cpp
+++ b/src/dynd/types/base_dim_type.cpp
@@ -14,15 +14,15 @@ using namespace dynd;
 base_dim_type::~base_dim_type() {
 }
 
-bool base_dim_type::matches(const char *arrmeta, const ndt::type &other_tp,
-                            const char *other_arrmeta,
-                            std::map<nd::string, ndt::type> &tp_vars) const
+bool base_dim_type::match(const char *arrmeta, const ndt::type &candidate_tp,
+                          const char *candidate_arrmeta,
+                          std::map<nd::string, ndt::type> &tp_vars) const
 {
-  if (get_type_id() != other_tp.get_type_id()) {
+  if (get_type_id() != candidate_tp.get_type_id()) {
     return false;
   }
 
-  return m_element_tp.matches(arrmeta,
-                              other_tp.extended<base_dim_type>()->m_element_tp,
-                              other_arrmeta, tp_vars);
+  return m_element_tp.match(
+      arrmeta, candidate_tp.extended<base_dim_type>()->m_element_tp,
+      candidate_arrmeta, tp_vars);
 }

--- a/src/dynd/types/base_memory_type.cpp
+++ b/src/dynd/types/base_memory_type.cpp
@@ -148,17 +148,17 @@ void base_memory_type::arrmeta_destruct(char *arrmeta) const
   }
 }
 
-bool base_memory_type::matches(const char *arrmeta, const ndt::type &other_tp,
-                               const char *other_arrmeta,
-                               std::map<nd::string, ndt::type> &tp_vars) const
+bool base_memory_type::match(const char *arrmeta, const ndt::type &candidate_tp,
+                             const char *candidate_arrmeta,
+                             std::map<nd::string, ndt::type> &tp_vars) const
 {
-  if (other_tp.get_kind() != memory_kind) {
+  if (candidate_tp.get_kind() != memory_kind) {
     return false;
   }
 
-  return m_element_tp.matches(
-      arrmeta, other_tp.extended<base_memory_type>()->m_element_tp,
-      other_arrmeta, tp_vars);
+  return m_element_tp.match(
+      arrmeta, candidate_tp.extended<base_memory_type>()->m_element_tp,
+      candidate_arrmeta, tp_vars);
 }
 
 static ndt::type property_get_storage_type(const ndt::type &tp)

--- a/src/dynd/types/base_struct_type.cpp
+++ b/src/dynd/types/base_struct_type.cpp
@@ -203,38 +203,39 @@ intptr_t base_struct_type::apply_linear_index(
   }
 }
 
-bool base_struct_type::matches(const char *arrmeta,
-                               const ndt::type &other_tp,
-                               const char *other_arrmeta,
-                               std::map<nd::string, ndt::type> &tp_vars) const
+bool base_struct_type::match(const char *arrmeta, const ndt::type &candidate_tp,
+                             const char *candidate_arrmeta,
+                             std::map<nd::string, ndt::type> &tp_vars) const
 {
-  intptr_t other_field_count =
-      other_tp.extended<base_struct_type>()->get_field_count();
-  bool other_variadic = other_tp.extended<base_tuple_type>()->is_variadic();
+  intptr_t candidate_field_count =
+      candidate_tp.extended<base_struct_type>()->get_field_count();
+  bool candidate_variadic =
+      candidate_tp.extended<base_tuple_type>()->is_variadic();
 
-  if ((m_field_count == other_field_count && !other_variadic) ||
-      ((other_field_count >= m_field_count) && m_variadic)) {
+  if ((m_field_count == candidate_field_count && !candidate_variadic) ||
+      ((candidate_field_count >= m_field_count) && m_variadic)) {
     // Compare the field names
-    if (m_field_count == other_field_count) {
+    if (m_field_count == candidate_field_count) {
       if (!get_field_names().equals_exact(
-              other_tp.extended<base_struct_type>()->get_field_names())) {
+              candidate_tp.extended<base_struct_type>()->get_field_names())) {
         return false;
       }
-    } else {
+    }
+    else {
       nd::array leading_field_names = get_field_names();
       if (!leading_field_names.equals_exact(
-              other_tp.extended<base_struct_type>()->get_field_names()(
+              candidate_tp.extended<base_struct_type>()->get_field_names()(
                   irange() < m_field_count))) {
         return false;
       }
     }
 
     const ndt::type *fields = get_field_types_raw();
-    const ndt::type *other_fields =
-        other_tp.extended<base_struct_type>()->get_field_types_raw();
+    const ndt::type *candidate_fields =
+        candidate_tp.extended<base_struct_type>()->get_field_types_raw();
     for (intptr_t i = 0; i < m_field_count; ++i) {
-      if (!fields[i].matches(arrmeta, other_fields[i], other_arrmeta,
-                             tp_vars)) {
+      if (!fields[i].match(arrmeta, candidate_fields[i], candidate_arrmeta,
+                           tp_vars)) {
         return false;
       }
     }

--- a/src/dynd/types/base_tuple_type.cpp
+++ b/src/dynd/types/base_tuple_type.cpp
@@ -395,29 +395,31 @@ void base_tuple_type::foreach_leading(const char *arrmeta, char *data,
   }
 }
 
-bool base_tuple_type::matches(const char *arrmeta, const ndt::type &other_tp,
-                              const char *other_arrmeta,
-                              std::map<nd::string, ndt::type> &tp_vars) const
+bool base_tuple_type::match(const char *arrmeta, const ndt::type &candidate_tp,
+                            const char *candidate_arrmeta,
+                            std::map<nd::string, ndt::type> &tp_vars) const
 {
-  intptr_t other_field_count =
-      other_tp.extended<base_tuple_type>()->get_field_count();
-  bool other_variadic = other_tp.extended<base_tuple_type>()->is_variadic();
+  intptr_t candidate_field_count =
+      candidate_tp.extended<base_tuple_type>()->get_field_count();
+  bool candidate_variadic =
+      candidate_tp.extended<base_tuple_type>()->is_variadic();
 
-  if ((m_field_count == other_field_count && !other_variadic) ||
-      ((other_field_count >= m_field_count) && m_variadic)) {
+  if ((m_field_count == candidate_field_count && !candidate_variadic) ||
+      ((candidate_field_count >= m_field_count) && m_variadic)) {
     auto arrmeta_offsets = get_arrmeta_offsets_raw();
     // Match against the types
     const ndt::type *fields = get_field_types_raw();
-    const ndt::type *other_fields =
-        other_tp.extended<base_tuple_type>()->get_field_types_raw();
+    const ndt::type *candidate_fields =
+        candidate_tp.extended<base_tuple_type>()->get_field_types_raw();
     for (intptr_t i = 0; i != m_field_count; ++i) {
-      if (!fields[i].matches(DYND_INC_IF_NOT_NULL(arrmeta, arrmeta_offsets[i]),
-                             other_fields[i], other_arrmeta, tp_vars)) {
+      if (!fields[i].match(DYND_INC_IF_NOT_NULL(arrmeta, arrmeta_offsets[i]),
+                           candidate_fields[i], candidate_arrmeta, tp_vars)) {
         return false;
       }
     }
     return true;
-  } else {
+  }
+  else {
     return false;
   }
 }

--- a/src/dynd/types/base_type.cpp
+++ b/src/dynd/types/base_type.cpp
@@ -305,15 +305,18 @@ size_t base_type::make_comparison_kernel(
     throw not_comparable_error(src0_dt, src1_dt, comptype);
 }
 
-bool base_type::matches(const char *DYND_UNUSED(arrmeta),
-                        const ndt::type &other_tp, const char *DYND_UNUSED(other_arrmeta),
-                        std::map<nd::string, ndt::type> &DYND_UNUSED(tp_vars)) const
+bool base_type::match(
+    const char *DYND_UNUSED(arrmeta), const ndt::type &candidate_tp,
+    const char *DYND_UNUSED(candidate_arrmeta),
+    std::map<nd::string, ndt::type> &DYND_UNUSED(tp_vars)) const
 {
-  if (other_tp.is_builtin()) {
+  // The default match implementation is equality, pattern types
+  // must override this virtual function.
+  if (candidate_tp.is_builtin()) {
     return false;
   }
 
-  return *this == *other_tp.extended();
+  return *this == *candidate_tp.extended();
 }
 
 void base_type::foreach_leading(const char *DYND_UNUSED(arrmeta),

--- a/src/dynd/types/cfixed_dim_type.cpp
+++ b/src/dynd/types/cfixed_dim_type.cpp
@@ -614,27 +614,28 @@ void cfixed_dim_type::foreach_leading(const char *arrmeta, char *data,
   }
 }
 
-bool cfixed_dim_type::matches(const char *arrmeta, const ndt::type &other_tp,
-                              const char *other_arrmeta,
-                              std::map<nd::string, ndt::type> &tp_vars) const
+bool cfixed_dim_type::match(const char *arrmeta, const ndt::type &candidate_tp,
+                            const char *candidate_arrmeta,
+                            std::map<nd::string, ndt::type> &tp_vars) const
 {
-  switch (other_tp.get_type_id()) {
+  switch (candidate_tp.get_type_id()) {
   case fixed_dim_type_id:
+    // TODO XXX This must also validate the stride in the fixed_dim arrmeta
     return m_dim_size ==
-               other_tp.extended<fixed_dim_type>()->get_fixed_dim_size() &&
-           m_element_tp.matches(
+               candidate_tp.extended<fixed_dim_type>()->get_fixed_dim_size() &&
+           m_element_tp.match(
                DYND_INC_IF_NOT_NULL(arrmeta, sizeof(cfixed_dim_type_arrmeta)),
-               other_tp.extended<base_dim_type>()->get_element_type(),
-               DYND_INC_IF_NOT_NULL(other_arrmeta,
+               candidate_tp.extended<base_dim_type>()->get_element_type(),
+               DYND_INC_IF_NOT_NULL(candidate_arrmeta,
                                     sizeof(fixed_dim_type_arrmeta)),
                tp_vars);
   case cfixed_dim_type_id:
-    return m_dim_size == other_tp.extended<cfixed_dim_type>()->m_dim_size &&
-           m_stride == other_tp.extended<cfixed_dim_type>()->m_stride &&
-           m_element_tp.matches(
+    return m_dim_size == candidate_tp.extended<cfixed_dim_type>()->m_dim_size &&
+           m_stride == candidate_tp.extended<cfixed_dim_type>()->m_stride &&
+           m_element_tp.match(
                DYND_INC_IF_NOT_NULL(arrmeta, sizeof(cfixed_dim_type_arrmeta)),
-               other_tp.extended<cfixed_dim_type>()->m_element_tp,
-               DYND_INC_IF_NOT_NULL(other_arrmeta,
+               candidate_tp.extended<cfixed_dim_type>()->m_element_tp,
+               DYND_INC_IF_NOT_NULL(candidate_arrmeta,
                                     sizeof(cfixed_dim_type_arrmeta)),
                tp_vars);
   default:

--- a/src/dynd/types/fixed_dim_type.cpp
+++ b/src/dynd/types/fixed_dim_type.cpp
@@ -736,37 +736,37 @@ static ndt::type get_element_type(const ndt::type &dt)
   return dt.extended<fixed_dim_type>()->get_element_type();
 }
 
-bool fixed_dim_type::matches(const char *arrmeta, const ndt::type &other_tp,
-                             const char *other_arrmeta,
-                             std::map<nd::string, ndt::type> &tp_vars) const
+bool fixed_dim_type::match(const char *arrmeta, const ndt::type &candidate_tp,
+                           const char *candidate_arrmeta,
+                           std::map<nd::string, ndt::type> &tp_vars) const
 {
-  switch (other_tp.get_type_id()) {
+  switch (candidate_tp.get_type_id()) {
   case fixed_dim_type_id:
+    // TODO XXX If the arrmeta is not NULL, the strides should be checked too
     return get_fixed_dim_size() ==
-               other_tp.extended<fixed_dim_type>()->get_fixed_dim_size() &&
-           m_element_tp.matches(
-               (arrmeta == NULL)
-                   ? arrmeta
-                   : (arrmeta + sizeof(fixed_dim_type_arrmeta)),
-               other_tp.extended<fixed_dim_type>()->m_element_tp,
-               (other_arrmeta == NULL)
-                   ? other_arrmeta
-                   : (other_arrmeta + sizeof(cfixed_dim_type_arrmeta)),
+               candidate_tp.extended<fixed_dim_type>()->get_fixed_dim_size() &&
+           m_element_tp.match(
+               (arrmeta == NULL) ? arrmeta
+                                 : (arrmeta + sizeof(fixed_dim_type_arrmeta)),
+               candidate_tp.extended<fixed_dim_type>()->m_element_tp,
+               (candidate_arrmeta == NULL)
+                   ? candidate_arrmeta
+                   : (candidate_arrmeta + sizeof(cfixed_dim_type_arrmeta)),
                tp_vars);
   case cfixed_dim_type_id:
+    // TODO XXX This could be a bit more lenient if arrmeta is NULL
     return arrmeta != NULL &&
            get_fixed_dim_size() ==
-               other_tp.extended<cfixed_dim_type>()->get_fixed_dim_size() &&
+               candidate_tp.extended<cfixed_dim_type>()->get_fixed_dim_size() &&
            get_fixed_stride(arrmeta) ==
-               other_tp.extended<cfixed_dim_type>()->get_fixed_stride() &&
-           m_element_tp.matches(
-               (arrmeta == NULL)
-                   ? arrmeta
-                   : (arrmeta + sizeof(fixed_dim_type_arrmeta)),
-               other_tp.extended<cfixed_dim_type>()->get_element_type(),
-               (other_arrmeta == NULL)
-                   ? other_arrmeta
-                   : (other_arrmeta + sizeof(cfixed_dim_type_arrmeta)),
+               candidate_tp.extended<cfixed_dim_type>()->get_fixed_stride() &&
+           m_element_tp.match(
+               (arrmeta == NULL) ? arrmeta
+                                 : (arrmeta + sizeof(fixed_dim_type_arrmeta)),
+               candidate_tp.extended<cfixed_dim_type>()->get_element_type(),
+               (candidate_arrmeta == NULL)
+                   ? candidate_arrmeta
+                   : (candidate_arrmeta + sizeof(cfixed_dim_type_arrmeta)),
                tp_vars);
   default:
     return false;

--- a/src/dynd/types/fixed_dimsym_type.cpp
+++ b/src/dynd/types/fixed_dimsym_type.cpp
@@ -223,25 +223,27 @@ void fixed_dimsym_type::data_destruct_strided(const char *DYND_UNUSED(arrmeta),
   throw runtime_error(ss.str());
 }
 
-bool fixed_dimsym_type::matches(const char *arrmeta, const ndt::type &other_tp,
-                                const char *other_arrmeta,
-                                std::map<nd::string, ndt::type> &tp_vars) const
+bool fixed_dimsym_type::match(const char *arrmeta,
+                              const ndt::type &candidate_tp,
+                              const char *candidate_arrmeta,
+                              std::map<nd::string, ndt::type> &tp_vars) const
 {
-  switch (other_tp.get_type_id()) {
+  switch (candidate_tp.get_type_id()) {
   case fixed_dim_type_id:
-    return m_element_tp.matches(
-        arrmeta, other_tp.extended<fixed_dim_type>()->get_element_type(),
-        DYND_INC_IF_NOT_NULL(other_arrmeta, sizeof(fixed_dim_type_arrmeta)),
+    return m_element_tp.match(
+        arrmeta, candidate_tp.extended<fixed_dim_type>()->get_element_type(),
+        DYND_INC_IF_NOT_NULL(candidate_arrmeta, sizeof(fixed_dim_type_arrmeta)),
         tp_vars);
   case cfixed_dim_type_id:
-    return m_element_tp.matches(
-        arrmeta, other_tp.extended<cfixed_dim_type>()->get_element_type(),
-        DYND_INC_IF_NOT_NULL(other_arrmeta, sizeof(cfixed_dim_type_arrmeta)),
+    return m_element_tp.match(
+        arrmeta, candidate_tp.extended<cfixed_dim_type>()->get_element_type(),
+        DYND_INC_IF_NOT_NULL(candidate_arrmeta,
+                             sizeof(cfixed_dim_type_arrmeta)),
         tp_vars);
   case fixed_dimsym_type_id:
-    return m_element_tp.matches(
-        arrmeta, other_tp.extended<fixed_dimsym_type>()->get_element_type(),
-        other_arrmeta, tp_vars);
+    return m_element_tp.match(
+        arrmeta, candidate_tp.extended<fixed_dimsym_type>()->get_element_type(),
+        candidate_arrmeta, tp_vars);
   case any_sym_type_id:
     return true;
   default:

--- a/src/dynd/types/option_type.cpp
+++ b/src/dynd/types/option_type.cpp
@@ -357,17 +357,17 @@ intptr_t option_type::make_assignment_kernel(
       ckb, ckb_offset, dst_tp, dst_arrmeta, src_tp, src_arrmeta, kernreq, ectx);
 }
 
-bool option_type::matches(const char *arrmeta, const ndt::type &other_tp,
-                          const char *other_arrmeta,
-                          std::map<nd::string, ndt::type> &tp_vars) const
+bool option_type::match(const char *arrmeta, const ndt::type &candidate_tp,
+                        const char *candidate_arrmeta,
+                        std::map<nd::string, ndt::type> &tp_vars) const
 {
-  if (other_tp.get_type_id() != option_type_id) {
+  if (candidate_tp.get_type_id() != option_type_id) {
     return false;
   }
 
-  return m_value_tp.matches(arrmeta,
-                            other_tp.extended<option_type>()->m_value_tp,
-                            other_arrmeta, tp_vars);
+  return m_value_tp.match(arrmeta,
+                          candidate_tp.extended<option_type>()->m_value_tp,
+                          candidate_arrmeta, tp_vars);
 }
 
 static ndt::type property_get_value_type(const ndt::type &tp)

--- a/src/dynd/types/pointer_type.cpp
+++ b/src/dynd/types/pointer_type.cpp
@@ -396,20 +396,20 @@ nd::array pointer_type::get_option_nafunc() const
       get_value_type().get_type_id());
 }
 
-bool pointer_type::matches(const char *arrmeta,
-                           const ndt::type &other_tp, const char *other_arrmeta,
-                           std::map<nd::string, ndt::type> &tp_vars) const
+bool pointer_type::match(const char *arrmeta, const ndt::type &candidate_tp,
+                         const char *candidate_arrmeta,
+                         std::map<nd::string, ndt::type> &tp_vars) const
 {
-  if (other_tp.get_type_id() != pointer_type_id) {
+  if (candidate_tp.get_type_id() != pointer_type_id) {
     return false;
   }
 
-  return m_target_tp.matches(
-      (arrmeta == NULL) ? arrmeta
-                             : (arrmeta + sizeof(pointer_type_arrmeta)),
-      other_tp.extended<pointer_type>()->m_target_tp,
-      (other_arrmeta == NULL) ? other_arrmeta
-                              : (other_arrmeta + sizeof(pointer_type_arrmeta)),
+  // TODO XXX If the arrmeta is non-null, need to compare the offset and the
+  //          data reference
+  return m_target_tp.match(
+      DYND_INC_IF_NOT_NULL(arrmeta, sizeof(pointer_type_arrmeta)),
+      candidate_tp.extended<pointer_type>()->m_target_tp,
+      DYND_INC_IF_NOT_NULL(candidate_arrmeta, sizeof(pointer_type_arrmeta)),
       tp_vars);
 }
 

--- a/src/dynd/types/pow_dimsym_type.cpp
+++ b/src/dynd/types/pow_dimsym_type.cpp
@@ -144,89 +144,92 @@ void pow_dimsym_type::arrmeta_destruct(char *DYND_UNUSED(arrmeta)) const
     throw type_error("Cannot store data of typevar type");
 }
 
-bool pow_dimsym_type::matches(const char *arrmeta, const ndt::type &other_tp,
-                              const char *other_arrmeta,
-                              std::map<nd::string, ndt::type> &tp_vars) const
+bool pow_dimsym_type::match(const char *arrmeta, const ndt::type &candidate_tp,
+                            const char *candidate_arrmeta,
+                            std::map<nd::string, ndt::type> &tp_vars) const
 {
-  if (other_tp.get_type_id() == typevar_constructed_type_id) {
-    return other_tp.extended<typevar_constructed_type>()->matches(other_arrmeta, ndt::type(this, true), arrmeta, tp_vars);
+  if (candidate_tp.get_type_id() == typevar_constructed_type_id) {
+    return candidate_tp.extended<typevar_constructed_type>()->match(
+        candidate_arrmeta, ndt::type(this, true), arrmeta, tp_vars);
   }
 
- if (other_tp.get_type_id() == pow_dimsym_type_id) {
-    if (m_base_tp.matches(
-            arrmeta, other_tp.extended<pow_dimsym_type>()->get_base_type(), NULL,
-            tp_vars)) {
+  if (candidate_tp.get_type_id() == pow_dimsym_type_id) {
+    if (m_base_tp.match(
+            arrmeta, candidate_tp.extended<pow_dimsym_type>()->get_base_type(),
+            NULL, tp_vars)) {
 
-      get_element_type().matches(
-          arrmeta, other_tp.extended<pow_dimsym_type>()->get_element_type(), NULL,
-          tp_vars);
+      get_element_type().match(
+          arrmeta, candidate_tp.extended<pow_dimsym_type>()->get_element_type(),
+          NULL, tp_vars);
       ndt::type &tv_type =
-          tp_vars[other_tp.extended<pow_dimsym_type>()->get_exponent()];
+          tp_vars[candidate_tp.extended<pow_dimsym_type>()->get_exponent()];
       if (tv_type.is_null()) {
         // This typevar hasn't been seen yet
         tv_type = ndt::make_typevar_dim(
-            other_tp.extended<pow_dimsym_type>()->get_exponent(),
+            candidate_tp.extended<pow_dimsym_type>()->get_exponent(),
             ndt::make_type<void>());
         return true;
-      } else {
+      }
+      else {
         // Make sure the type matches previous
         // instances of the type var
         return tv_type.get_type_id() == typevar_dim_type_id &&
                tv_type.extended<typevar_dim_type>()->get_name() ==
-                   other_tp.extended<pow_dimsym_type>()->get_exponent();
+                   candidate_tp.extended<pow_dimsym_type>()->get_exponent();
       }
     }
-  } else if (other_tp.get_ndim() == 0) {
+  }
+  else if (candidate_tp.get_ndim() == 0) {
     if (get_element_type().get_ndim() == 0) {
       // Look up to see if the exponent typevar is already matched
-      ndt::type &tv_type =
-          tp_vars[get_exponent()];
+      ndt::type &tv_type = tp_vars[get_exponent()];
       if (tv_type.is_null()) {
         // Fill in the exponent by the number of dimensions left
         tv_type = ndt::make_fixed_dim(0, ndt::make_type<void>());
-      } else if (tv_type.get_type_id() == fixed_dim_type_id) {
+      }
+      else if (tv_type.get_type_id() == fixed_dim_type_id) {
         // Make sure the exponent already seen matches the number of
         // dimensions left in the concrete type
         if (tv_type.extended<fixed_dim_type>()->get_fixed_dim_size() != 0) {
           return false;
         }
-      } else {
+      }
+      else {
         // The exponent is always the dim_size inside a fixed_dim_type
         return false;
       }
-      return m_element_tp.matches(arrmeta, other_tp, NULL, tp_vars);
-    } else {
+      return m_element_tp.match(arrmeta, candidate_tp, NULL, tp_vars);
+    }
+    else {
       return false;
     }
   }
 
   // Look up to see if the exponent typevar is already matched
-  ndt::type &tv_type =
-      tp_vars[get_exponent()];
+  ndt::type &tv_type = tp_vars[get_exponent()];
   intptr_t exponent;
   if (tv_type.is_null()) {
     // Fill in the exponent by the number of dimensions left
-    exponent =
-        other_tp.get_ndim() -
-        get_element_type().get_ndim();
+    exponent = candidate_tp.get_ndim() - get_element_type().get_ndim();
     tv_type = ndt::make_fixed_dim(exponent, ndt::make_type<void>());
-  } else if (tv_type.get_type_id() == fixed_dim_type_id) {
+  }
+  else if (tv_type.get_type_id() == fixed_dim_type_id) {
     // Make sure the exponent already seen matches the number of
     // dimensions left in the concrete type
     exponent = tv_type.extended<fixed_dim_type>()->get_fixed_dim_size();
-    if (exponent !=
-        other_tp.get_ndim() - get_element_type().get_ndim()) {
+    if (exponent != candidate_tp.get_ndim() - get_element_type().get_ndim()) {
       return false;
     }
-  } else {
+  }
+  else {
     // The exponent is always the dim_size inside a fixed_dim_type
     return false;
   }
   // If the exponent is zero, the base doesn't matter, just match the rest
   if (exponent == 0) {
-    return m_element_tp.matches(arrmeta,
-        other_tp, NULL, tp_vars);
-  } else if (exponent < 0) {
+    return m_element_tp.match(arrmeta, candidate_tp, NULL, tp_vars);
+  }
+  else if (exponent < 0) {
     return false;
   }
   // Get the base type
@@ -237,20 +240,22 @@ bool pow_dimsym_type::matches(const char *arrmeta, const ndt::type &other_tp,
     if (btv_type.is_null()) {
       // We haven't seen this typevar yet, set it to the concrete's
       // dimension type
-      btv_type = other_tp;
-      base_tp = other_tp;
-    } else if (btv_type.get_ndim() > 0 &&
-               btv_type.get_type_id() != dim_fragment_type_id) {
+      btv_type = candidate_tp;
+      base_tp = candidate_tp;
+    }
+    else if (btv_type.get_ndim() > 0 &&
+             btv_type.get_type_id() != dim_fragment_type_id) {
       // Continue matching after substituting in the typevar for
       // the base type
       base_tp = btv_type;
-    } else {
+    }
+    else {
       // Doesn't match if the typevar has a dim fragment or dtype in it
       return false;
     }
   }
   // Now make sure the base_tp is repeated the right number of times
-  ndt::type concrete_subtype = other_tp;
+  ndt::type concrete_subtype = candidate_tp;
   switch (base_tp.get_type_id()) {
   case fixed_dimsym_type_id:
     for (intptr_t i = 0; i < exponent; ++i) {
@@ -275,7 +280,8 @@ bool pow_dimsym_type::matches(const char *arrmeta, const ndt::type &other_tp,
               dim_size) {
         concrete_subtype =
             concrete_subtype.extended<base_dim_type>()->get_element_type();
-      } else {
+      }
+      else {
         return false;
       }
     }
@@ -292,8 +298,7 @@ bool pow_dimsym_type::matches(const char *arrmeta, const ndt::type &other_tp,
   default:
     return false;
   }
-  return m_element_tp.matches(arrmeta,
-      concrete_subtype, NULL, tp_vars);
+  return m_element_tp.match(arrmeta, concrete_subtype, NULL, tp_vars);
 }
 
 /*

--- a/src/dynd/types/typevar_dim_type.cpp
+++ b/src/dynd/types/typevar_dim_type.cpp
@@ -110,36 +110,36 @@ void typevar_dim_type::arrmeta_destruct(char *DYND_UNUSED(arrmeta)) const
     throw type_error("Cannot store data of typevar type");
 }
 
-bool typevar_dim_type::matches(const char *arrmeta,
-                               const ndt::type &other_tp, const char *DYND_UNUSED(other_arrmeta),
-                               std::map<nd::string, ndt::type> &tp_vars) const
+bool typevar_dim_type::match(const char *arrmeta, const ndt::type &candidate_tp,
+                             const char *DYND_UNUSED(candidate_arrmeta),
+                             std::map<nd::string, ndt::type> &tp_vars) const
 {
-  if (!other_tp.is_dim()) {
+  if (!candidate_tp.is_dim()) {
     return false;
   }
 
   ndt::type &tv_type = tp_vars[get_name()];
   if (tv_type.is_null()) {
     // This typevar hasn't been seen yet
-    tv_type = other_tp;
-    return m_element_tp.matches(
-        arrmeta, other_tp.get_type_at_dimension(NULL, 1),
-        NULL, tp_vars);
-  } else {
+    tv_type = candidate_tp;
+    return m_element_tp.match(
+        arrmeta, candidate_tp.get_type_at_dimension(NULL, 1), NULL, tp_vars);
+  }
+  else {
     // Make sure the type matches previous
     // instances of the type var
-    if (other_tp.get_type_id() != tv_type.get_type_id()) {
+    if (candidate_tp.get_type_id() != tv_type.get_type_id()) {
       return false;
     }
-    switch (other_tp.get_type_id()) {
+    switch (candidate_tp.get_type_id()) {
     case fixed_dim_type_id:
-      if (other_tp.extended<fixed_dim_type>()->get_fixed_dim_size() !=
+      if (candidate_tp.extended<fixed_dim_type>()->get_fixed_dim_size() !=
           tv_type.extended<fixed_dim_type>()->get_fixed_dim_size()) {
         return false;
       }
       break;
     case cfixed_dim_type_id:
-      if (other_tp.extended<cfixed_dim_type>()->get_fixed_dim_size() !=
+      if (candidate_tp.extended<cfixed_dim_type>()->get_fixed_dim_size() !=
           tv_type.extended<cfixed_dim_type>()->get_fixed_dim_size()) {
         return false;
       }
@@ -147,9 +147,8 @@ bool typevar_dim_type::matches(const char *arrmeta,
     default:
       break;
     }
-    return m_element_tp.matches(
-        arrmeta, other_tp.get_type_at_dimension(NULL, 1),
-        NULL, tp_vars);
+    return m_element_tp.match(
+        arrmeta, candidate_tp.get_type_at_dimension(NULL, 1), NULL, tp_vars);
   }
 }
 

--- a/src/dynd/types/typevar_type.cpp
+++ b/src/dynd/types/typevar_type.cpp
@@ -100,28 +100,29 @@ void typevar_type::arrmeta_destruct(char *DYND_UNUSED(arrmeta)) const
     throw type_error("Cannot store data of typevar type");
 }
 
-bool typevar_type::matches(const char *DYND_UNUSED(arrmeta),
-                           const ndt::type &other_tp,
-                           const char *DYND_UNUSED(other_arrmeta),
-                           std::map<nd::string, ndt::type> &tp_vars) const
+bool typevar_type::match(const char *DYND_UNUSED(arrmeta),
+                         const ndt::type &candidate_tp,
+                         const char *DYND_UNUSED(candidate_arrmeta),
+                         std::map<nd::string, ndt::type> &tp_vars) const
 {
-  if (other_tp.get_type_id() == typevar_type_id) {
-    return *this == *other_tp.extended();
+  if (candidate_tp.get_type_id() == typevar_type_id) {
+    return *this == *candidate_tp.extended();
   }
 
-  if (!other_tp.is_scalar()) {
+  if (!candidate_tp.is_scalar()) {
     return false;
   }
 
   ndt::type &tv_type = tp_vars[m_name];
   if (tv_type.is_null()) {
     // This typevar hasn't been seen yet
-    tv_type = other_tp;
+    tv_type = candidate_tp;
     return true;
-  } else {
+  }
+  else {
     // Make sure the type matches previous
     // instances of the type var
-    return other_tp == tv_type;
+    return candidate_tp == tv_type;
   }
 }
 

--- a/tests/dynd_assertions.hpp
+++ b/tests/dynd_assertions.hpp
@@ -145,44 +145,42 @@ CompareDyNDArrayToJSON(const char *expr1, const char *expr2, const char *json,
   return CompareDyNDArrays(expr1, expr2, a, b);
 }
 
-inline ::testing::AssertionResult MatchNdtTypes(const char *expr1,
-                                                const char *expr2,
-                                                const dynd::ndt::type &pattern,
-                                                const dynd::ndt::type &actual)
+inline ::testing::AssertionResult
+MatchNdtTypes(const char *expr1, const char *expr2,
+              const dynd::ndt::type &pattern, const dynd::ndt::type &candidate)
 {
-  if (pattern.matches(actual)) {
+  if (pattern.match(candidate)) {
     return ::testing::AssertionSuccess();
   } else {
     return ::testing::AssertionFailure()
-           << "The type of " << expr2 << " does not match pattern " << expr1
-           << "\n" << expr1 << " has value " << pattern << ",\n" << expr2
-           << " has value " << actual << ".";
+           << "The type of candidate " << expr2 << " does not match pattern "
+           << expr1 << "\n" << expr1 << " has value " << pattern << ",\n"
+           << expr2 << " has value " << candidate << ".";
   }
 }
 
-inline ::testing::AssertionResult MatchNdtTypes(const char *expr1,
-                                                const char *expr2,
-                                                const char *pattern,
-                                                const dynd::ndt::type &actual)
+inline ::testing::AssertionResult
+MatchNdtTypes(const char *expr1, const char *expr2, const char *pattern,
+              const dynd::ndt::type &candidate)
 {
-  return MatchNdtTypes(expr1, expr2, dynd::ndt::type(pattern), actual);
+  return MatchNdtTypes(expr1, expr2, dynd::ndt::type(pattern), candidate);
 }
 
 inline ::testing::AssertionResult MatchNdtTypes(const char *expr1,
                                                 const char *expr2,
                                                 const dynd::ndt::type &pattern,
-                                                const char *actual)
+                                                const char *candidate)
 {
-  return MatchNdtTypes(expr1, expr2, pattern, dynd::ndt::type(actual));
+  return MatchNdtTypes(expr1, expr2, pattern, dynd::ndt::type(candidate));
 }
 
 inline ::testing::AssertionResult MatchNdtTypes(const char *expr1,
                                                 const char *expr2,
                                                 const char *pattern,
-                                                const char *actual)
+                                                const char *candidate)
 {
   return MatchNdtTypes(expr1, expr2, dynd::ndt::type(pattern),
-                       dynd::ndt::type(actual));
+                       dynd::ndt::type(candidate));
 }
 
 /**
@@ -211,8 +209,14 @@ inline ::testing::AssertionResult MatchNdtTypes(const char *expr1,
 #define EXPECT_JSON_EQ_ARR(expected, actual)                                   \
   EXPECT_PRED_FORMAT2(CompareDyNDArrayToJSON, expected, actual)
 
-#define EXPECT_TYPE_MATCHES(pattern, actual)                                   \
-  EXPECT_PRED_FORMAT2(MatchNdtTypes, pattern, actual)
+/**
+ * Macro to validate that a candidate type matches against
+ * the provided pattern.
+ *
+ * EXPECT_TYPE_MATCH("Fixed * T", "10 * int32");
+ */
+#define EXPECT_TYPE_MATCH(pattern, candidate)                                \
+  EXPECT_PRED_FORMAT2(MatchNdtTypes, pattern, candidate)
 
 inline float rel_error(float expected, float actual)
 {

--- a/tests/func/test_reduction.cpp
+++ b/tests/func/test_reduction.cpp
@@ -184,9 +184,9 @@ TEST(Reduction, BuiltinSum_Lift1D_NoIdentity)
   // Set up some data for the test reduction
   float vals0[5] = {1.5, -22., 3.75, 1.125, -3.375};
   nd::array a = vals0;
-  EXPECT_TYPE_MATCHES(af.get_type()->get_pos_type(0), a.get_type());
+  EXPECT_TYPE_MATCH(af.get_type()->get_pos_type(0), a.get_type());
   nd::array b = nd::empty(ndt::make_type<float>());
-  EXPECT_TYPE_MATCHES(af.get_type()->get_return_type(), b.get_type());
+  EXPECT_TYPE_MATCH(af.get_type()->get_return_type(), b.get_type());
 
   // Instantiate the lifted ckernel
   unary_ckernel_builder ckb;
@@ -236,9 +236,9 @@ TEST(Reduction, BuiltinSum_Lift1D_WithIdentity)
   // Set up some data for the test reduction
   float vals0[5] = {1.5, -22., 3.75, 1.125, -3.375};
   nd::array a = vals0;
-  EXPECT_TYPE_MATCHES(af.get_type()->get_pos_type(0), a.get_type());
+  EXPECT_TYPE_MATCH(af.get_type()->get_pos_type(0), a.get_type());
   nd::array b = nd::empty(ndt::make_type<float>());
-  EXPECT_TYPE_MATCHES(af.get_type()->get_return_type(), b.get_type());
+  EXPECT_TYPE_MATCH(af.get_type()->get_return_type(), b.get_type());
 
   // Instantiate the lifted ckernel
   unary_ckernel_builder ckb;
@@ -271,9 +271,9 @@ TEST(Reduction, BuiltinSum_Lift2D_StridedStrided_ReduceReduce)
   // Set up some data for the test reduction
   nd::array a =
       parse_json("2 * 3 * float32", "[[1.5, 2, 7], [-2.25, 7, 2.125]]");
-  EXPECT_TYPE_MATCHES(af.get_type()->get_pos_type(0), a.get_type());
+  EXPECT_TYPE_MATCH(af.get_type()->get_pos_type(0), a.get_type());
   nd::array b = nd::empty(ndt::make_type<float>());
-  EXPECT_TYPE_MATCHES(af.get_type()->get_return_type(), b.get_type());
+  EXPECT_TYPE_MATCH(af.get_type()->get_return_type(), b.get_type());
 
   // Instantiate the lifted ckernel
   unary_ckernel_builder ckb;
@@ -320,9 +320,9 @@ TEST(Reduction, BuiltinSum_Lift2D_StridedStrided_ReduceReduce_KeepDim)
   // Set up some data for the test reduction
   nd::array a =
       parse_json("2 * 3 * float32", "[[1.5, 2, 7], [-2.25, 7, 2.125]]");
-  EXPECT_TYPE_MATCHES(af.get_type()->get_pos_type(0), a.get_type());
+  EXPECT_TYPE_MATCH(af.get_type()->get_pos_type(0), a.get_type());
   nd::array b = nd::empty(1, 1, "float32");
-  EXPECT_TYPE_MATCHES(af.get_type()->get_return_type(), b.get_type());
+  EXPECT_TYPE_MATCH(af.get_type()->get_return_type(), b.get_type());
 
   // Instantiate the lifted ckernel
   unary_ckernel_builder ckb;
@@ -354,9 +354,9 @@ TEST(Reduction, BuiltinSum_Lift2D_StridedStrided_BroadcastReduce)
   // Set up some data for the test reduction
   nd::array a =
       parse_json("2 * 3 * float32", "[[1.5, 2, 7], [-2.25, 7, 2.125]]");
-  EXPECT_TYPE_MATCHES(af.get_type()->get_pos_type(0), a.get_type());
+  EXPECT_TYPE_MATCH(af.get_type()->get_pos_type(0), a.get_type());
   nd::array b = nd::empty(2, "float32");
-  EXPECT_TYPE_MATCHES(af.get_type()->get_return_type(), b.get_type());
+  EXPECT_TYPE_MATCH(af.get_type()->get_return_type(), b.get_type());
 
   // Instantiate the lifted ckernel
   unary_ckernel_builder ckb;
@@ -407,9 +407,9 @@ TEST(Reduction, BuiltinSum_Lift2D_StridedStrided_BroadcastReduce_KeepDim)
   // Set up some data for the test reduction
   nd::array a =
       parse_json("2 * 3 * float32", "[[1.5, 2, 7], [-2.25, 7, 2.125]]");
-  EXPECT_TYPE_MATCHES(af.get_type()->get_pos_type(0), a.get_type());
+  EXPECT_TYPE_MATCH(af.get_type()->get_pos_type(0), a.get_type());
   nd::array b = nd::empty(2, 1, "float32");
-  EXPECT_TYPE_MATCHES(af.get_type()->get_return_type(), b.get_type());
+  EXPECT_TYPE_MATCH(af.get_type()->get_return_type(), b.get_type());
 
   // Instantiate the lifted ckernel
   unary_ckernel_builder ckb;
@@ -443,9 +443,9 @@ TEST(Reduction, BuiltinSum_Lift2D_StridedStrided_ReduceBroadcast)
   // Set up some data for the test reduction
   nd::array a =
       parse_json("2 * 3 * float32", "[[1.5, 2, 7], [-2.25, 7, 2.125]]");
-  EXPECT_TYPE_MATCHES(af.get_type()->get_pos_type(0), a.get_type());
+  EXPECT_TYPE_MATCH(af.get_type()->get_pos_type(0), a.get_type());
   nd::array b = nd::empty(3, "float32");
-  EXPECT_TYPE_MATCHES(af.get_type()->get_return_type(), b.get_type());
+  EXPECT_TYPE_MATCH(af.get_type()->get_return_type(), b.get_type());
 
   // Instantiate the lifted ckernel
   unary_ckernel_builder ckb;
@@ -498,9 +498,9 @@ TEST(Reduction, BuiltinSum_Lift2D_StridedStrided_ReduceBroadcast_KeepDim)
   // Set up some data for the test reduction
   nd::array a =
       parse_json("2 * 3 * float32", "[[1.5, 2, 7], [-2.25, 7, 2.125]]");
-  EXPECT_TYPE_MATCHES(af.get_type()->get_pos_type(0), a.get_type());
+  EXPECT_TYPE_MATCH(af.get_type()->get_pos_type(0), a.get_type());
   nd::array b = nd::empty(1, 3, "float32");
-  EXPECT_TYPE_MATCHES(af.get_type()->get_return_type(), b.get_type());
+  EXPECT_TYPE_MATCH(af.get_type()->get_return_type(), b.get_type());
 
   // Instantiate the lifted ckernel
   unary_ckernel_builder ckb;
@@ -537,9 +537,9 @@ TEST(Reduction, BuiltinSum_Lift3D_StridedStridedStrided_ReduceReduceReduce)
   nd::array a = parse_json("2 * 3 * 2 * float32", "[[[1.5, -2.375], [2, 1.25], "
                                                   "[7, -0.5]], [[-2.25, 1], "
                                                   "[7, 0], [2.125, 0.25]]]");
-  EXPECT_TYPE_MATCHES(af.get_type()->get_pos_type(0), a.get_type());
+  EXPECT_TYPE_MATCH(af.get_type()->get_pos_type(0), a.get_type());
   nd::array b = nd::empty("float32");
-  EXPECT_TYPE_MATCHES(af.get_type()->get_return_type(), b.get_type());
+  EXPECT_TYPE_MATCH(af.get_type()->get_return_type(), b.get_type());
 
   // Instantiate the lifted ckernel
   unary_ckernel_builder ckb;
@@ -575,9 +575,9 @@ TEST(Reduction, BuiltinSum_Lift3D_StridedStridedStrided_BroadcastReduceReduce)
   nd::array a = parse_json("2 * 3 * 2 * float32", "[[[1.5, -2.375], [2, 1.25], "
                                                   "[7, -0.5]], [[-2.25, 1], "
                                                   "[7, 0], [2.125, 0.25]]]");
-  EXPECT_TYPE_MATCHES(af.get_type()->get_pos_type(0), a.get_type());
+  EXPECT_TYPE_MATCH(af.get_type()->get_pos_type(0), a.get_type());
   nd::array b = nd::empty(2, "float32");
-  EXPECT_TYPE_MATCHES(af.get_type()->get_return_type(), b.get_type());
+  EXPECT_TYPE_MATCH(af.get_type()->get_return_type(), b.get_type());
 
   // Instantiate the lifted ckernel
   unary_ckernel_builder ckb;
@@ -614,9 +614,9 @@ TEST(Reduction, BuiltinSum_Lift3D_StridedStridedStrided_ReduceBroadcastReduce)
                                                   "[7, -0.5]], [[-2.25, 1], "
                                                   "[7, 0], [2.125, 0.25]]]");
   a = a(irange(), irange(), irange());
-  EXPECT_TYPE_MATCHES(af.get_type()->get_pos_type(0), a.get_type());
+  EXPECT_TYPE_MATCH(af.get_type()->get_pos_type(0), a.get_type());
   nd::array b = nd::empty(3, "float32");
-  EXPECT_TYPE_MATCHES(af.get_type()->get_return_type(), b.get_type());
+  EXPECT_TYPE_MATCH(af.get_type()->get_return_type(), b.get_type());
 
   // Instantiate the lifted ckernel
   unary_ckernel_builder ckb;

--- a/tests/types/test_type_pattern_match.cpp
+++ b/tests/types/test_type_pattern_match.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <stdexcept>
 #include "inc_gtest.hpp"
+#include "dynd_assertions.hpp"
 
 #include <dynd/types/pow_dimsym_type.hpp>
 
@@ -14,254 +15,240 @@ using namespace dynd;
 
 TEST(TypePatternMatch, Simple)
 {
-  EXPECT_TRUE(ndt::type("int32").matches(ndt::type("int32")));
-  EXPECT_TRUE(ndt::type("T").matches(ndt::type("int32")));
-  EXPECT_TRUE(ndt::type("A... * int32").matches(ndt::type("int32")));
-  EXPECT_TRUE(ndt::type("A... * T").matches(ndt::type("int32")));
-  EXPECT_TRUE(ndt::type("A... * 4 * M").matches(ndt::type("4 * int32")));
-  EXPECT_TRUE(ndt::type("3 * A... * M").matches(ndt::type("3 * int32")));
-  EXPECT_TRUE(
-      ndt::type("Fixed**N * int32").matches(ndt::type("Fixed**3 * int32")));
-  EXPECT_TRUE(ndt::type("A**N * var * int32")
-                  .matches(ndt::type("Fixed**2 * var * int32")));
-  EXPECT_TRUE(
-      ndt::type("Fixed**N * int32").matches(ndt::type("Fixed * int32")));
-  EXPECT_TRUE(
-      ndt::type("4**N * 3 * int32").matches(ndt::type("4 * 4 * 3 * int32")));
+  EXPECT_TYPE_MATCH("int32", "int32");
+  EXPECT_TYPE_MATCH("T", "int32");
+  EXPECT_TYPE_MATCH("A... * int32", "int32");
+  EXPECT_TYPE_MATCH("A... * T", "int32");
+  EXPECT_TYPE_MATCH("A... * 4 * M", "4 * int32");
+  EXPECT_TYPE_MATCH("3 * A... * M", "3 * int32");
+  EXPECT_TYPE_MATCH("Fixed**N * int32", "Fixed**3 * int32");
+  EXPECT_TYPE_MATCH("A**N * var * int32", "Fixed**2 * var * int32");
+  EXPECT_TYPE_MATCH("Fixed**N * int32", "Fixed * int32");
+  EXPECT_TYPE_MATCH("4**N * 3 * int32", "4 * 4 * 3 * int32");
 
-  EXPECT_TRUE(
-      ndt::type("4**N * M * int32").matches(ndt::type("4 * 4 * 2 * int32")));
-  EXPECT_TRUE(
-      ndt::type("4**N * N * int32").matches(ndt::type("4 * 4 * 2 * int32")));
+  EXPECT_TYPE_MATCH("4**N * M * int32", "4 * 4 * 2 * int32");
+  EXPECT_TYPE_MATCH("4**N * N * int32", "4 * 4 * 2 * int32");
 
-  EXPECT_FALSE(ndt::type("int32").matches(ndt::type("int64")));
-  EXPECT_FALSE(ndt::type("T").matches(ndt::type("3 * int32")));
-  EXPECT_FALSE(ndt::type("A... * int32").matches(ndt::type("int16")));
-  EXPECT_FALSE(ndt::type("A... * 3 * M").matches(ndt::type("4 * int32")));
-  EXPECT_FALSE(ndt::type("Fixed**N * var * int32")
-                   .matches(ndt::type("Fixed**3 * int32")));
-  EXPECT_FALSE(ndt::type("Fixed**N * int32")
-                   .matches(ndt::type("var * Fixed**3 * int32")));
-  EXPECT_FALSE(ndt::type("A**N * A * int32")
-                   .matches(ndt::type("Fixed**3 * var * int32")));
+  EXPECT_FALSE(ndt::type("int32").match(ndt::type("int64")));
+  EXPECT_FALSE(ndt::type("T").match(ndt::type("3 * int32")));
+  EXPECT_FALSE(ndt::type("A... * int32").match(ndt::type("int16")));
+  EXPECT_FALSE(ndt::type("A... * 3 * M").match(ndt::type("4 * int32")));
   EXPECT_FALSE(
-      ndt::type("4**N * N * int32").matches(ndt::type("4 * 4 * 3 * int32")));
+      ndt::type("Fixed**N * var * int32").match(ndt::type("Fixed**3 * int32")));
+  EXPECT_FALSE(
+      ndt::type("Fixed**N * int32").match(ndt::type("var * Fixed**3 * int32")));
+  EXPECT_FALSE(
+      ndt::type("A**N * A * int32").match(ndt::type("Fixed**3 * var * int32")));
+  EXPECT_FALSE(
+      ndt::type("4**N * N * int32").match(ndt::type("4 * 4 * 3 * int32")));
 
-  EXPECT_TRUE(ndt::type("... * T").matches(ndt::type("... * int32")));
+  EXPECT_TYPE_MATCH("... * T", "... * int32");
 }
 
 TEST(TypePatternMatch, Any)
 {
   // Match various dtypes against "Any"
-  EXPECT_TRUE(ndt::type("Any").matches(ndt::type("Any")));
-  EXPECT_TRUE(ndt::type("Any").matches(ndt::type("int32")));
-  EXPECT_TRUE(ndt::type("Any").matches(ndt::type("(float32, Any)")));
-  EXPECT_TRUE(ndt::type("Any").matches(ndt::type("{x: Any, y: bool}")));
-  EXPECT_TRUE(ndt::type("Any").matches(ndt::type("pointer[complex]")));
-  EXPECT_TRUE(ndt::type("Any").matches(ndt::type("?float64")));
+  EXPECT_TYPE_MATCH("Any", "Any");
+  EXPECT_TYPE_MATCH("Any", "int32");
+  EXPECT_TYPE_MATCH("Any", "(float32, Any)");
+  EXPECT_TYPE_MATCH("Any", "{x: Any, y: bool}");
+  EXPECT_TYPE_MATCH("Any", "pointer[complex]");
+  EXPECT_TYPE_MATCH("Any", "?float64");
 
   // Match various dimensions + dtypes against "Any"
-  EXPECT_TRUE(ndt::type("Fixed * T").matches(ndt::type("Any")));
-  EXPECT_TRUE(ndt::type("Any").matches(ndt::type("D * T")));
-  EXPECT_TRUE(ndt::type("... * T").matches(ndt::type("Any")));
-  EXPECT_TRUE(ndt::type("Dims... * float64").matches(ndt::type("Any")));
-  EXPECT_TRUE(ndt::type("Any").matches(ndt::type("2 * 3 * complex[float32]")));
-  EXPECT_TRUE(ndt::type("Any")
-                  .matches(ndt::type("3 * {x: 2 * int32, y: var * int16}")));
-  EXPECT_TRUE(ndt::type("Any").matches(
-      ndt::type("3 * 5 * var * (int32, float16, 2 * int8)")));
+  EXPECT_TYPE_MATCH("Any", "Fixed * T");
+  EXPECT_TYPE_MATCH("Any", "D * T");
+  EXPECT_TYPE_MATCH("Any", "... * T");
+  EXPECT_TYPE_MATCH("Any", "Dims... * float64");
+  EXPECT_TYPE_MATCH("Any", "2 * 3 * complex[float32]");
+  EXPECT_TYPE_MATCH("Any", "3 * {x: 2 * int32, y: var * int16}");
+  EXPECT_TYPE_MATCH("Any", "3 * 5 * var * (int32, float16, 2 * int8)");
+
+  // On the other hand, "Any" doesn't in general match against anything,
+  // because a match with a symbolic candidate is saying "For all types that
+  // match the candidate, they also match the pattern".
+  EXPECT_FALSE(ndt::type("int32").match(ndt::type("Any")));
+  EXPECT_FALSE(ndt::type("T").match(ndt::type("Any")));
+  // TODO: This should fail to match
+//  EXPECT_FALSE(ndt::type("Fixed**2 * T").match(ndt::type("Any")));
+  // TODO: This should fail to match
+//  EXPECT_FALSE(ndt::type("... * float32").match(ndt::type("Any")));
+
+  // TODO: This should match
+  EXPECT_TYPE_MATCH("... * T", "Any");
 }
 
 TEST(TypePatternMatch, VariadicTuple)
 {
-  EXPECT_TRUE(ndt::type("(...)").matches(ndt::type("(...)")));
-  EXPECT_TRUE(ndt::type("(...)").matches(ndt::type("()")));
-  EXPECT_FALSE(ndt::type("()").matches(ndt::type("(...)")));
-  EXPECT_TRUE(ndt::type("(...)").matches(ndt::type("(int32)")));
-  EXPECT_TRUE(ndt::type("(int32, ...)").matches(ndt::type("(int32)")));
-  EXPECT_TRUE(ndt::type("(...)").matches(ndt::type("(int32, int64)")));
-  EXPECT_TRUE(ndt::type("(...)").matches(ndt::type("(int32, int64, float32)")));
-  EXPECT_TRUE(
-      ndt::type("(int32, ...)").matches(ndt::type("(int32, int64, float32)")));
-  EXPECT_TRUE(ndt::type("(int32, int64, ...)")
-                  .matches(ndt::type("(int32, int64, float32)")));
-  EXPECT_TRUE(ndt::type("(int32, int64, float32, ...)")
-                  .matches(ndt::type("(int32, int64, float32)")));
-  EXPECT_TRUE(ndt::type("(int32, T, ...)")
-                  .matches(ndt::type("(int32, int64, float32)")));
+  EXPECT_TYPE_MATCH("(...)", "(...)");
+  EXPECT_TYPE_MATCH("(...)", "()");
+  EXPECT_FALSE(ndt::type("()").match(ndt::type("(...)")));
+  EXPECT_TYPE_MATCH("(...)", "(int32)");
+  EXPECT_TYPE_MATCH("(int32, ...)", "(int32)");
+  EXPECT_TYPE_MATCH("(...)", "(int32, int64)");
+  EXPECT_TYPE_MATCH("(...)", "(int32, int64, float32)");
+  EXPECT_TYPE_MATCH("(int32, ...)", "(int32, int64, float32)");
+  EXPECT_TYPE_MATCH("(int32, int64, ...)", "(int32, int64, float32)");
+  EXPECT_TYPE_MATCH("(int32, int64, float32, ...)", "(int32, int64, float32)");
+  EXPECT_TYPE_MATCH("(int32, T, ...)", "(int32, int64, float32)");
   EXPECT_FALSE(
-      ndt::type("(T, T, ...)").matches(ndt::type("(int32, int64, float32)")));
-  EXPECT_TRUE(
-      ndt::type("(T, T, ...)").matches(ndt::type("(int32, int32, float32)")));
+      ndt::type("(T, T, ...)").match(ndt::type("(int32, int64, float32)")));
+  EXPECT_TYPE_MATCH("(T, T, ...)", "(int32, int32, float32)");
 }
 
 TEST(TypePatternMatch, Struct)
 {
-  EXPECT_TRUE(ndt::type("{x: int32}").matches(ndt::type("{x: int32}")));
-  EXPECT_TRUE(ndt::type("{x: T}").matches(ndt::type("{x: int32}")));
-  EXPECT_TRUE(
-      ndt::type("A... * {x: B... * T}").matches(ndt::type("{x: int32}")));
-  EXPECT_TRUE(ndt::type("A... * {x: T, y: T}")
-                  .matches(ndt::type("100 * {x: int32, y: int32}")));
-  EXPECT_TRUE(ndt::type("M * {x: T, y: T, u: S, v: S}").matches(
-      ndt::type("100 * {x: int32, y: int32, u: int16, v: int16}")));
+  EXPECT_TYPE_MATCH("{x: int32}", "{x: int32}");
+  EXPECT_TYPE_MATCH("{x: T}", "{x: int32}");
+  EXPECT_TYPE_MATCH("A... * {x: B... * T}", "{x: int32}");
+  EXPECT_TYPE_MATCH("A... * {x: T, y: T}", "100 * {x: int32, y: int32}");
+  EXPECT_TYPE_MATCH("M * {x: T, y: T, u: S, v: S}",
+                    "100 * {x: int32, y: int32, u: int16, v: int16}");
 
   EXPECT_FALSE(ndt::type("100 * {x: int32, y: int32, u: int16, v: int32}")
-                   .matches(ndt::type("M * {x: T, y: T, u: S, v: S}")));
+                   .match(ndt::type("M * {x: T, y: T, u: S, v: S}")));
 }
 
 TEST(TypePatternMatch, VariadicStruct)
 {
-  EXPECT_TRUE(ndt::type("{...}").matches(ndt::type("{...}")));
-  EXPECT_TRUE(ndt::type("{...}").matches(ndt::type("{}")));
-  EXPECT_FALSE(ndt::type("{}").matches(ndt::type("{...}")));
-  EXPECT_TRUE(ndt::type("{...}").matches(ndt::type("{x: int32}")));
-  EXPECT_TRUE(ndt::type("{x: int32, ...}").matches(ndt::type("{x: int32}")));
-  EXPECT_TRUE(ndt::type("{...}").matches(ndt::type("{x: int32, y: int64}")));
-  EXPECT_TRUE(ndt::type("{...}")
-                  .matches(ndt::type("{x: int32, y: int64, z: float32}")));
-  EXPECT_TRUE(ndt::type("{x: int32, ...}")
-                  .matches(ndt::type("{x: int32, y: int64, z: float32}")));
+  EXPECT_TYPE_MATCH("{...}", "{...}");
+  EXPECT_TYPE_MATCH("{...}", "{}");
+  EXPECT_FALSE(ndt::type("{}").match(ndt::type("{...}")));
+  EXPECT_TYPE_MATCH("{...}", "{x: int32}");
+  EXPECT_TYPE_MATCH("{x: int32, ...}", "{x: int32}");
+  EXPECT_TYPE_MATCH("{...}", "{x: int32, y: int64}");
+  EXPECT_TYPE_MATCH("{...}", "{x: int32, y: int64, z: float32}");
+  EXPECT_TYPE_MATCH("{x: int32, ...}","{x: int32, y: int64, z: float32}");
   EXPECT_FALSE(ndt::type("{x: int32, y: int64, z: float32}")
-                   .matches(ndt::type("{y: int32, ...}")));
+                   .match(ndt::type("{y: int32, ...}")));
   EXPECT_FALSE(ndt::type("{y: int64, ...}")
-                   .matches(ndt::type("{x: int32, y: int64, z: float32}")));
-  EXPECT_TRUE(ndt::type("{x: int32, y: int64, ...}")
-                  .matches(ndt::type("{x: int32, y: int64, z: float32}")));
-  EXPECT_TRUE(ndt::type("{x: int32, y: int64, z: float32, ...}")
-                  .matches(ndt::type("{x: int32, y: int64, z: float32}")));
-  EXPECT_TRUE(ndt::type("{x: int32, y: T, ...}")
-                  .matches(ndt::type("{x: int32, y: int64, z: float32}")));
+                   .match(ndt::type("{x: int32, y: int64, z: float32}")));
+  EXPECT_TYPE_MATCH("{x: int32, y: int64, ...}",
+                    "{x: int32, y: int64, z: float32}");
+  EXPECT_TYPE_MATCH("{x: int32, y: int64, z: float32, ...}",
+                    "{x: int32, y: int64, z: float32}");
+  EXPECT_TYPE_MATCH("{x: int32, y: T, ...}",
+                    "{x: int32, y: int64, z: float32}");
   EXPECT_FALSE(ndt::type("{x: T, y: T, ...}")
-                   .matches(ndt::type("{x: int32, y: int64, z: float32}")));
-  EXPECT_TRUE(ndt::type("{x: T, y: T, ...}")
-                  .matches(ndt::type("{x: int32, y: int32, z: float32}")));
+                   .match(ndt::type("{x: int32, y: int64, z: float32}")));
+  EXPECT_TYPE_MATCH("{x: T, y: T, ...}", "{x: int32, y: int32, z: float32}");
 }
 
 TEST(TypePatternMatch, Option)
 {
-  EXPECT_TRUE(ndt::type("?int32").matches(ndt::type("?int32")));
-  EXPECT_TRUE(ndt::type("?T").matches(ndt::type("?int32")));
-  EXPECT_TRUE(ndt::type("T").matches(ndt::type("?int32")));
-  EXPECT_TRUE(ndt::type("M * {x: T, y: T, u: S, v: S}").matches(
-      ndt::type("100 * {x: ?int32, y: ?int32, u: int16, v: int16}")));
-  EXPECT_TRUE(ndt::type("M * {x: T, y: T, u: ?S, v: S}").matches(
-      ndt::type("100 * {x: ?int32, y: ?int32, u: ?int16, v: int16}")));
+  EXPECT_TYPE_MATCH("?int32", "?int32");
+  EXPECT_TYPE_MATCH("?T", "?int32");
+  EXPECT_TYPE_MATCH("T", "?int32");
+  EXPECT_TYPE_MATCH("M * {x: T, y: T, u: S, v: S}",
+                    "100 * {x: ?int32, y: ?int32, u: int16, v: int16}");
+  EXPECT_TYPE_MATCH("M * {x: T, y: T, u: ?S, v: S}",
+                    "100 * {x: ?int32, y: ?int32, u: ?int16, v: int16}");
 
-  EXPECT_FALSE(ndt::type("M * {x: T, y: T, u: S, v: S}").matches(
-      ndt::type("100 * {x: ?int32, y: ?int32, u: ?int16, v: int16}")));
+  EXPECT_FALSE(ndt::type("M * {x: T, y: T, u: S, v: S}")
+                   .match(ndt::type(
+                       "100 * {x: ?int32, y: ?int32, u: ?int16, v: int16}")));
 }
 
 TEST(TypePatternMatch, ArrFuncProto)
 {
-  EXPECT_TRUE(ndt::type("() -> void").matches(ndt::type("() -> void")));
-  EXPECT_TRUE(ndt::type("() -> T").matches(ndt::type("() -> void")));
-  EXPECT_FALSE(ndt::type("() -> void").matches(ndt::type("() -> int32")));
-  EXPECT_FALSE(ndt::type("() -> void").matches(ndt::type("(int32) -> void")));
-  EXPECT_FALSE(ndt::type("(int32) -> void").matches(ndt::type("() -> void")));
-  EXPECT_TRUE(ndt::type("() -> T").matches(ndt::type("() -> float32")));
-  EXPECT_TRUE(ndt::type("(T) -> T").matches(ndt::type("(float32) -> float32")));
-  EXPECT_TRUE(ndt::type("(S) -> T").matches(ndt::type("(int32) -> float32")));
-  EXPECT_TRUE(ndt::type("(S, A... * 2 * int16) -> T").matches(
-      ndt::type("(int32, 5 * var * 2 * int16) -> float32")));
+  EXPECT_TYPE_MATCH("() -> void", "() -> void");
+  EXPECT_TYPE_MATCH("() -> T", "() -> void");
+  EXPECT_FALSE(ndt::type("() -> void").match(ndt::type("() -> int32")));
+  EXPECT_FALSE(ndt::type("() -> void").match(ndt::type("(int32) -> void")));
+  EXPECT_FALSE(ndt::type("(int32) -> void").match(ndt::type("() -> void")));
+  EXPECT_TYPE_MATCH("() -> T", "() -> float32");
+  EXPECT_TYPE_MATCH("(T) -> T", "(float32) -> float32");
+  EXPECT_TYPE_MATCH("(S) -> T", "(int32) -> float32");
+  EXPECT_TYPE_MATCH("(S, A... * 2 * int16) -> T",
+                    "(int32, 5 * var * 2 * int16) -> float32");
 
-  EXPECT_FALSE(ndt::type("(int32) -> float32").matches(ndt::type("() -> T")));
-  EXPECT_FALSE(ndt::type("() -> float32").matches(ndt::type("(T) -> T")));
-  EXPECT_FALSE(ndt::type("(int32) -> float32").matches(ndt::type("(T) -> T")));
+  EXPECT_FALSE(ndt::type("(int32) -> float32").match(ndt::type("() -> T")));
+  EXPECT_FALSE(ndt::type("() -> float32").match(ndt::type("(T) -> T")));
+  EXPECT_FALSE(ndt::type("(int32) -> float32").match(ndt::type("(T) -> T")));
   EXPECT_FALSE(ndt::type("(int32, 5 * var * 2 * int16) -> float32")
-                   .matches(ndt::type("(S, M * 2 * int16) -> T")));
+                   .match(ndt::type("(S, M * 2 * int16) -> T")));
 }
 
 TEST(TypePatternMatch, VariadicArrFuncProto)
 {
-  EXPECT_TRUE(ndt::type("(...) -> void").matches(ndt::type("() -> void")));
-  EXPECT_FALSE(ndt::type("() -> void").matches(ndt::type("(...) -> void")));
-  EXPECT_TRUE(
-      ndt::type("(...) -> void").matches(ndt::type("(kw: int32) -> void")));
-  EXPECT_TRUE(ndt::type("(int32, kw: T, ...) -> void").matches(
-      ndt::type("(int32, kw: int32, x: float64) -> void")));
-  EXPECT_FALSE(ndt::type("(int32, wk: T, ...) -> void").matches(
-      ndt::type("(int32, kw: int32, x: float64) -> void")));
-  EXPECT_TRUE(ndt::type("(...) -> void")
-                  .matches(ndt::type("(int32, ..., kw: int32, ...) -> void")));
-  EXPECT_TRUE(ndt::type("(S, ...) -> T")
-                  .matches(ndt::type("(int32, float32) -> float32")));
-  EXPECT_TRUE(ndt::type("(Fixed**N * T, ..., func: (N * T) -> R) -> R").matches(
-      ndt::type(
-          "(2 * 3 * 4 * int32, float64, func: (3 * int32) -> bool) -> bool")));
+  EXPECT_TYPE_MATCH("(...) -> void", "() -> void");
+  EXPECT_FALSE(ndt::type("() -> void").match(ndt::type("(...) -> void")));
+  EXPECT_TYPE_MATCH("(...) -> void", "(kw: int32) -> void");
+  EXPECT_TYPE_MATCH("(int32, kw: T, ...) -> void",
+                    "(int32, kw: int32, x: float64) -> void");
+  EXPECT_FALSE(ndt::type("(int32, wk: T, ...) -> void")
+                   .match(ndt::type("(int32, kw: int32, x: float64) -> void")));
+  EXPECT_TYPE_MATCH("(...) -> void", "(int32, ..., kw: int32, ...) -> void");
+  EXPECT_TYPE_MATCH("(S, ...) -> T", "(int32, float32) -> float32");
+  EXPECT_TYPE_MATCH(
+      "(Fixed**N * T, ..., func: (N * T) -> R) -> R",
+      "(2 * 3 * 4 * int32, float64, func: (3 * int32) -> bool) -> bool");
 }
 
 TEST(TypePatternMatch, NestedArrFuncProto)
 {
-  EXPECT_TRUE(ndt::type("(N * S, (M * S) -> T) -> N * T").matches(
-      ndt::type("(3 * int32, (2 * int32) -> float64) -> 3 * float64")));
-  EXPECT_FALSE(ndt::type("(N * S, (M * S) -> T) -> N * T").matches(
-      ndt::type("(3 * int32, (2 * float64) -> float64) -> 3 * float64")));
+  EXPECT_TYPE_MATCH("(N * S, (M * S) -> T) -> N * T",
+                    "(3 * int32, (2 * int32) -> float64) -> 3 * float64");
+  EXPECT_FALSE(
+      ndt::type("(N * S, (M * S) -> T) -> N * T")
+          .match(ndt::type(
+              "(3 * int32, (2 * float64) -> float64) -> 3 * float64")));
   EXPECT_FALSE(ndt::type("(3 * int32, (2 * int32) -> float64) -> 2 * float64")
-                   .matches(ndt::type("(N * S, (M * S) -> T) -> N * T")));
-  EXPECT_TRUE(ndt::type("(N * S, (M * S) -> T) -> N * T").matches(
-      ndt::type("(3 * int32, (2 * int32) -> float64) -> 3 * float64")));
-  EXPECT_TRUE(ndt::type("(N * S, func: (M * S) -> T) -> N * T").matches(
-      ndt::type("(3 * int32, func: (2 * int32) -> float64) -> 3 * float64")));
-  EXPECT_FALSE(ndt::type("(N * S, funk: (M * S) -> T) -> N * T").matches(
-      ndt::type("(3 * int32, func: (2 * int32) -> float64) -> 3 * float64")));
+                   .match(ndt::type("(N * S, (M * S) -> T) -> N * T")));
+  EXPECT_TYPE_MATCH("(N * S, (M * S) -> T) -> N * T",
+                    "(3 * int32, (2 * int32) -> float64) -> 3 * float64");
+  EXPECT_TYPE_MATCH("(N * S, func: (M * S) -> T) -> N * T",
+                    "(3 * int32, func: (2 * int32) -> float64) -> 3 * float64");
+  EXPECT_FALSE(
+      ndt::type("(N * S, funk: (M * S) -> T) -> N * T")
+          .match(ndt::type(
+              "(3 * int32, func: (2 * int32) -> float64) -> 3 * float64")));
 }
 
 TEST(TypePatternMatch, Strided)
 {
   // cfixed and fixed can match against strided
-  EXPECT_TRUE(
-      ndt::type("Fixed * int32").matches(ndt::type("cfixed[3] * int32")));
-  EXPECT_TRUE(ndt::type("Fixed * int32").matches(ndt::type("3 * int32")));
+  EXPECT_TYPE_MATCH("Fixed * int32", "cfixed[3] * int32");
+  EXPECT_TYPE_MATCH("Fixed * int32", "3 * int32");
   // cfixed can match against strided if the sizes match
-  EXPECT_TRUE(ndt::type("cfixed[3] * int32").matches(ndt::type("3 * int32")));
+  EXPECT_TYPE_MATCH("cfixed[3] * int32", "3 * int32");
   // Things do not hold in other cases
-  EXPECT_FALSE(ndt::type("3 * int32").matches(ndt::type("cfixed[3] * int32")));
-  EXPECT_FALSE(ndt::type("cfixed[3] * int32").matches(ndt::type("4 * int32")));
+  EXPECT_FALSE(ndt::type("3 * int32").match(ndt::type("cfixed[3] * int32")));
+  EXPECT_FALSE(ndt::type("cfixed[3] * int32").match(ndt::type("4 * int32")));
 }
 
 TEST(TypePatternMatch, Pow)
 {
   // Match pow_dimsym against itself
-  EXPECT_TRUE(
-      ndt::type("Fixed**N * int32").matches(ndt::type("Fixed**N * int32")));
-  EXPECT_TRUE(
-      ndt::type("Fixed**N * int32").matches(ndt::type("Fixed**M * int32")));
+  EXPECT_TYPE_MATCH("Fixed**N * int32", "Fixed**N * int32");
+  EXPECT_TYPE_MATCH("Fixed**N * int32", "Fixed**M * int32");
   // Match fixed_dim against fixed_dimsym within the power's base
-  EXPECT_TRUE(ndt::type("Fixed**N * int32").matches(ndt::type("3**N * int32")));
-  EXPECT_TRUE(ndt::type("Fixed**M * int32").matches(ndt::type("3**N * int32")));
+  EXPECT_TYPE_MATCH("Fixed**N * int32", "3**N * int32");
+  EXPECT_TYPE_MATCH("Fixed**M * int32", "3**N * int32");
   // Ensure that the typevar D is constrained in the power's base
-  EXPECT_TRUE(ndt::type("D * D**N * int32")
-                  .matches(ndt::type("Fixed * Fixed * Fixed * int32")));
+  EXPECT_TYPE_MATCH("D * D**N * int32", "Fixed * Fixed * Fixed * int32");
 
-  EXPECT_TRUE(
-      ndt::type("D * D**N * int32").matches(ndt::type("3 * 3 * 3 * int32")));
+  EXPECT_TYPE_MATCH("D * D**N * int32", "3 * 3 * 3 * int32");
   EXPECT_FALSE(
-      ndt::type("D * D**N * int32").matches(ndt::type("2 * 3 * 3 * int32")));
+      ndt::type("D * D**N * int32").match(ndt::type("2 * 3 * 3 * int32")));
   EXPECT_FALSE(
-      ndt::type("2 * 2 * 3 * int32").matches(ndt::type("D * D**N * int32")));
+      ndt::type("2 * 2 * 3 * int32").match(ndt::type("D * D**N * int32")));
   // Make sure an exponent of zero works as expected
-  EXPECT_TRUE(
-      ndt::type("D**N * Fixed * int32").matches(ndt::type("5 * int32")));
-  EXPECT_TRUE(
-      ndt::type("3**N * Fixed * int32").matches(ndt::type("2 * int32")));
-  EXPECT_TRUE(ndt::type("D**N * int32").matches(ndt::type("int32")));
-  EXPECT_TRUE(ndt::type("3**N * int32").matches(ndt::type("int32")));
-  EXPECT_TRUE(
-      ndt::type("D**N * 3 * D * int32").matches(ndt::type("3 * 4 * int32")));
-  EXPECT_TRUE(
-      ndt::type("D**N * N * D * int32").matches(ndt::type("0 * 4 * int32")));
+  EXPECT_TYPE_MATCH("D**N * Fixed * int32", "5 * int32");
+  EXPECT_TYPE_MATCH("3**N * Fixed * int32", "2 * int32");
+  EXPECT_TYPE_MATCH("D**N * int32", "int32");
+  EXPECT_TYPE_MATCH("3**N * int32", "int32");
+  EXPECT_TYPE_MATCH("D**N * 3 * D * int32", "3 * 4 * int32");
+  EXPECT_TYPE_MATCH("D**N * N * D * int32", "0 * 4 * int32");
   // Can't have a negative exponent
-  EXPECT_FALSE(ndt::type("int32").matches(ndt::type("D**N * E * int32")));
+  EXPECT_FALSE(ndt::type("int32").match(ndt::type("D**N * E * int32")));
 }
 
 TEST(TypePatternMatch, TypeVarConstructed)
 {
 #ifdef DYND_CUDA
-  EXPECT_TRUE(ndt::type("M[int32]").matches(ndt::type("cuda_device[int32]")));
-//  EXPECT_TRUE(ndt::type("cuda_device[10 * 5 * int32]")
-//                .matches(ndt::type("M[10 * 5 * int32]")));
-// EXPECT_TRUE(
-//   ndt::type("cuda_device[7 * int32]").matches(ndt::type("M[Dims... * T]")));
+  EXPECT_TYPE_MATCH("M[int32]", "cuda_device[int32]");
+// EXPECT_TYPE_MATCH("M[10 * 5 * int32]", "cuda_device[10 * 5 * int32]");
+// EXPECT_TYPE_MATCH("M[Dims... * T]", "cuda_device[7 * int32]");
 #endif
 }


### PR DESCRIPTION
The previous naming was so "tp.matches(pattern)" intuitively
reads as "tp matches pattern". With the order switched, this no
longer fits that intuition. "pattern.match(tp)" seems a little bit
better, as "match tp against pattern".

Also marked a few places where the matching code looked suspicious.