### PR TITLE
exceptions to subclass from std::exception again

### DIFF
--- a/include/dynd/exceptions.hpp
+++ b/include/dynd/exceptions.hpp
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <vector>
+#include <stdexcept>
 
 #include <dynd/irange.hpp>
 #include <dynd/string_encodings.hpp>
@@ -22,7 +23,7 @@ namespace nd {
   class array;
 } // namespace nd
 
-class DYND_API dynd_exception {
+class DYND_API dynd_exception : public std::exception {
 protected:
   std::string m_message, m_what;
 


### PR DESCRIPTION
I've spent a decent bit of time hunting for the bug causing bad exception handling with dynd-python in the Travis build. I haven't been able to isolate it yet, so this patch allows dynd exceptions to subclass from std::exception again to get our build working while I dig into this a little more.