### PR TITLE
Use "-O0 -g" in debug build (cmake -DCMAKE_BUILD_TYPE=debug).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,11 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 set(LIB_SUFFIX "" CACHE STRING
     "Typically an empty string or 64. Controls installation to lib or lib64")
 
+if(NOT WIN32)
+  set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
+  set(CMAKE_C_FLAGS_DEBUG "-O0 -g")
+endif()
+
 # Only add these options if this is the top level CMakeLists.txt
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
 ################################################


### PR DESCRIPTION

Hi,

would it be possible to use "-O0 -g" in the debug build?  Cmake overrides CFLAGS="-O0 -g"
passed on the command line, so changing CMakeLists.txt seems to be the only sane way.