### PR TITLE
Visibility

### DIFF
--- a/include/dynd/config.hpp
+++ b/include/dynd/config.hpp
@@ -588,8 +588,8 @@ https://connect.microsoft.com/VisualStudio/feedback/details/1045260/unpacking-st
 namespace dynd {
 // These are defined in git_version.cpp, generated from
 // git_version.cpp.in by the CMake build configuration.
-extern const char dynd_git_sha1[];
-extern const char dynd_version_string[];
+extern DYND_API const char dynd_git_sha1[];
+extern DYND_API const char dynd_version_string[];
 } // namespace dynd
 
 // Check endian: define DYND_BIG_ENDIAN if big endian, otherwise assume little

--- a/include/dynd/func/arithmetic.hpp
+++ b/include/dynd/func/arithmetic.hpp
@@ -67,7 +67,7 @@ namespace nd {
   callable arithmetic_operator<FuncType, KernelType, 1>::children
       [DYND_TYPE_ID_MAX + 1];
 
-  extern struct plus : arithmetic_operator<plus, plus_kernel, 1> {
+  extern DYND_API struct plus : arithmetic_operator<plus, plus_kernel, 1> {
     static std::string what(const ndt::type &src0_type)
     {
       std::stringstream ss;
@@ -78,7 +78,7 @@ namespace nd {
     }
   } plus;
 
-  extern struct minus : arithmetic_operator<minus, minus_kernel, 1> {
+  extern DYND_API struct minus : arithmetic_operator<minus, minus_kernel, 1> {
     static std::string what(const ndt::type &src0_type)
     {
       std::stringstream ss;
@@ -152,7 +152,7 @@ namespace nd {
   callable arithmetic_operator<FuncType, KernelType, 2>::children
       [DYND_TYPE_ID_MAX + 1][DYND_TYPE_ID_MAX + 1];
 
-  extern struct add : arithmetic_operator<add, add_kernel, 2> {
+  extern DYND_API struct add : arithmetic_operator<add, add_kernel, 2> {
     static std::string what(const ndt::type &src0_tp, const ndt::type &src1_tp)
     {
       std::stringstream ss;
@@ -162,7 +162,7 @@ namespace nd {
     }
   } add;
 
-  extern struct subtract : arithmetic_operator<subtract, subtract_kernel, 2> {
+  extern DYND_API struct subtract : arithmetic_operator<subtract, subtract_kernel, 2> {
     static std::string what(const ndt::type &src0_tp, const ndt::type &src1_tp)
     {
       std::stringstream ss;
@@ -172,7 +172,7 @@ namespace nd {
     }
   } subtract;
 
-  extern struct multiply : arithmetic_operator<multiply, multiply_kernel, 2> {
+  extern DYND_API struct multiply : arithmetic_operator<multiply, multiply_kernel, 2> {
     static std::string what(const ndt::type &src0_tp, const ndt::type &src1_tp)
     {
       std::stringstream ss;
@@ -182,7 +182,7 @@ namespace nd {
     }
   } multiply;
 
-  extern struct divide : arithmetic_operator<divide, divide_kernel, 2> {
+  extern DYND_API struct divide : arithmetic_operator<divide, divide_kernel, 2> {
     static std::string what(const ndt::type &src0_tp, const ndt::type &src1_tp)
     {
       std::stringstream ss;
@@ -244,11 +244,11 @@ namespace nd {
   callable compound_arithmetic_operator<FuncType, KernelType>::children
       [DYND_TYPE_ID_MAX + 1][DYND_TYPE_ID_MAX + 1];
 
-  extern struct compound_add
+  extern DYND_API struct compound_add
       : compound_arithmetic_operator<compound_add, compound_add_kernel_t> {
   } compound_add;
 
-  extern struct compound_div
+  extern DYND_API struct compound_div
       : compound_arithmetic_operator<compound_div, compound_div_kernel_t> {
   } compound_div;
 

--- a/include/dynd/func/assignment.hpp
+++ b/include/dynd/func/assignment.hpp
@@ -89,7 +89,7 @@ make_assignment_kernel(void *ckb, intptr_t ckb_offset, const ndt::type &dst_tp,
                        const char *src_arrmeta, kernel_request_t kernreq,
                        const eval::eval_context *ectx);
 
-DYND_API inline intptr_t
+inline intptr_t
 make_assignment_kernel(void *ckb, intptr_t ckb_offset, const ndt::type &dst_tp,
                        const char *dst_arrmeta, const ndt::type *src_tp,
                        const char *const *src_arrmeta, kernel_request_t kernreq,

--- a/include/dynd/func/assignment.hpp
+++ b/include/dynd/func/assignment.hpp
@@ -49,14 +49,14 @@ namespace nd {
   template <typename T>
   callable declop<T, 2>::default_child;
 
-  extern struct assign : declop<assign, 2> {
+  extern DYND_API struct assign : declop<assign, 2> {
     static callable &overload(const ndt::type &dst_tp, const ndt::type &src0_tp)
     {
       get();
       return children[dst_tp.get_type_id()][src0_tp.get_type_id()];
     }
 
-    static std::map<std::array<type_id_t, 2>, callable> make_children();
+    static DYND_API std::map<std::array<type_id_t, 2>, callable> make_children();
   } assign;
 
 } // namespace dynd::nd

--- a/include/dynd/func/comparison.hpp
+++ b/include/dynd/func/comparison.hpp
@@ -89,14 +89,14 @@ namespace nd {
   callable comparison_operator<T, K, 2>::children[DYND_TYPE_ID_MAX + 1]
                                                  [DYND_TYPE_ID_MAX + 1];
 
-  extern struct less : comparison_operator<less, less_kernel, 2> {
+  extern DYND_API struct less : comparison_operator<less, less_kernel, 2> {
   } less;
 
-  extern struct less_equal
+  extern DYND_API struct less_equal
       : comparison_operator<less_equal, less_equal_kernel, 2> {
   } less_equal;
 
-  extern struct equal : comparison_operator<equal, equal_kernel, 2> {
+  extern DYND_API struct equal : comparison_operator<equal, equal_kernel, 2> {
     static std::map<std::array<type_id_t, 2>, callable> make_children()
     {
       std::map<std::array<type_id_t, 2>, callable> children =
@@ -120,7 +120,7 @@ namespace nd {
     }
   } equal;
 
-  extern struct not_equal
+  extern DYND_API struct not_equal
       : comparison_operator<not_equal, not_equal_kernel, 2> {
     static std::map<std::array<type_id_t, 2>, callable> make_children()
     {
@@ -143,11 +143,11 @@ namespace nd {
     }
   } not_equal;
 
-  extern struct greater_equal
+  extern DYND_API struct greater_equal
       : comparison_operator<greater_equal, greater_equal_kernel, 2> {
   } greater_equal;
 
-  extern struct greater : comparison_operator<greater, greater_kernel, 2> {
+  extern DYND_API struct greater : comparison_operator<greater, greater_kernel, 2> {
   } greater;
 
 } // namespace dynd::nd

--- a/include/dynd/func/fft.hpp
+++ b/include/dynd/func/fft.hpp
@@ -100,20 +100,20 @@ namespace nd {
 
 #endif
 
-  extern struct fft : declfunc<fft> {
-    static callable make();
+  extern DYND_API struct fft : declfunc<fft> {
+    static DYND_API callable make();
   } fft;
 
-  extern struct ifft : declfunc<ifft> {
-    static callable make();
+  extern DYND_API struct ifft : declfunc<ifft> {
+    static DYND_API callable make();
   } ifft;
 
-  extern struct rfft : declfunc<rfft> {
-    static callable make();
+  extern DYND_API struct rfft : declfunc<rfft> {
+    static DYND_API callable make();
   } rfft;
 
-  extern struct irfft : declfunc<irfft> {
-    static callable make();
+  extern DYND_API struct irfft : declfunc<irfft> {
+    static DYND_API callable make();
   } irfft;
 
   /**

--- a/include/dynd/func/max.hpp
+++ b/include/dynd/func/max.hpp
@@ -10,8 +10,8 @@
 namespace dynd {
 namespace nd {
 
-  extern struct max : declfunc<max> {
-    static callable make();
+  extern DYND_API struct max : declfunc<max> {
+    static DYND_API callable make();
   } max;
 
 } // namespace dynd::nd

--- a/include/dynd/func/take_by_pointer.hpp
+++ b/include/dynd/func/take_by_pointer.hpp
@@ -17,8 +17,8 @@ namespace nd {
    * operation, but stores the pointers.
    *
    */
-  extern struct take_by_pointer : declfunc<take_by_pointer> {
-    static callable make();
+  extern DYND_API struct take_by_pointer : declfunc<take_by_pointer> {
+    static DYND_API callable make();
   } take_by_pointer;
 
 } // namespace dynd::nd

--- a/include/dynd/type.hpp
+++ b/include/dynd/type.hpp
@@ -90,7 +90,6 @@ namespace ndt {
 
   } // namespace dynd::ndt::detail
 
-  DYND_API type make_pointer_type(const type &target_tp);
   DYND_API type make_fixed_dim(size_t dim_size, const type &element_tp);
 
   /**

--- a/include/dynd/type.hpp
+++ b/include/dynd/type.hpp
@@ -1260,7 +1260,7 @@ namespace ndt {
    * static_builtin_types[type_id_of<int>::value] as a fast
    * way to get a const reference to its type.
    */
-  extern const type static_builtin_types[builtin_type_id_count];
+  extern DYND_API const type static_builtin_types[builtin_type_id_count];
 
   DYND_API std::ostream &operator<<(std::ostream &o, const type &rhs);
 

--- a/include/dynd/types/base_type.hpp
+++ b/include/dynd/types/base_type.hpp
@@ -819,9 +819,9 @@ namespace ndt {
   }
 
   namespace detail {
-    extern uint8_t builtin_data_sizes[builtin_type_id_count];
-    extern uint8_t builtin_kinds[builtin_type_id_count];
-    extern uint8_t builtin_data_alignments[builtin_type_id_count];
+    extern DYND_API uint8_t builtin_data_sizes[builtin_type_id_count];
+    extern DYND_API uint8_t builtin_kinds[builtin_type_id_count];
+    extern DYND_API uint8_t builtin_data_alignments[builtin_type_id_count];
   } // namespace dynd::ndt::detail
 
   /**

--- a/src/dynd/func/arithmetic.cpp
+++ b/src/dynd/func/arithmetic.cpp
@@ -8,42 +8,42 @@
 using namespace std;
 using namespace dynd;
 
-struct nd::plus nd::plus;
+DYND_API struct nd::plus nd::plus;
 
 nd::array nd::operator+(const array &a0)
 {
   return plus(a0);
 }
 
-struct nd::minus nd::minus;
+DYND_API struct nd::minus nd::minus;
 
 nd::array nd::operator-(const array &a0)
 {
   return minus(a0);
 }
 
-struct nd::add nd::add;
+DYND_API struct nd::add nd::add;
 
 nd::array nd::operator+(const array &a0, const array &a1)
 {
   return add(a0, a1);
 }
 
-struct nd::subtract nd::subtract;
+DYND_API struct nd::subtract nd::subtract;
 
 nd::array nd::operator-(const array &a0, const array &a1)
 {
   return subtract(a0, a1);
 }
 
-struct nd::multiply nd::multiply;
+DYND_API struct nd::multiply nd::multiply;
 
 nd::array nd::operator*(const array &a0, const array &a1)
 {
   return multiply(a0, a1);
 }
 
-struct nd::divide nd::divide;
+DYND_API struct nd::divide nd::divide;
 
 nd::array nd::operator/(const array &a0, const array &a1)
 {
@@ -60,9 +60,9 @@ nd::array &nd::array::operator+=(const array &rhs)
 }
 */
 
-struct nd::compound_add nd::compound_add;
+DYND_API struct nd::compound_add nd::compound_add;
 
-struct nd::compound_div nd::compound_div;
+DYND_API struct nd::compound_div nd::compound_div;
 
 nd::array &nd::array::operator/=(const array &rhs)
 {

--- a/src/dynd/func/assignment.cpp
+++ b/src/dynd/func/assignment.cpp
@@ -9,7 +9,7 @@
 using namespace std;
 using namespace dynd;
 
-map<array<type_id_t, 2>, nd::callable> nd::assign::make_children()
+DYND_API map<array<type_id_t, 2>, nd::callable> nd::assign::make_children()
 {
   typedef type_id_sequence<
       bool_type_id, int8_type_id, int16_type_id, int32_type_id, int64_type_id,
@@ -24,7 +24,7 @@ map<array<type_id_t, 2>, nd::callable> nd::assign::make_children()
   return children2;
 }
 
-struct nd::assign nd::assign;
+DYND_API struct nd::assign nd::assign;
 
 size_t dynd::make_pod_typed_data_assignment_kernel(void *ckb,
                                                    intptr_t ckb_offset,

--- a/src/dynd/func/comparison.cpp
+++ b/src/dynd/func/comparison.cpp
@@ -8,42 +8,42 @@
 using namespace std;
 using namespace dynd;
 
-struct nd::less nd::less;
+DYND_API struct nd::less nd::less;
 
 nd::array nd::operator<(const array &a0, const array &a1)
 {
   return less(a0, a1);
 }
 
-struct nd::less_equal nd::less_equal;
+DYND_API struct nd::less_equal nd::less_equal;
 
 nd::array nd::operator<=(const array &a0, const array &a1)
 {
   return less_equal(a0, a1);
 }
 
-struct nd::equal nd::equal;
+DYND_API struct nd::equal nd::equal;
 
 nd::array nd::operator==(const array &a0, const array &a1)
 {
   return equal(a0, a1);
 }
 
-struct nd::not_equal nd::not_equal;
+DYND_API struct nd::not_equal nd::not_equal;
 
 nd::array nd::operator!=(const array &a0, const array &a1)
 {
   return not_equal(a0, a1);
 }
 
-struct nd::greater_equal nd::greater_equal;
+DYND_API struct nd::greater_equal nd::greater_equal;
 
 nd::array nd::operator>=(const array &a0, const array &a1)
 {
   return greater_equal(a0, a1);
 }
 
-struct nd::greater nd::greater;
+DYND_API struct nd::greater nd::greater;
 
 nd::array nd::operator>(const array &a0, const array &a1)
 {

--- a/src/dynd/func/fft.cpp
+++ b/src/dynd/func/fft.cpp
@@ -10,7 +10,7 @@
 using namespace std;
 using namespace dynd;
 
-nd::callable nd::fft::make()
+DYND_API nd::callable nd::fft::make()
 {
   std::vector<nd::callable> children;
 
@@ -38,7 +38,7 @@ nd::callable nd::fft::make()
 */
 }
 
-nd::callable nd::ifft::make()
+DYND_API nd::callable nd::ifft::make()
 {
   std::vector<nd::callable> children;
 
@@ -66,7 +66,7 @@ nd::callable nd::ifft::make()
 */
 }
 
-nd::callable nd::rfft::make()
+DYND_API nd::callable nd::rfft::make()
 {
 #ifdef DYND_FFTW
   return nd::callable::make<fftw_ck<fftw_complex, double>>(0);
@@ -75,7 +75,7 @@ nd::callable nd::rfft::make()
 #endif
 }
 
-nd::callable nd::irfft::make()
+DYND_API nd::callable nd::irfft::make()
 {
 #ifdef DYND_FFTW
   return nd::callable::make<fftw_ck<double, fftw_complex>>(0);
@@ -84,11 +84,11 @@ nd::callable nd::irfft::make()
 #endif
 }
 
-struct nd::fft nd::fft;
-struct nd::rfft nd::rfft;
+DYND_API struct nd::fft nd::fft;
+DYND_API struct nd::rfft nd::rfft;
 
-struct nd::ifft nd::ifft;
-struct nd::irfft nd::irfft;
+DYND_API struct nd::ifft nd::ifft;
+DYND_API struct nd::irfft nd::irfft;
 
 nd::array nd::fftshift(const nd::array &x)
 {

--- a/src/dynd/func/max.cpp
+++ b/src/dynd/func/max.cpp
@@ -12,7 +12,7 @@
 using namespace std;
 using namespace dynd;
 
-nd::callable nd::max::make()
+DYND_API nd::callable nd::max::make()
 {
   auto children = callable::make_all<max_kernel, arithmetic_type_ids>();
 
@@ -33,4 +33,4 @@ nd::callable nd::max::make()
       data_size_max(children)));
 }
 
-struct nd::max nd::max;
+DYND_API struct nd::max nd::max;

--- a/src/dynd/func/take_by_pointer.cpp
+++ b/src/dynd/func/take_by_pointer.cpp
@@ -144,7 +144,7 @@ struct take_by_pointer_virtual_ck
   }
 };
 
-nd::callable nd::take_by_pointer::make()
+DYND_API nd::callable nd::take_by_pointer::make()
 {
   return callable::make<take_by_pointer_virtual_ck>(
       ndt::callable_type::make(ndt::type("R * pointer[T]"),
@@ -152,4 +152,4 @@ nd::callable nd::take_by_pointer::make()
       0);
 }
 
-struct nd::take_by_pointer nd::take_by_pointer;
+DYND_API struct nd::take_by_pointer nd::take_by_pointer;

--- a/src/dynd/git_version.cpp.in
+++ b/src/dynd/git_version.cpp.in
@@ -12,8 +12,7 @@
 
 namespace dynd {
 
-const char dynd_git_sha1[] = DYND_GIT_SHA1;
-const char dynd_version_string[] = DYND_VERSION_STRING;
+const DYND_API char dynd_git_sha1[] = DYND_GIT_SHA1;
+const DYND_API char dynd_version_string[] = DYND_VERSION_STRING;
 
 } // namespace dynd
-

--- a/src/dynd/type.cpp
+++ b/src/dynd/type.cpp
@@ -72,7 +72,7 @@ char *dynd::iterdata_broadcasting_terminator_reset(iterdata_common *iterdata,
   return data;
 }
 
-const ndt::type ndt::static_builtin_types[builtin_type_id_count] = {
+const DYND_API ndt::type ndt::static_builtin_types[builtin_type_id_count] = {
     ndt::type(uninitialized_type_id),   ndt::type(bool_type_id),
     ndt::type(int8_type_id),            ndt::type(int16_type_id),
     ndt::type(int32_type_id),           ndt::type(int64_type_id),

--- a/src/dynd/types/base_type.cpp
+++ b/src/dynd/types/base_type.cpp
@@ -465,7 +465,7 @@ ndt::base_type::reverse_adapt_type(const type &DYND_UNUSED(value_tp),
 
 // Some information about the builtin types
 
-uint8_t ndt::detail::builtin_data_sizes[builtin_type_id_count] = {
+DYND_API uint8_t ndt::detail::builtin_data_sizes[builtin_type_id_count] = {
     0,                            sizeof(bool1),
     sizeof(int8),                 sizeof(int16),
     sizeof(int32),                sizeof(int64),
@@ -477,13 +477,13 @@ uint8_t ndt::detail::builtin_data_sizes[builtin_type_id_count] = {
     sizeof(dynd::complex<float>), sizeof(dynd::complex<double>),
     0};
 
-uint8_t ndt::detail::builtin_kinds[builtin_type_id_count] = {
+DYND_API uint8_t ndt::detail::builtin_kinds[builtin_type_id_count] = {
     void_kind, bool_kind,    sint_kind,    sint_kind, sint_kind,
     sint_kind, sint_kind,    uint_kind,    uint_kind, uint_kind,
     uint_kind, uint_kind,    real_kind,    real_kind, real_kind,
     real_kind, complex_kind, complex_kind, void_kind};
 
-uint8_t ndt::detail::builtin_data_alignments[builtin_type_id_count] = {
+DYND_API uint8_t ndt::detail::builtin_data_alignments[builtin_type_id_count] = {
     1,
     1,
     1,


### PR DESCRIPTION
This includes a few more visibility fixes that improve consistency in the symbols exported by the dll. It also fixes a few warnings when building with mingw.