### PR TITLE
callable static initialization fix

### DIFF
--- a/include/dynd/func/arithmetic.hpp
+++ b/include/dynd/func/arithmetic.hpp
@@ -38,7 +38,7 @@ namespace nd {
   };
 
 #define DYND_DEF_UNARY_OP_CALLABLE(NAME, TYPES)                                                                        \
-  extern DYND_API struct NAME : unary_arithmetic_operator<NAME, NAME##_kernel, TYPES> {                                \
+  extern DYND_API struct DYND_API NAME : unary_arithmetic_operator<NAME, NAME##_kernel, TYPES> {                       \
     static std::string what(const ndt::type &src0_type)                                                                \
     {                                                                                                                  \
       std::stringstream ss;                                                                                            \
@@ -94,7 +94,7 @@ namespace nd {
   };
 
 #define DYND_DEF_BINARY_OP_CALLABLE(NAME, TYPES)                                                                       \
-  extern DYND_API struct NAME : binary_arithmetic_operator<NAME, NAME##_kernel, TYPES> {                               \
+  extern DYND_API struct DYND_API NAME : binary_arithmetic_operator<NAME, NAME##_kernel, TYPES> {                      \
     static std::string what(const ndt::type &src0_tp, const ndt::type &src1_tp)                                        \
     {                                                                                                                  \
       std::stringstream ss;                                                                                            \
@@ -157,7 +157,7 @@ namespace nd {
   };
 
 #define DYND_DEF_COMPOUND_OP_CALLABLE(NAME, TYPES)                                                                     \
-  extern DYND_API struct NAME : compound_arithmetic_operator<NAME, NAME##_kernel_t, TYPES> {                           \
+  extern DYND_API struct DYND_API NAME : compound_arithmetic_operator<NAME, NAME##_kernel_t, TYPES> {                  \
   } NAME;
 
   DYND_DEF_COMPOUND_OP_CALLABLE(compound_add, detail::binop_type_ids)

--- a/include/dynd/func/assignment.hpp
+++ b/include/dynd/func/assignment.hpp
@@ -11,8 +11,8 @@
 namespace dynd {
 namespace nd {
 
-  extern DYND_API struct assign : declfunc<assign> {
-    static DYND_API callable make();
+  extern DYND_API struct DYND_API assign : declfunc<assign> {
+    static callable make();
   } assign;
 
 } // namespace dynd::nd

--- a/include/dynd/func/comparison.hpp
+++ b/include/dynd/func/comparison.hpp
@@ -70,13 +70,13 @@ namespace nd {
     }
   };
 
-  extern DYND_API struct less : comparison_operator<less, less_kernel> {
+  extern DYND_API struct DYND_API less : comparison_operator<less, less_kernel> {
   } less;
 
-  extern DYND_API struct less_equal : comparison_operator<less_equal, less_equal_kernel> {
+  extern DYND_API struct DYND_API less_equal : comparison_operator<less_equal, less_equal_kernel> {
   } less_equal;
 
-  extern DYND_API struct equal : comparison_operator<equal, equal_kernel> {
+  extern DYND_API struct DYND_API equal : comparison_operator<equal, equal_kernel> {
     static std::map<std::array<type_id_t, 2>, callable> make_children()
     {
       std::map<std::array<type_id_t, 2>, callable> children = comparison_operator::make_children();
@@ -92,7 +92,7 @@ namespace nd {
     }
   } equal;
 
-  extern DYND_API struct not_equal : comparison_operator<not_equal, not_equal_kernel> {
+  extern DYND_API struct DYND_API not_equal : comparison_operator<not_equal, not_equal_kernel> {
     static std::map<std::array<type_id_t, 2>, callable> make_children()
     {
       std::map<std::array<type_id_t, 2>, callable> children = comparison_operator::make_children();
@@ -108,14 +108,14 @@ namespace nd {
     }
   } not_equal;
 
-  extern DYND_API struct greater_equal : comparison_operator<greater_equal, greater_equal_kernel> {
+  extern DYND_API struct DYND_API greater_equal : comparison_operator<greater_equal, greater_equal_kernel> {
   } greater_equal;
 
-  extern DYND_API struct greater : comparison_operator<greater, greater_kernel> {
+  extern DYND_API struct DYND_API greater : comparison_operator<greater, greater_kernel> {
   } greater;
 
-  extern DYND_API struct total_order : declfunc<total_order> {
-    static DYND_API callable make();
+  extern DYND_API struct DYND_API total_order : declfunc<total_order> {
+    static callable make();
   } total_order;
 
 } // namespace dynd::nd

--- a/include/dynd/func/copy.hpp
+++ b/include/dynd/func/copy.hpp
@@ -14,16 +14,16 @@ namespace nd {
    * Returns an arrfunc which copies data from one
    * array to another, without broadcasting
    */
-  DYND_API extern struct copy : declfunc<copy> {
-    DYND_API static callable make();
+  DYND_API extern struct DYND_API copy : declfunc<copy> {
+    static callable make();
   } copy;
 
   /**
    * Returns an arrfunc which copies data from one
    * array to another, with broadcasting.
    */
-  DYND_API extern struct broadcast_copy : declfunc<broadcast_copy> {
-    DYND_API static callable make();
+  DYND_API extern struct DYND_API broadcast_copy : declfunc<broadcast_copy> {
+    static callable make();
   } broadcast_copy;
 
 } // namespace dynd::nd

--- a/include/dynd/func/fft.hpp
+++ b/include/dynd/func/fft.hpp
@@ -100,20 +100,20 @@ namespace nd {
 
 #endif
 
-  extern DYND_API struct fft : declfunc<fft> {
-    static DYND_API callable make();
+  extern DYND_API struct DYND_API fft : declfunc<fft> {
+    static callable make();
   } fft;
 
-  extern DYND_API struct ifft : declfunc<ifft> {
-    static DYND_API callable make();
+  extern DYND_API struct DYND_API ifft : declfunc<ifft> {
+    static callable make();
   } ifft;
 
-  extern DYND_API struct rfft : declfunc<rfft> {
-    static DYND_API callable make();
+  extern DYND_API struct DYND_API rfft : declfunc<rfft> {
+    static callable make();
   } rfft;
 
-  extern DYND_API struct irfft : declfunc<irfft> {
-    static DYND_API callable make();
+  extern DYND_API struct DYND_API irfft : declfunc<irfft> {
+    static callable make();
   } irfft;
 
   /**

--- a/include/dynd/func/math.hpp
+++ b/include/dynd/func/math.hpp
@@ -10,20 +10,20 @@
 namespace dynd {
 namespace nd {
 
-  extern DYND_API struct cos : declfunc<cos> {
-    static DYND_API callable make();
+  extern DYND_API struct DYND_API cos : declfunc<cos> {
+    static callable make();
   } cos;
 
-  extern DYND_API struct sin : declfunc<sin> {
-    static DYND_API callable make();
+  extern DYND_API struct DYND_API sin : declfunc<sin> {
+    static callable make();
   } sin;
 
-  extern DYND_API struct tan : declfunc<tan> {
-    static DYND_API callable make();
+  extern DYND_API struct DYND_API tan : declfunc<tan> {
+    static callable make();
   } tan;
 
-  extern DYND_API struct exp : declfunc<exp> {
-    static DYND_API callable make();
+  extern DYND_API struct DYND_API exp : declfunc<exp> {
+    static callable make();
   } exp;
 
 } // namespace dynd::nd

--- a/include/dynd/func/max.hpp
+++ b/include/dynd/func/max.hpp
@@ -10,8 +10,8 @@
 namespace dynd {
 namespace nd {
 
-  extern DYND_API struct max : declfunc<max> {
-    static DYND_API callable make();
+  extern DYND_API struct DYND_API max : declfunc<max> {
+    static callable make();
   } max;
 
 } // namespace dynd::nd

--- a/include/dynd/func/mean.hpp
+++ b/include/dynd/func/mean.hpp
@@ -10,8 +10,8 @@
 namespace dynd {
 namespace nd {
 
-  extern DYND_API struct mean : declfunc<mean> {
-    static DYND_API callable make();
+  extern DYND_API struct DYND_API mean : declfunc<mean> {
+    static callable make();
   } mean;
 
 } // namespace dynd::nd

--- a/include/dynd/func/min.hpp
+++ b/include/dynd/func/min.hpp
@@ -10,8 +10,8 @@
 namespace dynd {
 namespace nd {
 
-  extern DYND_API struct min : declfunc<min> {
-    static DYND_API callable make();
+  extern DYND_API struct DYND_API min : declfunc<min> {
+    static callable make();
   } min;
 
 } // namespace dynd::nd

--- a/include/dynd/func/random.hpp
+++ b/include/dynd/func/random.hpp
@@ -10,8 +10,8 @@ namespace dynd {
 namespace nd {
   namespace random {
 
-    extern DYND_API struct uniform : declfunc<uniform> {
-      static DYND_API callable make();
+    extern DYND_API struct DYND_API uniform : declfunc<uniform> {
+      static callable make();
     } uniform;
 
   } // namespace dynd::nd::random

--- a/include/dynd/func/sum.hpp
+++ b/include/dynd/func/sum.hpp
@@ -10,8 +10,8 @@
 namespace dynd {
 namespace nd {
 
-  extern DYND_API struct sum : declfunc<sum> {
-    static DYND_API callable make();
+  extern DYND_API struct DYND_API sum : declfunc<sum> {
+    static callable make();
   } sum;
 
 } // namespace dynd::nd

--- a/include/dynd/func/take.hpp
+++ b/include/dynd/func/take.hpp
@@ -14,8 +14,8 @@ namespace nd {
    * An callable which applies either a boolean masked or
    * an indexed take/"fancy indexing" operation.
    */
-  extern DYND_API struct take : declfunc<take> {
-    static DYND_API callable make();
+  extern DYND_API struct DYND_API take : declfunc<take> {
+    static callable make();
   } take;
 
 } // namespace dynd::nd

--- a/include/dynd/func/take_by_pointer.hpp
+++ b/include/dynd/func/take_by_pointer.hpp
@@ -17,8 +17,8 @@ namespace nd {
    * operation, but stores the pointers.
    *
    */
-  extern DYND_API struct take_by_pointer : declfunc<take_by_pointer> {
-    static DYND_API callable make();
+  extern DYND_API struct DYND_API take_by_pointer : declfunc<take_by_pointer> {
+    static callable make();
   } take_by_pointer;
 
 } // namespace dynd::nd

--- a/include/dynd/func/view.hpp
+++ b/include/dynd/func/view.hpp
@@ -10,8 +10,8 @@
 namespace dynd {
 namespace nd {
 
-  extern DYND_API struct view : declfunc<view> {
-    static DYND_API callable make();
+  extern DYND_API struct DYND_API view : declfunc<view> {
+    static callable make();
   } view;
 
 } // namespace dynd::nd

--- a/include/dynd/kernels/byteswap_kernels.hpp
+++ b/include/dynd/kernels/byteswap_kernels.hpp
@@ -109,12 +109,12 @@ namespace nd {
     }
   };
 
-  extern DYND_API struct byteswap : declfunc<byteswap> {
-    static DYND_API callable make();
+  extern DYND_API struct DYND_API byteswap : declfunc<byteswap> {
+    static callable make();
   } byteswap;
 
-  extern DYND_API struct pairwise_byteswap : declfunc<pairwise_byteswap> {
-    static DYND_API callable make();
+  extern DYND_API struct DYND_API pairwise_byteswap : declfunc<pairwise_byteswap> {
+    static callable make();
   } pairwise_byteswap;
 
 } // namespace dynd::nd

--- a/include/dynd/kernels/multidispatch_kernel.hpp
+++ b/include/dynd/kernels/multidispatch_kernel.hpp
@@ -123,7 +123,9 @@ namespace nd {
 
         callable &child = dispatcher(dst_tp, nsrc, src_tp);
         if (child.is_null()) {
-          throw std::runtime_error("no suitable child for multidispatch");
+          std::stringstream ss;
+          ss << "no suitable child for multidispatch for types " << src_tp << ", and " << dst_tp << "\n";
+          throw std::runtime_error(ss.str());
         }
         return child->instantiate(child->static_data(), data, ckb, ckb_offset, dst_tp, dst_arrmeta, nsrc, src_tp,
                                   src_arrmeta, kernreq, nkwd, kwds, tp_vars);

--- a/include/dynd/logic.hpp
+++ b/include/dynd/logic.hpp
@@ -10,8 +10,8 @@
 namespace dynd {
 namespace nd {
 
-  extern DYND_API struct all : declfunc<all> {
-    static DYND_API callable make();
+  extern DYND_API struct DYND_API all : declfunc<all> {
+    static callable make();
   } all;
 
 } // namespace dynd::nd

--- a/include/dynd/option.hpp
+++ b/include/dynd/option.hpp
@@ -10,12 +10,12 @@
 namespace dynd {
 namespace nd {
 
-  extern DYND_API struct assign_na : declfunc<assign_na> {
-    static DYND_API callable make();
+  extern DYND_API struct DYND_API assign_na : declfunc<assign_na> {
+    static callable make();
   } assign_na;
 
-  extern DYND_API struct is_missing : declfunc<is_missing> {
-    static DYND_API callable make();
+  extern DYND_API struct DYND_API is_missing : declfunc<is_missing> {
+    static callable make();
   } is_missing;
 
 } // namespace dynd::nd

--- a/include/dynd/parse.hpp
+++ b/include/dynd/parse.hpp
@@ -1446,7 +1446,7 @@ namespace json {
 namespace nd {
   namespace json {
 
-    extern DYND_API struct parse : declfunc<parse> {
+    extern DYND_API struct DYND_API parse : declfunc<parse> {
       array operator()(const ndt::type &ret_tp, const char *begin, const char *end)
       {
         skip_whitespace(begin, end);
@@ -1474,7 +1474,7 @@ namespace nd {
         return (*this)(ret_tp, s.c_str(), s.c_str() + s.size());
       }
 
-      static DYND_API callable make();
+      static callable make();
     } parse;
 
   } // namespace dynd::nd::json

--- a/include/dynd/search.hpp
+++ b/include/dynd/search.hpp
@@ -16,8 +16,8 @@ namespace nd {
    *
    * \returns  The index of the found element, or -1 if not found.
    */
-  extern DYND_API struct binary_search : declfunc<binary_search> {
-    static DYND_API callable make();
+  extern DYND_API struct DYND_API binary_search : declfunc<binary_search> {
+    static callable make();
   } binary_search;
 
 } // namespace dynd::nd

--- a/include/dynd/sort.hpp
+++ b/include/dynd/sort.hpp
@@ -10,12 +10,12 @@
 namespace dynd {
 namespace nd {
 
-  extern DYND_API struct sort : declfunc<sort> {
-    static DYND_API callable make();
+  extern DYND_API struct DYND_API sort : declfunc<sort> {
+    static callable make();
   } sort;
 
-  extern DYND_API struct unique : declfunc<unique> {
-    static DYND_API callable make();
+  extern DYND_API struct DYND_API unique : declfunc<unique> {
+    static callable make();
   } unique;
 
 } // namespace dynd::nd


### PR DESCRIPTION
This fixes a bug that came to light in dynd-python where the struct type and the corresponding static data for each callable exported using the declfunc interface was getting included by the linker on a per-dll basis rather than being instantiated once in libdynd and shared across modules that depend on it.