### PR TITLE
Separate exceptions from standard library

### DIFF
--- a/include/dynd/auxiliary_data.hpp
+++ b/include/dynd/auxiliary_data.hpp
@@ -105,7 +105,7 @@ namespace detail {
         const auxiliary_data_holder<T> *adh = reinterpret_cast<const auxiliary_data_holder<T> *>(auxdata);
         try {
             return reinterpret_cast<AuxDataBase *>(new auxiliary_data_holder<T>(*adh));
-        } catch(const std::exception&) {
+        } catch(...) {
             return 0;
         }
     }

--- a/include/dynd/buffer_storage.hpp
+++ b/include/dynd/buffer_storage.hpp
@@ -56,7 +56,7 @@ class DYND_API buffer_storage {
           m_arrmeta = new char[metasize];
           m_type.extended()->arrmeta_default_construct(m_arrmeta, true);
         }
-        catch (const std::exception &) {
+        catch (...) {
           delete[] m_storage;
           delete[] m_arrmeta;
           throw;

--- a/include/dynd/exceptions.hpp
+++ b/include/dynd/exceptions.hpp
@@ -23,11 +23,14 @@ namespace nd {
   class array;
 } // namespace nd
 
-class DYND_API dynd_exception : public std::exception {
+// Avoid subclassing std::exception to not have
+// to export std::exception across dll boundaries.
+class DYND_API dynd_exception {
 protected:
   std::string m_message, m_what;
 
 public:
+  dynd_exception() {}
   dynd_exception(const char *exception_name, const std::string &msg)
       : m_message(msg), m_what(std::string() + exception_name + ": " + msg)
   {

--- a/src/dynd/func/callable.cpp
+++ b/src/dynd/func/callable.cpp
@@ -34,25 +34,17 @@ struct unary_assignment_ck : nd::base_virtual_kernel<unary_assignment_ck> {
               const nd::array *DYND_UNUSED(kwds),
               const std::map<std::string, ndt::type> &DYND_UNUSED(tp_vars))
   {
-    try
-    {
-      assign_error_mode errmode =
-          *reinterpret_cast<assign_error_mode *>(static_data);
-      if (errmode == ectx->errmode) {
-        return make_assignment_kernel(ckb, ckb_offset, dst_tp, dst_arrmeta,
-                                      src_tp[0], src_arrmeta[0], kernreq, ectx);
-      } else {
-        eval::eval_context ectx_tmp(*ectx);
-        ectx_tmp.errmode = errmode;
-        return make_assignment_kernel(ckb, ckb_offset, dst_tp, dst_arrmeta,
-                                      src_tp[0], src_arrmeta[0], kernreq,
-                                      &ectx_tmp);
-      }
-    }
-    catch (const std::exception &e)
-    {
-      cout << "exception: " << e.what() << endl;
-      throw;
+    assign_error_mode errmode =
+      *reinterpret_cast<assign_error_mode *>(static_data);
+    if (errmode == ectx->errmode) {
+      return make_assignment_kernel(ckb, ckb_offset, dst_tp, dst_arrmeta,
+                                    src_tp[0], src_arrmeta[0], kernreq, ectx);
+    } else {
+      eval::eval_context ectx_tmp(*ectx);
+      ectx_tmp.errmode = errmode;
+      return make_assignment_kernel(ckb, ckb_offset, dst_tp, dst_arrmeta,
+                                    src_tp[0], src_arrmeta[0], kernreq,
+                                    &ectx_tmp);
     }
   }
 };

--- a/src/dynd/json_parser.cpp
+++ b/src/dynd/json_parser.cpp
@@ -515,6 +515,9 @@ static void parse_number_json(const ndt::type &tp, const char *arrmeta,
     catch (const std::exception &e) {
       throw json_parse_error(rbegin, e.what(), tp);
     }
+    catch (const dynd::dynd_exception &e) {
+      throw json_parse_error(rbegin, e.what(), tp);
+    }
   } else {
     throw json_parse_error(rbegin, "expected a number", tp);
   }
@@ -554,6 +557,9 @@ static void parse_string_json(const ndt::type &tp, const char *arrmeta,
       }
     }
     catch (const std::exception &e) {
+      throw json_parse_error(skip_whitespace(rbegin, begin), e.what(), tp);
+    }
+    catch (const dynd::dynd_exception &e) {
       throw json_parse_error(skip_whitespace(rbegin, begin), e.what(), tp);
     }
   } else {
@@ -603,6 +609,9 @@ static void parse_datetime_json(const ndt::type &tp, const char *arrmeta,
     catch (const std::exception &e) {
       throw json_parse_error(skip_whitespace(rbegin, begin), e.what(), tp);
     }
+    catch (const dynd::dynd_exception &e) {
+      throw json_parse_error(skip_whitespace(rbegin, begin), e.what(), tp);
+    }
   } else {
     throw json_parse_error(begin, "expected a string", tp);
   }
@@ -640,6 +649,9 @@ static void parse_type(const ndt::type &tp, const char *DYND_UNUSED(arrmeta),
       *reinterpret_cast<ndt::type *>(out_data) = ndt::type(strbegin, strend);
     }
     catch (const std::exception &e) {
+      throw json_parse_error(skip_whitespace(rbegin, begin), e.what(), tp);
+    }
+    catch (const dynd::dynd_exception &e) {
       throw json_parse_error(skip_whitespace(rbegin, begin), e.what(), tp);
     }
   } else {
@@ -696,6 +708,9 @@ static void parse_option_json(const ndt::type &tp, const char *arrmeta,
           return;
         }
         catch (const exception &e) {
+          throw json_parse_error(saved_begin, e.what(), tp);
+        }
+        catch (const dynd::dynd_exception &e) {
           throw json_parse_error(saved_begin, e.what(), tp);
         }
       } else if (value_tp.get_kind() == bool_kind) {


### PR DESCRIPTION
This makes it so that exceptions no longer have to pass across the dll boundary.
Corresponding changes to dynd-python are in https://github.com/libdynd/dynd-python/pull/356.