### PR TITLE
Add a function for parsing generic datashape type constructor arguments

### DIFF
--- a/include/dynd/parser_util.hpp
+++ b/include/dynd/parser_util.hpp
@@ -405,8 +405,10 @@ inline bool parse_unsigned_int_no_ws(const char *&rbegin, const char *end,
 inline bool parse_int_no_ws(const char *&rbegin, const char *end, const char *&out_strbegin, const char *&out_strend)
 {
   const char *begin = rbegin;
+  const char *saved_begin = begin;
   parse_token(begin, end, '-');
   if (parse_unsigned_int_no_ws(begin, end, out_strbegin, out_strend)) {
+    out_strbegin = saved_begin;
     rbegin = begin;
     return true;
   }

--- a/include/dynd/parser_util.hpp
+++ b/include/dynd/parser_util.hpp
@@ -391,6 +391,29 @@ inline bool parse_unsigned_int_no_ws(const char *&rbegin, const char *end,
 }
 
 /**
+ * Without skipping whitespace, parses a signed integer.
+ *
+ * Example:
+ *     // Match a two digit month
+ *     const char *match_begin, *match_end;
+ *     if (parse_int_no_ws(begin, end, match_begin, match_end) {
+ *         // Convert to int, process
+ *     } else {
+ *         // Couldn't match unsigned integer
+ *     }
+ */
+inline bool parse_int_no_ws(const char *&rbegin, const char *end, const char *&out_strbegin, const char *&out_strend)
+{
+  const char *begin = rbegin;
+  parse_token(begin, end, '-');
+  if (parse_unsigned_int_no_ws(begin, end, out_strbegin, out_strend)) {
+    rbegin = begin;
+    return true;
+  }
+  return false;
+}
+
+/**
  * Without skipping whitespace, parses an integer with exactly two digits.
  * A leading zero is accepted.
  *
@@ -479,6 +502,13 @@ DYND_API uint128 checked_string_to_uint128(const char *begin, const char *end,
  * there are problems.
  */
 DYND_API intptr_t checked_string_to_intptr(const char *begin, const char *end);
+
+/**
+ * Converts a string containing only an integer (no leading or
+ * trailing space, etc) into an int64, raising an exception if
+ * there are problems.
+ */
+DYND_API int64_t checked_string_to_int64(const char *begin, const char *end);
 
 /**
  * Converts a string containing only an unsigned integer (no leading or

--- a/include/dynd/types/datashape_parser.hpp
+++ b/include/dynd/types/datashape_parser.hpp
@@ -43,6 +43,8 @@ inline ndt::type type_from_datashape(const char (&datashape)[N])
  * Returns a NULL nd::array if there is no arg list, and an nd::array with datashape
  *   "{pos: N * arg, kw: {name: arg, ...}}" otherwise.
  */
-nd::array parse_type_constr_args(const char *&rbegin, const char *end, std::map<std::string, ndt::type> &symtable);
+DYND_API nd::array parse_type_constr_args(const char *&rbegin, const char *end, std::map<std::string, ndt::type> &symtable);
+
+DYND_API nd::array parse_type_constr_args(const std::string &str);
 
 } // namespace dynd

--- a/include/dynd/types/datashape_parser.hpp
+++ b/include/dynd/types/datashape_parser.hpp
@@ -37,4 +37,12 @@ inline ndt::type type_from_datashape(const char (&datashape)[N])
     return type_from_datashape(datashape, datashape + N - 1);
 }
 
+/**
+ * Low level parsing function for parsing the argument list passed to a datashape type constructor.
+ *
+ * Returns a NULL nd::array if there is no arg list, and an nd::array with datashape
+ *   "{pos: N * arg, kw: {name: arg, ...}}" otherwise.
+ */
+nd::array parse_type_constr_args(const char *&rbegin, const char *end, std::map<std::string, ndt::type> &symtable);
+
 } // namespace dynd

--- a/src/dynd/parser_util.cpp
+++ b/src/dynd/parser_util.cpp
@@ -466,29 +466,40 @@ uint128 parse::checked_string_to_uint128(const char *begin, const char *end, boo
   return checked_string_to_uint<uint128>(begin, end, out_overflow, out_badparse);
 }
 
