### PR TITLE
Move the children of arithmetic operators into an std::map

### DIFF
--- a/benchmarks/func/benchmark_arithmetic.cpp
+++ b/benchmarks/func/benchmark_arithmetic.cpp
@@ -16,7 +16,7 @@
 using namespace std;
 using namespace dynd;
 
-static const int size = 100000; // 256 * 256
+static const int size = 10000; // 256 * 256
 
 static void BM_Func_Arithmetic_Add(benchmark::State &state)
 {

--- a/src/dynd/func/arithmetic.cpp
+++ b/src/dynd/func/arithmetic.cpp
@@ -8,18 +8,24 @@
 using namespace std;
 using namespace dynd;
 
-#define DYND_DEF_UNARY_OP_AND_CALLABLE(OP, NAME)                     \
-DYND_API struct nd:: NAME nd:: NAME;                                 \
-nd::array nd::operator OP(const array &a0) { return nd:: NAME(a0); } \
+#define DYND_DEF_UNARY_OP_AND_CALLABLE(OP, NAME)                                                                       \
+  DYND_API struct nd::NAME nd::NAME;                                                                                   \
+  nd::array nd::operator OP(const array &a0)                                                                           \
+  {                                                                                                                    \
+    return nd::NAME(a0);                                                                                               \
+  }
 
 DYND_DEF_UNARY_OP_AND_CALLABLE(+, plus)
 DYND_DEF_UNARY_OP_AND_CALLABLE(-, minus)
 
 #undef DYND_DEF_UNARY_OP_AND_CALLABLE
 
-#define DYND_DEF_BINARY_OP_WITH_CALLABLE(OP, NAME)                                        \
-DYND_API struct nd:: NAME nd:: NAME;                                                      \
-nd::array nd::operator OP(const array &a0, const array &a1) { return nd:: NAME(a0, a1); } \
+#define DYND_DEF_BINARY_OP_WITH_CALLABLE(OP, NAME)                                                                     \
+  DYND_API struct nd::NAME nd::NAME;                                                                                   \
+  nd::array nd::operator OP(const array &a0, const array &a1)                                                          \
+  {                                                                                                                    \
+    return nd::NAME(a0, a1);                                                                                           \
+  }
 
 DYND_DEF_BINARY_OP_WITH_CALLABLE(+, add)
 DYND_DEF_BINARY_OP_WITH_CALLABLE(-, subtract)
@@ -28,13 +34,13 @@ DYND_DEF_BINARY_OP_WITH_CALLABLE(/, divide)
 
 #undef DYND_DEF_BINARY_OP_WITH_CALLABLE
 
-#define DYND_DEF_COMPOUND_OP_WITH_CALLABLE(OP, NAME)  \
-DYND_API struct nd:: NAME nd:: NAME;                  \
-nd::array &nd::array::operator OP(const array &rhs)   \
-{                                                     \
-  nd:: NAME(rhs, kwds("dst", *this));                 \
-  return *this;                                       \
-}                                                     \
+#define DYND_DEF_COMPOUND_OP_WITH_CALLABLE(OP, NAME)                                                                   \
+  DYND_API struct nd::NAME nd::NAME;                                                                                   \
+  nd::array &nd::array::operator OP(const array &rhs)                                                                  \
+  {                                                                                                                    \
+    nd::NAME(rhs, kwds("dst", *this));                                                                                 \
+    return *this;                                                                                                      \
+  }
 
 DYND_DEF_COMPOUND_OP_WITH_CALLABLE(+=, compound_add)
 DYND_DEF_COMPOUND_OP_WITH_CALLABLE(/=, compound_div)


### PR DESCRIPTION
This PR only affects arithmetic operators at the moment, but ultimately we should break out the pattern we're using there into a more general abstraction.