### PR TITLE
Remove unneeded apt package source.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ addons:
     sources:
     - ubuntu-toolchain-r-test
     - kalakris-cmake
-    - llvm-toolchain-precise-3.4
     packages:
     - gcc-4.9
     - g++-4.9


### PR DESCRIPTION
I noticed a warning about this from the Travis build system in our builds.
The apt source for LLVM 3.4 isn't included in the Travis-ci whitelist for
package repositories, so it isn't used for our builds.