### PR TITLE
Switched to a more portable shebang in libdynd-config

### DIFF
--- a/libdynd-config.in
+++ b/libdynd-config.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "$1" == "-lflag" ]; then
     echo @DYND_LINK_FLAG@


### PR DESCRIPTION
This fixes a weird issue I've kept running into on my BSD machine. When libdynd-config was being called from within the cmake build process the shebang in libdynd-config assumed bash was located in /usr/bin. That is true on Mac and Linux, but not on BSD. This change makes it so that the shebang pulls the bash path from the user's environment rather than assuming it is in a particular place.