### PR TITLE
Add explicit `os:` to osx matrix entry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ matrix:
     script:
     - conda build conda.recipe
   - language: objective-c
+    os: osx
     osx_image: xcode6.4
     compiler: clang
     env: OSX CONDA=true


### PR DESCRIPTION
- Turns out all that's needed is to add
  an explicit `os: osx` to the matrix
  entry for the routing to work properly