### PR TITLE
Operators

### DIFF
--- a/include/dynd/config.hpp
+++ b/include/dynd/config.hpp
@@ -625,6 +625,21 @@ T floor(T value)
   return std::floor(value);
 }
 
+namespace detail {
+  // Use these declarations before includeing bool1, int128, uint128, etc. so they are usable there.
+  // Helper to use for determining if a type is in a given list of unique types.
+  template<typename T, typename... Types>
+  struct TypeSetCheckInternal : std::is_same<T, Types>... {};
+
+  // Determine if a type is in a given list of unique types.
+  template<typename T, typename... Types>
+  struct TypeSetCheck : std::is_base_of<std::true_type, TypeSetCheckInternal<T, Types...>>::type {};
+
+  // Enable a given template only for a given list of unique types.
+  template<typename T, typename... Types>
+  struct enable_for : std::enable_if<TypeSetCheck<T, Types...>::value, int> {};
+} //namespace dynd::detail
+
 } // namespace dynd
 
 #include <dynd/bool1.hpp>

--- a/include/dynd/func/arithmetic.hpp
+++ b/include/dynd/func/arithmetic.hpp
@@ -203,6 +203,10 @@ namespace nd {
 
     static void fill()
     {
+        typedef type_id_sequence<int8_type_id, int16_type_id, int32_type_id,
+                                 int64_type_id, float32_type_id, float64_type_id,
+                                 complex_float32_type_id,
+                                 complex_float64_type_id> numeric_type_ids;
       for (const auto &pair : callable::make_all<KernelType, numeric_type_ids,
                                                  numeric_type_ids>()) {
         children[pair.first[0]][pair.first[1]] = pair.second;

--- a/include/dynd/uint128.hpp
+++ b/include/dynd/uint128.hpp
@@ -418,6 +418,11 @@ DYND_CUDA_HOST_DEVICE inline bool operator<(unsigned long long lhs,
   return uint128(lhs) < rhs;
 }
 
+template<typename T, typename dynd::detail::enable_for<T, unsigned char, unsigned short, unsigned int, unsigned long, unsigned long long>::type = 0>
+DYND_CUDA_HOST_DEVICE inline void operator+=(uint128 DYND_UNUSED(lhs), T DYND_UNUSED(rhs)) {
+  throw std::runtime_error("operator += is not implemented for uint128");
+}
+
 DYND_API std::ostream &operator<<(std::ostream &out, const uint128 &val);
 
 } // namespace dynd

--- a/src/dynd/func/arithmetic.cpp
+++ b/src/dynd/func/arithmetic.cpp
@@ -50,17 +50,13 @@ nd::array nd::operator/(const array &a0, const array &a1)
   return divide(a0, a1);
 }
 
-/*
-struct nd::compound_add nd::compound_add;
+DYND_API struct nd::compound_add nd::compound_add;
 
 nd::array &nd::array::operator+=(const array &rhs)
 {
   compound_add(rhs, kwds("dst", *this));
   return *this;
 }
-*/
-
-DYND_API struct nd::compound_add nd::compound_add;
 
 DYND_API struct nd::compound_div nd::compound_div;
 


### PR DESCRIPTION
This is a little more work toward simplifying the operator code. This enables `operator+=` by restricting the number of types the in-place operators apply to. From here I plan on expanding the number of operators available, adding dummy functions for all the missing operators, and then re-enabling the full list of numeric types for all the different operators.