### PR TITLE
Add tests for scalar string concatenation

### DIFF
--- a/include/dynd/bytes.hpp
+++ b/include/dynd/bytes.hpp
@@ -89,14 +89,22 @@ public:
 
   const bytes operator+(const bytes& rhs)
   {
-      bytes result;
+    bytes result;
 
-      result.resize(size() + rhs.size());
+    result.resize(size() + rhs.size());
 
-      DYND_MEMCPY(result.begin(), begin(), size());
-      DYND_MEMCPY(result.begin() + size(), rhs.begin(), rhs.size());
+    DYND_MEMCPY(result.begin(), begin(), size());
+    DYND_MEMCPY(result.begin() + size(), rhs.begin(), rhs.size());
 
-      return result;
+    return result;
+  }
+
+  bytes &operator+=(const bytes& rhs)
+  {
+    size_t orig_size = size();
+    resize(size() + rhs.size());
+    DYND_MEMCPY(begin() + orig_size, rhs.begin(), rhs.size());
+    return *this;
   }
 };
 

--- a/include/dynd/types/string_type.hpp
+++ b/include/dynd/types/string_type.hpp
@@ -22,6 +22,8 @@ public:
 
   string(const std::string &other) : string(other.data(), other.size()) {}
 
+  string(const bytes &other) : string(other.data(), other.size()) {}
+
   bool operator<(const string &rhs) const
   {
     return std::lexicographical_compare(begin(), end(), rhs.begin(), rhs.end());

--- a/tests/types/test_string_type.cpp
+++ b/tests/types/test_string_type.cpp
@@ -431,6 +431,22 @@ TEST(StringType, Comparisons)
 }
 
 
+TEST(StringType, ConcatenationScalar) {
+    dynd::string a("first");
+    dynd::string b("second");
+
+    dynd::string c(a + b);
+    ASSERT_EQ(dynd::string("firstsecond"), c);
+
+    a = dynd::string("foo");
+    a += dynd::string("bar");
+
+    printf("%s\n", a.begin());
+
+    ASSERT_EQ(dynd::string("foobar"), a);
+}
+
+
 TEST(StringType, Concatenation) {
     nd::array a, b, c;
 

--- a/tests/types/test_string_type.cpp
+++ b/tests/types/test_string_type.cpp
@@ -441,8 +441,6 @@ TEST(StringType, ConcatenationScalar) {
     a = dynd::string("foo");
     a += dynd::string("bar");
 
-    printf("%s\n", a.begin());
-
     ASSERT_EQ(dynd::string("foobar"), a);
 }
 


### PR DESCRIPTION
This probably should have been part of #901.

Just adds a test for the `operator+` I added to `bytes`, and also adds an `operator+=`.