### PR TITLE
Fix build errors from maybe-uninitialized warnings

### DIFF
--- a/include/dynd/config.hpp
+++ b/include/dynd/config.hpp
@@ -52,6 +52,13 @@
 
 #define DYND_IGNORE_UNUSED(NAME) NAME __attribute__((unused))
 
+// Ignore erroneous maybe-uninitizlized
+// warnings on a given line or code block.
+#define DYND_IGNORE_MAYBE_UNINITIALIZED                                        \
+  _Pragma("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
+#define DYND_END_IGNORE_MAYBE_UNINITIALIZED                                    \
+  _Pragma("GCC diagnostic pop")  
+
 #define DYND_CONSTEXPR constexpr
 
 #define DYND_ISSPACE isspace
@@ -538,6 +545,11 @@ https://connect.microsoft.com/VisualStudio/feedback/details/1045260/unpacking-st
 
 #ifndef DYND_IGNORE_UNUSED
 #define DYND_IGNORE_UNUSED(NAME) NAME
+#endif
+
+#ifndef DYND_IGNORE_MAYBE_UNINITIALIZED
+#define DYND_IGNORE_MAYBE_UNINITIALIZED
+#define DYND_END_IGNORE_MAYBE_UNINITIALIZED
 #endif
 
 #define DYND_INC_IF_NOT_NULL(POINTER, OFFSET)                                  \

--- a/include/dynd/float16.hpp
+++ b/include/dynd/float16.hpp
@@ -113,7 +113,9 @@ public:
 
   DYND_CUDA_HOST_DEVICE explicit operator int16() const
   {
+    DYND_IGNORE_MAYBE_UNINITIALIZED
     return static_cast<int16>(halfbits_to_float(m_bits));
+    DYND_END_IGNORE_MAYBE_UNINITIALIZED
   }
 
   DYND_CUDA_HOST_DEVICE explicit operator int32() const
@@ -152,7 +154,9 @@ public:
 
   DYND_CUDA_HOST_DEVICE operator float32() const
   {
+    DYND_IGNORE_MAYBE_UNINITIALIZED
     return halfbits_to_float(m_bits);
+    DYND_END_IGNORE_MAYBE_UNINITIALIZED
   }
 
   DYND_CUDA_HOST_DEVICE explicit operator float64() const

--- a/src/dynd/types/expr_type.cpp
+++ b/src/dynd/types/expr_type.cpp
@@ -232,7 +232,9 @@ struct expr_type_offset_applier_extra
   {
     char *src_modified[N];
     for (int i = 0; i < N; ++i) {
+      DYND_IGNORE_MAYBE_UNINITIALIZED
       src_modified[i] = src[i] + offsets[i];
+      DYND_END_IGNORE_MAYBE_UNINITIALIZED
     }
     ckernel_prefix *echild = this->get_child_ckernel();
     expr_single_t opchild = echild->get_function<expr_single_t>();


### PR DESCRIPTION
This is the best version I was able to get for suppressing the maybe-uninitialized errors. Supposedly [according to this](http://stackoverflow.com/questions/5080848/disable-gcc-may-be-used-uninitialized-on-a-particular-variable), erroneous maybe-uninitialized and uninitialized errors aren't uncommon since the compiler is only able to use heuristics to provide a best guess as to whether or not they should be applied. I'm pretty sure the warning in expr_type.cpp was erroneous. As near as I can tell, the second warning in the float16 header is one where we may actually *want* to allow the cast to work with uninitialized data. A second pair of eyes would be greatly appreciated there though.