-intptr_t parse::checked_string_to_intptr(const char *begin, const char *end)
+template <class T>
+static T checked_string_to_signed_int(const char *begin, const char *end)
 {
   bool negative = false, overflow = false, badparse = false;
   if (begin < end && *begin == '-') {
     negative = true;
     ++begin;
   }
-  uint64_t uvalue = checked_string_to_uint64(begin, end, overflow, badparse);
-  if (overflow || overflow_check<intptr_t>::is_overflow(uvalue, negative)) {
+  uint64_t uvalue = parse::checked_string_to_uint64(begin, end, overflow, badparse);
+  if (overflow || parse::overflow_check<T>::is_overflow(uvalue, negative)) {
     stringstream ss;
     ss << "overflow converting string ";
     ss.write(begin, end - begin);
-    ss << " to intptr";
+    ss << " to " << ndt::type::make<T>();
     throw overflow_error(ss.str());
   } else if (badparse) {
     stringstream ss;
     ss << "parse error converting string ";
     ss.write(begin, end - begin);
-    ss << " to intptr";
+    ss << " to" << ndt::type::make<T>();
     throw invalid_argument(ss.str());
   } else {
-    return negative ? -static_cast<intptr_t>(uvalue) : static_cast<intptr_t>(uvalue);
+    return negative ? -static_cast<T>(uvalue) : static_cast<T>(uvalue);
   }
+}
+
+intptr_t parse::checked_string_to_intptr(const char *begin, const char *end)
+{
+  return checked_string_to_signed_int<intptr_t>(begin, end);
+}
+
+int64_t parse::checked_string_to_int64(const char *begin, const char *end)
+{
+  return checked_string_to_signed_int<int64_t>(begin, end);
 }
 
 uint64_t parse::unchecked_string_to_uint64(const char *begin, const char *end)

--- a/src/dynd/types/datashape_parser.cpp
+++ b/src/dynd/types/datashape_parser.cpp
@@ -962,7 +962,7 @@ nd::array dynd::parse_type_constr_args(const char *&rbegin, const char *end, map
       const char *saved_begin = begin;
       parse::skip_whitespace_and_pound_comments(begin, end);
       if (!parse::parse_name_no_ws(begin, end, field_name_begin, field_name_end)) {
-        throw datashape_parse_error(begin, "Expected a keyword name or terminating ']'");
+        throw datashape_parse_error(saved_begin, "Expected a keyword name or terminating ']'");
       }
       if (!parse_token_ds(begin, end, ':')) {
         throw datashape_parse_error(begin, "Expected ':' between keyword name and parameter");

--- a/tests/types/test_datashape_parser.cpp
+++ b/tests/types/test_datashape_parser.cpp
@@ -888,3 +888,31 @@ TEST(DataShapeParser, SpecialCharacterFields)
                 string::npos);
   }
 }
+
+static string to_str(const nd::array &a)
+{
+  stringstream ss;
+  ss << a;
+  return ss.str();
+}
+
+TEST(DataShapeParser, TypeConstructorArgs)
+{
+  nd::array a, b;
+  EXPECT_JSON_EQ_ARR("[[], {}]", parse_type_constr_args("[]"));
+  EXPECT_JSON_EQ_ARR("[[3, -10, \"test\"], {}]", parse_type_constr_args("[3, -10, \"test\"]"));
+  // The following currently raises a broadcast error in equality testing
+  b = parse_type_constr_args("[3, -10, \"test\", first:int32, second:[1,2,3]]");
+  a = parse_json(b.get_type(), "[[3, -10, \"test\"], [\"int32\", [1,2,3]]]");
+  EXPECT_EQ(to_str(a), to_str(b));
+  EXPECT_JSON_EQ_ARR("[[3, -10, \"test\"], [\"int32\", \"blah\"]]",
+                     parse_type_constr_args("[3, -10, \"test\", first:int32, second:\"blah\"]"));
+  // The following currently raises a broadcast error in equality testing
+  b = parse_type_constr_args("[[1, 2, 3], [2 * int32, float32, 3 * int8], [\"x\", \"yz\"]]");
+  a = parse_json(b.get_type(), "[[[1, 2, 3], [\"2 * int32\", \"float32\", \"3 * int8\"], [\"x\", \"yz\"]], []]");
+  EXPECT_EQ(to_str(a), to_str(b));
+  // The following currently raises a broadcast error in equality testing
+  b = parse_type_constr_args("[[1, 2, 3], x: [2 * int32, float32, 3 * int8], y: [\"x\", \"yz\"]]");
+  a = parse_json(b.get_type(), "[[[1, 2, 3]], [[\"2 * int32\", \"float32\", \"3 * int8\"], [\"x\", \"yz\"]]]");
+  EXPECT_EQ(to_str(a), to_str(b));
+}


### PR DESCRIPTION
This is exposed as its own function, and tested as such. Has not been hooked up elsewhere in the type string parser yet.