### PR TITLE
Clang 3.7 compilation fixes

### DIFF
--- a/src/dynd/array_range.cpp
+++ b/src/dynd/array_range.cpp
@@ -138,7 +138,7 @@ nd::array dynd::nd::range(const ndt::type &scalar_tp, const void *beginval,
                                                                    stepval);   \
     nd::array result = nd::empty(dim_size, scalar_tp);                         \
     range_specialization<type>::range(beginval, stepval, result);              \
-    return std::move(result);                                                  \
+    return result;                                                             \
   }
 
   switch (scalar_tp.get_type_id()) {
@@ -257,14 +257,14 @@ nd::array dynd::nd::linspace(const ndt::type &dt, const void *startval,
     linspace_specialization(*reinterpret_cast<const float *>(startval),
                             *reinterpret_cast<const float *>(stopval), count,
                             result);
-    return std::move(result);
+    return result;
   }
   case float64_type_id: {
     nd::array result = nd::empty(count, dt);
     linspace_specialization(*reinterpret_cast<const double *>(startval),
                             *reinterpret_cast<const double *>(stopval), count,
                             result);
-    return std::move(result);
+    return result;
   }
   case complex_float32_type_id: {
     nd::array result = nd::empty(count, dt);
@@ -272,7 +272,7 @@ nd::array dynd::nd::linspace(const ndt::type &dt, const void *startval,
         *reinterpret_cast<const dynd::complex<float> *>(startval),
         *reinterpret_cast<const dynd::complex<float> *>(stopval), count,
         result);
-    return std::move(result);
+    return result;
   }
   case complex_float64_type_id: {
     nd::array result = nd::empty(count, dt);
@@ -280,7 +280,7 @@ nd::array dynd::nd::linspace(const ndt::type &dt, const void *startval,
         *reinterpret_cast<const dynd::complex<double> *>(startval),
         *reinterpret_cast<const dynd::complex<double> *>(stopval), count,
         result);
-    return std::move(result);
+    return result;
   }
   default:
     break;

--- a/src/dynd/types/typevar_type.cpp
+++ b/src/dynd/types/typevar_type.cpp
@@ -217,5 +217,5 @@ nd::array ndt::make_typevar_range(const char *name, intptr_t count)
     result_ptr[i] = typevar_type::make(s);
     s[s.size() - 1]++;
   }
-  return move(result);
+  return result;
 }


### PR DESCRIPTION
This removes a handful of unnecessary calls to std::move that cause warnings with the new clang/llvm. The new compiler warns if an unnecessary call to std::move prevents return value optimization. I've been aware of the issue for some time, but since Clang 3.7 is now officially released, adding this seemed sensible.