### PR TITLE
Include missing header file needed for tests.

### DIFF
--- a/tests/types/test_time_type.cpp
+++ b/tests/types/test_time_type.cpp
@@ -15,6 +15,7 @@
 #include <dynd/types/string_type.hpp>
 #include <dynd/types/convert_type.hpp>
 #include <dynd/types/struct_type.hpp>
+#include <dynd/gfunc/call_callable.hpp>
 
 using namespace std;
 using namespace dynd;


### PR DESCRIPTION
This is a straightforward fix for a compile error that was showing up with gcc 5.1. See https://github.com/libdynd/libdynd/issues/467.