### PR TITLE
get_then_copy_kernel: parameterize over the return type.

### DIFF
--- a/src/dynd/types/callable_type.cpp
+++ b/src/dynd/types/callable_type.cpp
@@ -266,18 +266,19 @@ bool ndt::callable_type::match(const char *arrmeta, const type &candidate_tp, co
 std::map<std::string, nd::callable> ndt::callable_type::get_dynamic_type_properties() const
 {
   std::map<std::string, nd::callable> properties;
-  properties["pos_types"] = nd::callable::make<nd::get_then_copy_kernel2<callable_type, &callable_type::get_pos_types>>(
-      ndt::callable_type::make(m_pos_tuple.extended<ndt::tuple_type>()->get_type(),
-                               ndt::tuple_type::make(),
+  properties["pos_types"] = nd::callable::make<
+      nd::get_then_copy_kernel<const std::vector<type> &, callable_type, &callable_type::get_pos_types>>(
+      ndt::callable_type::make(m_pos_tuple.extended<ndt::tuple_type>()->get_type(), ndt::tuple_type::make(),
                                ndt::struct_type::make({"self"}, {ndt::make_type<ndt::type_type>()})));
-  properties["kwd_types"] = nd::callable::make<nd::get_then_copy_kernel2<callable_type, &callable_type::get_kwd_types>>(
-      ndt::callable_type::make(m_kwd_struct.extended<ndt::struct_type>()->get_type(),
-                               ndt::tuple_type::make(),
+  properties["kwd_types"] = nd::callable::make<
+      nd::get_then_copy_kernel<const std::vector<type> &, callable_type, &callable_type::get_kwd_types>>(
+      ndt::callable_type::make(m_kwd_struct.extended<ndt::struct_type>()->get_type(), ndt::tuple_type::make(),
                                ndt::struct_type::make({"self"}, {ndt::make_type<ndt::type_type>()})));
-  properties["kwd_names"] = nd::callable::make<nd::get_then_copy_kernel<callable_type, &callable_type::get_kwd_names>>(
-      ndt::callable_type::make(m_kwd_struct.extended<ndt::struct_type>()->get_field_names().get_type(),
-                               ndt::tuple_type::make(),
-                               ndt::struct_type::make({"self"}, {ndt::make_type<ndt::type_type>()})));
+  properties["kwd_names"] =
+      nd::callable::make<nd::get_then_copy_kernel<const nd::array &, callable_type, &callable_type::get_kwd_names>>(
+          ndt::callable_type::make(m_kwd_struct.extended<ndt::struct_type>()->get_field_names().get_type(),
+                                   ndt::tuple_type::make(),
+                                   ndt::struct_type::make({"self"}, {ndt::make_type<ndt::type_type>()})));
   properties["return_type"] = nd::callable([](type self) { return self.extended<callable_type>()->get_return_type(); });
 
   return properties;

--- a/src/dynd/types/struct_type.cpp
+++ b/src/dynd/types/struct_type.cpp
@@ -326,16 +326,18 @@ intptr_t ndt::struct_type::apply_linear_index(intptr_t nindices, const irange *i
 std::map<std::string, nd::callable> ndt::struct_type::get_dynamic_type_properties() const
 {
   std::map<std::string, nd::callable> properties;
-  properties["field_types"] = nd::callable::make<nd::get_then_copy_kernel2<tuple_type, &tuple_type::get_field_types>>(
-      ndt::callable_type::make(this->get_type(), ndt::tuple_type::make(),
-                               ndt::struct_type::make({"self"}, {ndt::make_type<ndt::type_type>()})));
+  properties["field_types"] =
+      nd::callable::make<nd::get_then_copy_kernel<const std::vector<type> &, tuple_type, &tuple_type::get_field_types>>(
+          ndt::callable_type::make(get_type(), ndt::tuple_type::make(),
+                                   ndt::struct_type::make({"self"}, {ndt::make_type<ndt::type_type>()})));
   properties["metadata_offsets"] =
-      nd::callable::make<nd::get_then_copy_kernel<tuple_type, &tuple_type::get_arrmeta_offsets>>(
+      nd::callable::make<nd::get_then_copy_kernel<const nd::array &, tuple_type, &tuple_type::get_arrmeta_offsets>>(
           ndt::callable_type::make(m_arrmeta_offsets.get_type(), ndt::tuple_type::make(),
                                    ndt::struct_type::make({"self"}, {ndt::make_type<ndt::type_type>()})));
-  properties["field_names"] = nd::callable::make<nd::get_then_copy_kernel<struct_type, &struct_type::get_field_names>>(
-      ndt::callable_type::make(m_field_names.get_type(), ndt::tuple_type::make(),
-                               ndt::struct_type::make({"self"}, {ndt::make_type<ndt::type_type>()})));
+  properties["field_names"] =
+      nd::callable::make<nd::get_then_copy_kernel<const nd::array &, struct_type, &struct_type::get_field_names>>(
+          ndt::callable_type::make(m_field_names.get_type(), ndt::tuple_type::make(),
+                                   ndt::struct_type::make({"self"}, {ndt::make_type<ndt::type_type>()})));
 
   return properties;
 }

--- a/src/dynd/types/tuple_type.cpp
+++ b/src/dynd/types/tuple_type.cpp
@@ -516,11 +516,12 @@ bool ndt::tuple_type::match(const char *arrmeta, const type &candidate_tp, const
 std::map<std::string, nd::callable> ndt::tuple_type::get_dynamic_type_properties() const
 {
   std::map<std::string, nd::callable> properties;
-  properties["field_types"] = nd::callable::make<nd::get_then_copy_kernel2<tuple_type, &tuple_type::get_field_types>>(
-      ndt::callable_type::make(get_type(), ndt::tuple_type::make(),
-                               ndt::struct_type::make({"self"}, {ndt::make_type<ndt::type_type>()})));
+  properties["field_types"] =
+      nd::callable::make<nd::get_then_copy_kernel<const std::vector<type> &, tuple_type, &tuple_type::get_field_types>>(
+          ndt::callable_type::make(get_type(), ndt::tuple_type::make(),
+                                   ndt::struct_type::make({"self"}, {ndt::make_type<ndt::type_type>()})));
   properties["metadata_offsets"] =
-      nd::callable::make<nd::get_then_copy_kernel<tuple_type, &tuple_type::get_arrmeta_offsets>>(
+      nd::callable::make<nd::get_then_copy_kernel<const nd::array &, tuple_type, &tuple_type::get_arrmeta_offsets>>(
           ndt::callable_type::make(m_arrmeta_offsets.get_type(), ndt::tuple_type::make(),
                                    ndt::struct_type::make({"self"}, {ndt::make_type<ndt::type_type>()})));
 


### PR DESCRIPTION
For further work more return types will be needed (std::vector<uintptr_t> etc.), so
I think it's best to add a return type parameter to the template.