### PR TITLE
Fix various build errors when building with MSVC 2015 and Python 3.

### DIFF
--- a/include/dynd/types/datetime_type.hpp
+++ b/include/dynd/types/datetime_type.hpp
@@ -30,7 +30,7 @@ namespace ndt {
     datetime_tz_t m_timezone;
 
   public:
-    datetime_type(datetime_tz_t timezone);
+    datetime_type(datetime_tz_t);
 
     virtual ~datetime_type();
 
@@ -113,10 +113,10 @@ namespace ndt {
       return datetime_tp;
     }
 
-    /** Returns type "datetime[tz=<timezone>]" */
-    static type make(datetime_tz_t timezone)
+    /** Returns type "datetime[tz=<t>]" */
+    static type make(datetime_tz_t t)
     {
-      return type(new datetime_type(timezone), false);
+      return type(new datetime_type(t), false);
     }
   };
 

--- a/include/dynd/types/time_type.hpp
+++ b/include/dynd/types/time_type.hpp
@@ -15,7 +15,7 @@ namespace ndt {
     datetime_tz_t m_timezone;
 
   public:
-    time_type(datetime_tz_t timezone);
+    time_type(datetime_tz_t);
 
     virtual ~time_type();
 
@@ -93,10 +93,10 @@ namespace ndt {
       return time_tp;
     }
 
-    /** Returns type "time[tz=<timezone>]" */
-    static type make(datetime_tz_t timezone)
+    /** Returns type "time[tz=<t>]" */
+    static type make(datetime_tz_t t)
     {
-      return type(new time_type(timezone), false);
+      return type(new time_type(t), false);
     }
   };
 


### PR DESCRIPTION
`timezone` is used as a macro in the Python 3.5 headers. Its declaration
there was making it so that, rather than getting arguments with a given
type and the name `timezone` we were getting arguments with an alternative
type formed by parsing the type we specified and the expansion of the
`timezone` macro. The simplest solution for now was to just not use
`timezone` as a name for a function argument. A more robust
preprocessor-based solution can be added later.