### PR TITLE
Conda build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -758,6 +758,14 @@ if (DYND_INSTALL_LIB)
     if(WIN32)
         install(PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/libdynd-config.bat"
             DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
+        # Make sure the dll is installed into the bin directory so it can
+        # be on the path when installed as a conda package.
+        if(DYND_SHARED_LIB)
+            add_custom_command(TARGET libdynd POST_BUILD
+                               COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                               $<TARGET_FILE_DIR:libdynd>/libdynd.dll
+                               "${CMAKE_INSTALL_PREFIX}/bin")
+        endif()
     else()
         install(PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/libdynd-config"
             DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")

--- a/conda.recipe/bld.bat
+++ b/conda.recipe/bld.bat
@@ -3,20 +3,17 @@ cd %RECIPE_DIR%
 cd ..
 mkdir build
 cd build
-echo %CD%
 
-REM Override cmake generator to visual studio 2013
-if "%ARCH%" == "32" set CMAKE_GENERATOR=Visual Studio 12
-if "%ARCH%" == "64" set CMAKE_GENERATOR=Visual Studio 12 Win64
+:: Override cmake generator to visual studio 2015
+if "%ARCH%" == "32" set CMAKE_GENERATOR=Visual Studio 14
+if "%ARCH%" == "64" set CMAKE_GENERATOR=Visual Studio 14 Win64
 
-set MSVC_VERSION=10.0
-
-REM Configure step
+:: Configure step
 cmake -G "%CMAKE_GENERATOR%" -DCMAKE_BUILD_TYPE=Release -DDYND_INSTALL_LIB=ON -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% -DCMAKE_INSTALL_PREFIX:PATH=%LIBRARY_PREFIX% .. || exit /b 1
 
-REM Build step
+:: Build step
 cmake --build . --config Release || exit /b 1
 
-REM Install step
+:: Install step
 cmake --build . --config Release --target install || exit /b 1
 


### PR DESCRIPTION
This updates libdynd's conda build. Due to some changes in how Anaconda handles its paths, the tests don't run properly unless you use the current development version of conda_build.