### PR TITLE
Added support for some partial var dim reductions

### DIFF
--- a/tests/func/test_reduction.cpp
+++ b/tests/func/test_reduction.cpp
@@ -110,7 +110,7 @@ TEST(Reduction, BuiltinSum_Lift2D_StridedStrided_ReduceBroadcast_KeepDim)
                     kwds("axes", nd::array(initializer_list<int>{0}), "keepdims", true)));
 }
 
-TEST(Reduction, BuiltinSum_Lift2D_VarFixed_ReduceReduce)
+TEST(Reduction, FixedVar)
 {
   nd::callable f = nd::functional::reduction(nd::functional::apply([](double x, double y) { return x + y; }));
 
@@ -120,6 +120,18 @@ TEST(Reduction, BuiltinSum_Lift2D_VarFixed_ReduceReduce)
   a(2).vals() = {6, 7, 8, 9};
 
   EXPECT_ARRAY_EQ(45.0, f(a));
+}
+
+TEST(Reduction, FixedVarWithAxes)
+{
+  nd::callable f = nd::functional::reduction(nd::functional::apply([](double x, double y) { return x + y; }));
+
+  nd::array a = nd::empty("3 * var * float64");
+  a(0).vals() = {1, 2};
+  a(1).vals() = {3, 4, 5};
+  a(2).vals() = {6, 7, 8, 9};
+
+  EXPECT_ARRAY_EQ((nd::array{3.0, 12.0, 30.0}), f(a, kwds("axes", nd::array{1})));
 }
 
 TEST(Reduction, BuiltinSum_Lift3D_StridedStridedStrided_ReduceReduceReduce)


### PR DESCRIPTION
This is preliminary support for variable-sized dimension reductions along a subset of axes.

It also might be the missing piece for the favorite example of @mrocklin.