### PR TITLE
Apply clang-format to all files in include/dynd/types/ and src/dynd/t…

### DIFF
--- a/include/dynd/types/array_type.hpp
+++ b/include/dynd/types/array_type.hpp
@@ -24,34 +24,23 @@ namespace ndt {
       return tp;
     }
 
-    const type &get_value_type() const
-    {
-      return m_value_tp.value_type();
-    }
+    const type &get_value_type() const { return m_value_tp.value_type(); }
 
     bool operator==(const base_type &rhs) const;
 
     virtual void data_construct(const char *arrmeta, char *data) const;
 
-    virtual void data_destruct(const char *DYND_UNUSED(arrmeta),
-                               char *DYND_UNUSED(data)) const;
+    virtual void data_destruct(const char *DYND_UNUSED(arrmeta), char *DYND_UNUSED(data)) const;
 
-    bool is_expression() const
-    {
-      return m_value_tp.is_expression();
-    }
+    bool is_expression() const { return m_value_tp.is_expression(); }
 
-    void print_data(std::ostream &o, const char *arrmeta,
-                    const char *data) const;
+    void print_data(std::ostream &o, const char *arrmeta, const char *data) const;
 
     void print_type(std::ostream &o) const;
 
     type with_replaced_storage_type(const type &replacement_tp) const;
 
-    static type make(const type &value_tp)
-    {
-      return type(new array_type(value_tp), false);
-    }
+    static type make(const type &value_tp) { return type(new array_type(value_tp), false); }
   };
 
 } // namespace dynd::ndt

--- a/include/dynd/types/base_bytes_type.hpp
+++ b/include/dynd/types/base_bytes_type.hpp
@@ -17,18 +17,16 @@ namespace ndt {
    */
   class DYND_API base_bytes_type : public base_type {
   public:
-    base_bytes_type(type_id_t type_id, type_kind_t kind, size_t data_size,
-                    size_t alignment, flags_type flags, size_t arrmeta_size)
-        : base_type(type_id, kind, data_size, alignment, flags, arrmeta_size, 0,
-                    0)
+    base_bytes_type(type_id_t type_id, type_kind_t kind, size_t data_size, size_t alignment, flags_type flags,
+                    size_t arrmeta_size)
+        : base_type(type_id, kind, data_size, alignment, flags, arrmeta_size, 0, 0)
     {
     }
 
     virtual ~base_bytes_type();
 
     /** Retrieves the data range in which a bytes object is stored */
-    virtual void get_bytes_range(const char **out_begin, const char **out_end,
-                                 const char *arrmeta,
+    virtual void get_bytes_range(const char **out_begin, const char **out_end, const char *arrmeta,
                                  const char *data) const = 0;
 
     // Bytes types stop the iterdata chain

--- a/include/dynd/types/base_dim_type.hpp
+++ b/include/dynd/types/base_dim_type.hpp
@@ -22,38 +22,28 @@ namespace ndt {
     size_t m_element_arrmeta_offset;
 
   public:
-    base_dim_type(type_id_t type_id, type_kind_t tp_kind,
-                  const type &element_tp, size_t data_size, size_t alignment,
+    base_dim_type(type_id_t type_id, type_kind_t tp_kind, const type &element_tp, size_t data_size, size_t alignment,
                   size_t element_arrmeta_offset, flags_type flags, bool strided)
-        : base_type(type_id, tp_kind, data_size, alignment,
-                    flags | type_flag_indexable,
-                    element_arrmeta_offset + element_tp.get_arrmeta_size(),
-                    1 + element_tp.get_ndim(),
+        : base_type(type_id, tp_kind, data_size, alignment, flags | type_flag_indexable,
+                    element_arrmeta_offset + element_tp.get_arrmeta_size(), 1 + element_tp.get_ndim(),
                     strided ? (1 + element_tp.get_strided_ndim()) : 0),
-          m_element_tp(element_tp),
-          m_element_arrmeta_offset(element_arrmeta_offset)
+          m_element_tp(element_tp), m_element_arrmeta_offset(element_arrmeta_offset)
     {
       if (m_element_tp.get_kind() == memory_kind) {
-        throw std::invalid_argument(
-            "a memory_type cannot be an element of a dim_type");
+        throw std::invalid_argument("a memory_type cannot be an element of a dim_type");
       }
     }
 
-    base_dim_type(type_id_t tp_id, const type &element_tp, size_t data_size,
-                  size_t data_alignment, size_t element_arrmeta_offset,
-                  flags_type flags, bool strided)
-        : base_dim_type(tp_id, dim_kind, element_tp, data_size, data_alignment,
-                        element_arrmeta_offset, flags, strided)
+    base_dim_type(type_id_t tp_id, const type &element_tp, size_t data_size, size_t data_alignment,
+                  size_t element_arrmeta_offset, flags_type flags, bool strided)
+        : base_dim_type(tp_id, dim_kind, element_tp, data_size, data_alignment, element_arrmeta_offset, flags, strided)
     {
     }
 
     virtual ~base_dim_type();
 
     /** The element type. */
-    const type &get_element_type() const
-    {
-      return m_element_tp;
-    }
+    const type &get_element_type() const { return m_element_tp; }
 
     void get_element_types(std::size_t ndim, const type **element_tp) const;
 
@@ -71,9 +61,11 @@ namespace ndt {
       intptr_t this_ndim = get_ndim(), stp_ndim = subarray_tp.get_ndim();
       if (this_ndim > stp_ndim) {
         return get_element_type().is_type_subarray(subarray_tp);
-      } else if (this_ndim == stp_ndim) {
+      }
+      else if (this_ndim == stp_ndim) {
         return (*this) == (*subarray_tp.extended());
-      } else {
+      }
+      else {
         return false;
       }
     }
@@ -82,10 +74,7 @@ namespace ndt {
      * The offset to add to the arrmeta to get to the
      * element type's arrmeta.
      */
-    size_t get_element_arrmeta_offset() const
-    {
-      return m_element_arrmeta_offset;
-    }
+    size_t get_element_arrmeta_offset() const { return m_element_arrmeta_offset; }
 
     /**
      * The dimension size, or -1 if it can't be determined
@@ -96,8 +85,7 @@ namespace ndt {
      *
      * \returns  The size of the dimension, or -1.
      */
-    virtual intptr_t get_dim_size(const char *arrmeta = NULL,
-                                  const char *data = NULL) const = 0;
+    virtual intptr_t get_dim_size(const char *arrmeta = NULL, const char *data = NULL) const = 0;
 
     intptr_t get_size(const char *arrmeta) const
     {
@@ -109,10 +97,7 @@ namespace ndt {
       return dim_size * m_element_tp.get_size(NULL);
     }
 
-    virtual void get_vars(std::unordered_set<std::string> &vars) const
-    {
-      m_element_tp.get_vars(vars);
-    }
+    virtual void get_vars(std::unordered_set<std::string> &vars) const { m_element_tp.get_vars(vars); }
 
     /**
      * Constructs the nd::array arrmeta for one dimension of this type, leaving
@@ -128,12 +113,10 @@ namespace ndt {
      *                            when putting it in a new nd::array, need to
      *                            hold a reference to that memory.
      */
-    virtual size_t arrmeta_copy_construct_onedim(
-        char *dst_arrmeta, const char *src_arrmeta,
-        const intrusive_ptr<memory_block_data> &embedded_reference) const = 0;
+    virtual size_t arrmeta_copy_construct_onedim(char *dst_arrmeta, const char *src_arrmeta,
+                                                 const intrusive_ptr<memory_block_data> &embedded_reference) const = 0;
 
-    virtual bool match(const char *arrmeta, const type &candidate_tp,
-                       const char *candidate_arrmeta,
+    virtual bool match(const char *arrmeta, const type &candidate_tp, const char *candidate_arrmeta,
                        std::map<std::string, type> &tp_vars) const;
 
     virtual type with_element_type(const type &element_tp) const = 0;

--- a/include/dynd/types/busdate_type.hpp
+++ b/include/dynd/types/busdate_type.hpp
@@ -43,8 +43,7 @@ namespace ndt {
     nd::array m_holidays;
 
   public:
-    busdate_type(busdate_roll_t roll, const bool *weekmask,
-                 const nd::array &holidays);
+    busdate_type(busdate_roll_t roll, const bool *weekmask, const nd::array &holidays);
 
     virtual ~busdate_type();
 
@@ -58,15 +57,14 @@ namespace ndt {
 
     bool is_default_workweek() const
     {
-      return m_workweek[0] && m_workweek[1] && m_workweek[2] && m_workweek[3] &&
-             m_workweek[4] && !m_workweek[5] && !m_workweek[6];
+      return m_workweek[0] && m_workweek[1] && m_workweek[2] && m_workweek[3] && m_workweek[4] && !m_workweek[5] &&
+             !m_workweek[6];
     }
 
     void print_workweek(std::ostream &o) const;
     void print_holidays(std::ostream &o) const;
 
-    void print_data(std::ostream &o, const char *arrmeta,
-                    const char *data) const;
+    void print_data(std::ostream &o, const char *arrmeta, const char *data) const;
 
     void print_type(std::ostream &o) const;
 
@@ -74,24 +72,18 @@ namespace ndt {
 
     bool operator==(const base_type &rhs) const;
 
-    void arrmeta_default_construct(char *DYND_UNUSED(arrmeta),
-                                   bool DYND_UNUSED(blockref_alloc)) const
-    {
-    }
-    void arrmeta_copy_construct(
-        char *DYND_UNUSED(dst_arrmeta), const char *DYND_UNUSED(src_arrmeta),
-        const intrusive_ptr<memory_block_data> &DYND_UNUSED(embedded_reference)) const
+    void arrmeta_default_construct(char *DYND_UNUSED(arrmeta), bool DYND_UNUSED(blockref_alloc)) const {}
+    void arrmeta_copy_construct(char *DYND_UNUSED(dst_arrmeta), const char *DYND_UNUSED(src_arrmeta),
+                                const intrusive_ptr<memory_block_data> &DYND_UNUSED(embedded_reference)) const
     {
     }
     void arrmeta_destruct(char *DYND_UNUSED(arrmeta)) const {}
-    void arrmeta_debug_print(const char *DYND_UNUSED(arrmeta),
-                             std::ostream &DYND_UNUSED(o),
+    void arrmeta_debug_print(const char *DYND_UNUSED(arrmeta), std::ostream &DYND_UNUSED(o),
                              const std::string &DYND_UNUSED(indent)) const
     {
     }
 
-    static type make(busdate_roll_t roll = busdate_roll_following,
-                     const bool *weekmask = NULL,
+    static type make(busdate_roll_t roll = busdate_roll_following, const bool *weekmask = NULL,
                      const nd::array &holidays = nd::array())
     {
       return type(new busdate_type(roll, weekmask, holidays), false);

--- a/include/dynd/types/c_contiguous_type.hpp
+++ b/include/dynd/types/c_contiguous_type.hpp
@@ -17,10 +17,7 @@ namespace ndt {
   public:
     c_contiguous_type(const type &child_tp);
 
-    const type &get_child_type() const
-    {
-      return m_child_tp;
-    }
+    const type &get_child_type() const { return m_child_tp; }
 
     void print_data(std::ostream &o, const char *arrmeta, const char *data) const;
 
@@ -32,8 +29,8 @@ namespace ndt {
                             bool leading_dimension) const;
 
     intptr_t apply_linear_index(intptr_t nindices, const irange *indices, const char *arrmeta, const type &result_type,
-                                char *out_arrmeta, const intrusive_ptr<memory_block_data> &embedded_reference, size_t current_i,
-                                const type &root_tp, bool leading_dimension, char **inout_data,
+                                char *out_arrmeta, const intrusive_ptr<memory_block_data> &embedded_reference,
+                                size_t current_i, const type &root_tp, bool leading_dimension, char **inout_data,
                                 intrusive_ptr<memory_block_data> &inout_dataref) const;
 
     type at_single(intptr_t i0, const char **inout_arrmeta, const char **inout_data) const;
@@ -52,10 +49,7 @@ namespace ndt {
     virtual bool match(const char *arrmeta, const type &candidate_tp, const char *candidate_arrmeta,
                        std::map<std::string, type> &tp_vars) const;
 
-    static type make(const type &child_tp)
-    {
-      return type(new c_contiguous_type(child_tp), false);
-    }
+    static type make(const type &child_tp) { return type(new c_contiguous_type(child_tp), false); }
   };
 
 } // namespace dynd::ndt

--- a/include/dynd/types/categorical_kind_type.hpp
+++ b/include/dynd/types/categorical_kind_type.hpp
@@ -18,8 +18,7 @@ namespace ndt {
 
     size_t get_default_data_size() const;
 
-    void print_data(std::ostream &o, const char *arrmeta,
-                    const char *data) const;
+    void print_data(std::ostream &o, const char *arrmeta, const char *data) const;
 
     void print_type(std::ostream &o) const;
 
@@ -37,15 +36,12 @@ namespace ndt {
     void arrmeta_reset_buffers(char *arrmeta) const;
     void arrmeta_finalize_buffers(char *arrmeta) const;
     void arrmeta_destruct(char *arrmeta) const;
-    void arrmeta_debug_print(const char *arrmeta, std::ostream &o,
-                             const std::string &indent) const;
+    void arrmeta_debug_print(const char *arrmeta, std::ostream &o, const std::string &indent) const;
 
     void data_destruct(const char *arrmeta, char *data) const;
-    void data_destruct_strided(const char *arrmeta, char *data, intptr_t stride,
-                               size_t count) const;
+    void data_destruct_strided(const char *arrmeta, char *data, intptr_t stride, size_t count) const;
 
-    bool match(const char *arrmeta, const type &candidate_tp,
-               const char *candidate_arrmeta,
+    bool match(const char *arrmeta, const type &candidate_tp, const char *candidate_arrmeta,
                std::map<std::string, type> &tp_vars) const;
 
     static type make() { return type(new categorical_kind_type(), false); }

--- a/include/dynd/types/datashape_formatter.hpp
+++ b/include/dynd/types/datashape_formatter.hpp
@@ -17,9 +17,7 @@ namespace dynd {
  * \param prefix  Prepends the datashape with this string
  * \param multiline  If true, split the datashape across multiple lines.
  */
-DYND_API std::string format_datashape(const nd::array& n,
-                const std::string& prefix = "",
-                bool multiline = true);
+DYND_API std::string format_datashape(const nd::array &n, const std::string &prefix = "", bool multiline = true);
 
 /**
  * Formats the type as a blaze datashape.
@@ -28,9 +26,7 @@ DYND_API std::string format_datashape(const nd::array& n,
  * \param prefix  Prepends the datashape with this string
  * \param multiline  If true, split the datashape across multiple lines.
  */
-DYND_API std::string format_datashape(const ndt::type& tp,
-                const std::string& prefix = "",
-                bool multiline = true);
+DYND_API std::string format_datashape(const ndt::type &tp, const std::string &prefix = "", bool multiline = true);
 
 /**
  * Formats the given type + arrmeta + data as a Blaze
@@ -46,8 +42,7 @@ DYND_API std::string format_datashape(const ndt::type& tp,
  *              This may be NULL.
  * \param multiline  If true, split the datashape across multiple lines.
  */
-DYND_API void format_datashape(std::ostream& o, const ndt::type& tp,
-                const char *arrmeta, const char *data, bool multiline);
-
+DYND_API void format_datashape(std::ostream &o, const ndt::type &tp, const char *arrmeta, const char *data,
+                               bool multiline);
 
 } // namespace dynd

--- a/include/dynd/types/datashape_parser.hpp
+++ b/include/dynd/types/datashape_parser.hpp
@@ -21,20 +21,20 @@ namespace dynd {
  */
 DYND_API ndt::type type_from_datashape(const char *datashape_begin, const char *datashape_end);
 
-inline ndt::type type_from_datashape(const std::string& datashape)
+inline ndt::type type_from_datashape(const std::string &datashape)
 {
-    return type_from_datashape(datashape.data(), datashape.data() + datashape.size());
+  return type_from_datashape(datashape.data(), datashape.data() + datashape.size());
 }
 
 inline ndt::type type_from_datashape(const char *datashape)
 {
-    return type_from_datashape(datashape, datashape + strlen(datashape));
+  return type_from_datashape(datashape, datashape + strlen(datashape));
 }
 
-template<int N>
-inline ndt::type type_from_datashape(const char (&datashape)[N])
+template <int N>
+inline ndt::type type_from_datashape(const char(&datashape)[N])
 {
-    return type_from_datashape(datashape, datashape + N - 1);
+  return type_from_datashape(datashape, datashape + N - 1);
 }
 
 /**
@@ -43,7 +43,8 @@ inline ndt::type type_from_datashape(const char (&datashape)[N])
  * Returns a NULL nd::array if there is no arg list, and an nd::array with datashape
  *   "{pos: N * arg, kw: {name: arg, ...}}" otherwise.
  */
-DYND_API nd::array parse_type_constr_args(const char *&rbegin, const char *end, std::map<std::string, ndt::type> &symtable);
+DYND_API nd::array parse_type_constr_args(const char *&rbegin, const char *end,
+                                          std::map<std::string, ndt::type> &symtable);
 
 DYND_API nd::array parse_type_constr_args(const std::string &str);
 

--- a/include/dynd/types/date_util.hpp
+++ b/include/dynd/types/date_util.hpp
@@ -19,239 +19,223 @@
 namespace dynd {
 
 namespace ndt {
-    class type;
+  class type;
 } // namespace ndt
 
 /**
  * An enumeration for describing how to interpret ambiguous
  * dates such as "01/02/03" or "01/02/1995".
  */
-enum date_parse_order_t {
-    date_parse_no_ambig,
-    date_parse_ymd,
-    date_parse_mdy,
-    date_parse_dmy
-};
+enum date_parse_order_t { date_parse_no_ambig, date_parse_ymd, date_parse_mdy, date_parse_dmy };
 
-DYND_API std::ostream& operator<<(std::ostream& o, date_parse_order_t date_order);
+DYND_API std::ostream &operator<<(std::ostream &o, date_parse_order_t date_order);
 
 struct DYND_API date_ymd {
-    int16_t year;
-    int8_t month;
-    int8_t day;
+  int16_t year;
+  int8_t month;
+  int8_t day;
 
-    static const int month_lengths[2][12];
-    static const int month_starts[2][13];
+  static const int month_lengths[2][12];
+  static const int month_starts[2][13];
 
-    static inline bool is_leap_year(int year) {
-        return year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+  static inline bool is_leap_year(int year) { return year % 4 == 0 && (year % 100 != 0 || year % 400 == 0); }
+
+  static inline int get_month_length(int year, int month)
+  {
+    if (month >= 1 && month <= 12) {
+      return month_lengths[is_leap_year(year)][month - 1];
     }
-
-    static inline int get_month_length(int year, int month) {
-        if (month >= 1 && month <= 12) {
-            return month_lengths[is_leap_year(year)][month - 1];
-        } else {
-            return 0;
-        }
+    else {
+      return 0;
     }
+  }
 
-    static inline bool is_valid(int year, int month, int day) {
-        if (month < 1 || month > 12) {
-            return false;
-        } else if (day < 1 ||
-                   day > month_lengths[is_leap_year(year)][month - 1]) {
-            return false;
-        } else {
-            return true;
-        }
+  static inline bool is_valid(int year, int month, int day)
+  {
+    if (month < 1 || month > 12) {
+      return false;
     }
-
-    inline bool is_valid() const {
-        return is_valid(year, month, day);
+    else if (day < 1 || day > month_lengths[is_leap_year(year)][month - 1]) {
+      return false;
     }
-
-    inline bool is_na() const {
-        return month == -128;
+    else {
+      return true;
     }
+  }
 
-    /**
-     * Gets the length of the month this date is
-     * in. Returns 0 for an invalid date.
-     */
-    inline int get_month_length() const {
-        return get_month_length(year, month);
+  inline bool is_valid() const { return is_valid(year, month, day); }
+
+  inline bool is_na() const { return month == -128; }
+
+  /**
+   * Gets the length of the month this date is
+   * in. Returns 0 for an invalid date.
+   */
+  inline int get_month_length() const { return get_month_length(year, month); }
+
+  /**
+   * Gets the 0-based day of the week, where
+   * 0 is Monday, 6 is Sunday.
+   */
+  inline int get_weekday() const
+  {
+    int days = to_days();
+    // January 5, 1970 is Monday
+    int weekday = (days - 4) % 7;
+    if (weekday < 0) {
+      weekday += 7;
     }
+    return weekday;
+  }
 
-    /**
-     * Gets the 0-based day of the week, where
-     * 0 is Monday, 6 is Sunday.
-     */
-    inline int get_weekday() const {
-        int days = to_days();
-        // January 5, 1970 is Monday
-        int weekday = (days - 4) % 7;
-        if (weekday < 0) {
-            weekday += 7;
-        }
-        return weekday;
+  /**
+   * Gets the 0-based day of the year,
+   * values 0-365, but returns -1 for an invalid
+   * date.
+   */
+  inline int get_day_of_year() const
+  {
+    if (is_valid(year, month, day)) {
+      return month_starts[is_leap_year(year)][month - 1] + day - 1;
     }
-
-    /**
-     * Gets the 0-based day of the year,
-     * values 0-365, but returns -1 for an invalid
-     * date.
-     */
-    inline int get_day_of_year() const {
-        if (is_valid(year, month, day)) {
-            return month_starts[is_leap_year(year)][month-1] + day - 1;
-        } else {
-            return -1;
-        }
+    else {
+      return -1;
     }
+  }
 
-    /**
-     * Converts the ymd into a days offset from January 1, 1970.
-     */
-    static int32_t to_days(int year, int month, int day);
+  /**
+   * Converts the ymd into a days offset from January 1, 1970.
+   */
+  static int32_t to_days(int year, int month, int day);
 
-    /**
-     * Converts the ymd into a days offset from January 1, 1970.
-     */
-    int32_t to_days() const {
-        return to_days(year, month, day);
+  /**
+   * Converts the ymd into a days offset from January 1, 1970.
+   */
+  int32_t to_days() const { return to_days(year, month, day); }
+
+  /**
+   * Converts the ymd into an ISO 8601 string, or "" if it
+   * is invalid. For years from 0001 to 9999, uses "####-##-##",
+   * and for years outside that range uses "-######-##-##" or
+   * "+######-##-##".
+   */
+  static std::string to_str(int year, int month, int day);
+
+  /**
+   * Converts the ymd into an ISO 8601 string, or "" if it
+   * is invalid. For years from 0001 to 9999, uses "####-##-##",
+   * and for years outside that range uses "-######-##-##" or
+   * "+######-##-##".
+   */
+  inline std::string to_str() const { return to_str(year, month, day); }
+
+  /**
+   * Sets the year/month/day from a 1970 epoch days offset.
+   *
+   * \param days  A days offset from January 1, 1970.
+   */
+  void set_from_days(int32_t days);
+
+  /**
+   * Sets the year/month/day from the ticks-based date, throwing
+   * away the time portion.
+   */
+  inline void set_from_ticks(int64_t ticks)
+  {
+    if (ticks >= 0) {
+      set_from_days(static_cast<int32_t>(ticks / DYND_TICKS_PER_DAY));
     }
-
-    /**
-     * Converts the ymd into an ISO 8601 string, or "" if it
-     * is invalid. For years from 0001 to 9999, uses "####-##-##",
-     * and for years outside that range uses "-######-##-##" or
-     * "+######-##-##".
-     */
-    static std::string to_str(int year, int month, int day);
-
-    /**
-     * Converts the ymd into an ISO 8601 string, or "" if it
-     * is invalid. For years from 0001 to 9999, uses "####-##-##",
-     * and for years outside that range uses "-######-##-##" or
-     * "+######-##-##".
-     */
-    inline std::string to_str() const {
-        return to_str(year, month, day);
+    else {
+      set_from_days(static_cast<int32_t>((ticks - (DYND_TICKS_PER_DAY - 1)) / DYND_TICKS_PER_DAY));
     }
+  }
 
-    /**
-     * Sets the year/month/day from a 1970 epoch days offset.
-     *
-     * \param days  A days offset from January 1, 1970.
-     */
-    void set_from_days(int32_t days);
+  /**
+   * Sets the year/month/day to NA.
+   */
+  inline void set_to_na() { month = -128; }
 
-    /**
-     * Sets the year/month/day from the ticks-based date, throwing
-     * away the time portion.
-     */
-    inline void set_from_ticks(int64_t ticks) {
-        if (ticks >= 0) {
-            set_from_days(static_cast<int32_t>(ticks / DYND_TICKS_PER_DAY));
-        } else {
-            set_from_days(static_cast<int32_t>(
-                (ticks - (DYND_TICKS_PER_DAY - 1)) / DYND_TICKS_PER_DAY));
-        }
-    }
+  /**
+   * Sets the year/month/day from a string. Accepts a wide variety of
+   * inputs, but by default rejects ambiguous formats like MM/DD/YY vs
+   * DD/MM/YY. Two digit years are handled with a sliding window
+   * starting 70 years ago by default.
+   *
+   * \param s  Date string.
+   * \param ambig  Order to use for ambiguous cases like "01/02/03"
+   *               or "01/02/1995".
+   * \param century_window  Number describing how to handle dates with
+   *                        two digit years. Values 1 to 99 mean to use
+   *                        a sliding window starting that many years back.
+   *                        Values 1000 and higher mean to use a fixed window
+   *                        starting at the year given. The value 0 means to
+   *                        disallow two digit years.
+   */
+  inline void set_from_str(const std::string &s, date_parse_order_t ambig = date_parse_no_ambig,
+                           int century_window = 70, assign_error_mode errmode = assign_error_fractional)
+  {
+    return set_from_str(s.data(), s.data() + s.size(), ambig, century_window, errmode);
+  }
 
-    /**
-     * Sets the year/month/day to NA.
-     */
-    inline void set_to_na() {
-        month = -128;
-    }
+  void set_from_str(const char *begin, const char *end, date_parse_order_t ambig, int century_window,
+                    assign_error_mode errmode);
 
-    /**
-     * Sets the year/month/day from a string. Accepts a wide variety of
-     * inputs, but by default rejects ambiguous formats like MM/DD/YY vs
-     * DD/MM/YY. Two digit years are handled with a sliding window
-     * starting 70 years ago by default.
-     *
-     * \param s  Date string.
-     * \param ambig  Order to use for ambiguous cases like "01/02/03"
-     *               or "01/02/1995".
-     * \param century_window  Number describing how to handle dates with
-     *                        two digit years. Values 1 to 99 mean to use
-     *                        a sliding window starting that many years back.
-     *                        Values 1000 and higher mean to use a fixed window
-     *                        starting at the year given. The value 0 means to
-     *                        disallow two digit years.
-     */
-    inline void
-    set_from_str(const std::string &s,
-                 date_parse_order_t ambig = date_parse_no_ambig,
-                 int century_window = 70,
-                 assign_error_mode errmode = assign_error_fractional)
-    {
-        return set_from_str(s.data(), s.data() + s.size(), ambig, century_window, errmode);
-    }
+  /**
+   * When a year is a two digit year that should be resolved as a four
+   * digit year, this function provides the resolution
+   * using a fixed window strategy. The window is from `year_start` to
+   * 100 years later.
+   *
+   * \param year  The year to apply the fixed window to.
+   * \param year_start  The year at which the window starts.
+   *
+   * \returns  The adjusted year.
+   */
+  static int resolve_2digit_year_fixed_window(int year, int year_start);
 
-    void set_from_str(const char *begin, const char *end,
-                      date_parse_order_t ambig,
-                      int century_window,
-                      assign_error_mode errmode);
+  /**
+   * When a year is a two digit year that should be resolved as a four
+   * digit year, this function provides the resolution
+   * using a sliding window strategy. The window is from
+   * the current year with `years_ago` years subtracted from it, and is
+   * one century long.
+   *
+   * This function simply retrieves the current year, and calls the variant
+   * with selectable `year_start`.
+   *
+   * \param year  The year to apply the sliding window to.
+   * \param years_ago  The number of years before the current date for the
+   *                   start of the window.
+   *
+   * \returns  The adjusted year.
+   */
+  static int resolve_2digit_year_sliding_window(int year, int years_ago);
 
-    /**
-     * When a year is a two digit year that should be resolved as a four
-     * digit year, this function provides the resolution
-     * using a fixed window strategy. The window is from `year_start` to
-     * 100 years later.
-     *
-     * \param year  The year to apply the fixed window to.
-     * \param year_start  The year at which the window starts.
-     *
-     * \returns  The adjusted year.
-     */
-    static int resolve_2digit_year_fixed_window(int year, int year_start);
+  /**
+   * This function resolves a two digit year, choosing between a sliding
+   * or fixed window approach based on the parameter value.
+   *
+   * \param year  The year to apply the century selection to.
+   * \param century_window  Number describing how to handle dates with
+   *                        two digit years. Values 1 to 99 mean to use
+   *                        a sliding window starting that many years back.
+   *                        Values 1000 and higher mean to use a fixed window
+   *                        starting at the year given. The value 0 means to
+   *                        disallow two digit years.
+   *
+   * \returns  The adjusted year.
+   */
+  static int resolve_2digit_year(int year, int century_window);
 
-    /**
-     * When a year is a two digit year that should be resolved as a four
-     * digit year, this function provides the resolution
-     * using a sliding window strategy. The window is from
-     * the current year with `years_ago` years subtracted from it, and is
-     * one century long.
-     *
-     * This function simply retrieves the current year, and calls the variant
-     * with selectable `year_start`.
-     *
-     * \param year  The year to apply the sliding window to.
-     * \param years_ago  The number of years before the current date for the
-     *                   start of the window.
-     *
-     * \returns  The adjusted year.
-     */
-    static int resolve_2digit_year_sliding_window(int year, int years_ago);
+  /**
+   * Returns the current date in the local time zone.
+   */
+  static date_ymd get_current_local_date();
 
-    /**
-     * This function resolves a two digit year, choosing between a sliding
-     * or fixed window approach based on the parameter value.
-     *
-     * \param year  The year to apply the century selection to.
-     * \param century_window  Number describing how to handle dates with
-     *                        two digit years. Values 1 to 99 mean to use
-     *                        a sliding window starting that many years back.
-     *                        Values 1000 and higher mean to use a fixed window
-     *                        starting at the year given. The value 0 means to
-     *                        disallow two digit years.
-     *
-     * \returns  The adjusted year.
-     */
-    static int resolve_2digit_year(int year, int century_window);
-
-    /**
-     * Returns the current date in the local time zone.
-     */
-    static date_ymd get_current_local_date();
-
-    /**
-     * Returns an ndt::type corresponding to the date_ymd structure.
-     */
-    static const ndt::type& type();
+  /**
+   * Returns an ndt::type corresponding to the date_ymd structure.
+   */
+  static const ndt::type &type();
 };
 
 } // namespace dynd

--- a/include/dynd/types/datetime_util.hpp
+++ b/include/dynd/types/datetime_util.hpp
@@ -14,107 +14,100 @@
 namespace dynd {
 
 enum datetime_tz_t {
-    // The abstract time zone is disconnected from a real physical
-    // time. It is a time based on an abstract calendar.
-    tz_abstract,
-    // The UTC time zone. This cannot represent added leap seconds,
-    // as it is based on the POSIX approach.
-    tz_utc,
-    // TODO: A "time zone" based on TAI atomic clock time. This can represent
-    // the leap seconds UTC cannot, but converting to/from UTC is not
-    // lossless.
-    //tz_tai,
-    // TODO: other time zones based on a time zone database
-    // tz_other
+  // The abstract time zone is disconnected from a real physical
+  // time. It is a time based on an abstract calendar.
+  tz_abstract,
+  // The UTC time zone. This cannot represent added leap seconds,
+  // as it is based on the POSIX approach.
+  tz_utc,
+  // TODO: A "time zone" based on TAI atomic clock time. This can represent
+  // the leap seconds UTC cannot, but converting to/from UTC is not
+  // lossless.
+  // tz_tai,
+  // TODO: other time zones based on a time zone database
+  // tz_other
 };
 
 struct DYND_API datetime_struct {
-    date_ymd ymd;
-    time_hmst hmst;
+  date_ymd ymd;
+  time_hmst hmst;
 
-    inline bool is_valid() const {
-        return ymd.is_valid() && hmst.is_valid();
+  inline bool is_valid() const { return ymd.is_valid() && hmst.is_valid(); }
+
+  inline bool is_na() const { return ymd.is_na(); }
+
+  int64_t to_ticks() const
+  {
+    if (is_valid()) {
+      return ymd.to_days() * DYND_TICKS_PER_DAY + hmst.to_ticks();
     }
-
-    inline bool is_na() const {
-        return ymd.is_na();
+    else {
+      return DYND_DATETIME_NA;
     }
+  }
 
-    int64_t to_ticks() const {
-        if (is_valid()) {
-            return ymd.to_days() * DYND_TICKS_PER_DAY + hmst.to_ticks();
-        } else {
-            return DYND_DATETIME_NA;
+  std::string to_str() const;
+
+  void set_from_ticks(int64_t ticks)
+  {
+    if (ticks != DYND_DATETIME_NA) {
+      int32_t days;
+      if (ticks >= 0) {
+        days = static_cast<int32_t>(ticks / DYND_TICKS_PER_DAY);
+        ticks = ticks % DYND_TICKS_PER_DAY;
+      }
+      else {
+        days = static_cast<int32_t>((ticks - (DYND_TICKS_PER_DAY - 1)) / DYND_TICKS_PER_DAY);
+        ticks = ticks % DYND_TICKS_PER_DAY;
+        if (ticks < 0) {
+          ticks += DYND_TICKS_PER_DAY;
         }
+      }
+      ymd.set_from_days(days);
+      hmst.set_from_ticks(ticks);
     }
-
-    std::string to_str() const;
-
-    void set_from_ticks(int64_t ticks) {
-        if (ticks != DYND_DATETIME_NA) {
-            int32_t days;
-            if (ticks >= 0) {
-                days = static_cast<int32_t>(ticks / DYND_TICKS_PER_DAY);
-                ticks = ticks % DYND_TICKS_PER_DAY;
-            } else {
-                days = static_cast<int32_t>((ticks - (DYND_TICKS_PER_DAY - 1)) / DYND_TICKS_PER_DAY);
-                ticks = ticks % DYND_TICKS_PER_DAY;
-                if (ticks < 0) {
-                    ticks += DYND_TICKS_PER_DAY;
-                }
-            }
-            ymd.set_from_days(days);
-            hmst.set_from_ticks(ticks);
-        } else {
-            set_to_na();
-        }
+    else {
+      set_to_na();
     }
+  }
 
-    void set_to_na() {
-        ymd.set_to_na();
-    }
+  void set_to_na() { ymd.set_to_na(); }
 
-    /**
-     * Sets the datetime from a string. Accepts a wide variety of
-     * inputs, and interprets ambiguous formats like MM/DD/YY vs DD/MM/YY
-     * using the monthfirst parameter.
-     *
-     * \param s  Datetime string.
-     * \param ambig  Order to use for ambiguous cases like "01/02/03"
-     *               or "01/02/1995".
-     * \param century_window  Number describing how to handle dates with
-     *                        two digit years. Values 1 to 99 mean to use
-     *                        a sliding window starting that many years back.
-     *                        Values 1000 and higher mean to use a fixed window
-     *                        starting at the year given. The value 0 means to
-     *                        disallow two digit years.
-     * \param errmode  The error mode to use for how strict to be when converting
-     *                 values. In mode assign_error_nocheck, tries to do a "best interpretation"
-     *                 conversion.
-     *
-     * \returns  The time zone, if any, found in the string
-     */
-    inline std::string
-    set_from_str(const std::string &s,
-                 date_parse_order_t ambig = date_parse_no_ambig,
-                 int century_window = 70,
-                 assign_error_mode errmode = assign_error_fractional)
-    {
-        const char *tz_begin = NULL, *tz_end = NULL;
-        set_from_str(s.data(), s.data() + s.size(), ambig, century_window,
-                     errmode, tz_begin, tz_end);
-        return std::string(tz_begin, tz_end);
-    }
+  /**
+   * Sets the datetime from a string. Accepts a wide variety of
+   * inputs, and interprets ambiguous formats like MM/DD/YY vs DD/MM/YY
+   * using the monthfirst parameter.
+   *
+   * \param s  Datetime string.
+   * \param ambig  Order to use for ambiguous cases like "01/02/03"
+   *               or "01/02/1995".
+   * \param century_window  Number describing how to handle dates with
+   *                        two digit years. Values 1 to 99 mean to use
+   *                        a sliding window starting that many years back.
+   *                        Values 1000 and higher mean to use a fixed window
+   *                        starting at the year given. The value 0 means to
+   *                        disallow two digit years.
+   * \param errmode  The error mode to use for how strict to be when converting
+   *                 values. In mode assign_error_nocheck, tries to do a "best interpretation"
+   *                 conversion.
+   *
+   * \returns  The time zone, if any, found in the string
+   */
+  inline std::string set_from_str(const std::string &s, date_parse_order_t ambig = date_parse_no_ambig,
+                                  int century_window = 70, assign_error_mode errmode = assign_error_fractional)
+  {
+    const char *tz_begin = NULL, *tz_end = NULL;
+    set_from_str(s.data(), s.data() + s.size(), ambig, century_window, errmode, tz_begin, tz_end);
+    return std::string(tz_begin, tz_end);
+  }
 
-    void set_from_str(const char *begin, const char *end,
-                      date_parse_order_t ambig, int century_window,
-                      assign_error_mode errmode, const char *&out_tz_begin,
-                      const char *&out_tz_end);
+  void set_from_str(const char *begin, const char *end, date_parse_order_t ambig, int century_window,
+                    assign_error_mode errmode, const char *&out_tz_begin, const char *&out_tz_end);
 
-    /**
-     * Returns an ndt::type corresponding to the datetime_struct structure.
-     */
-    static const ndt::type& type();
+  /**
+   * Returns an ndt::type corresponding to the datetime_struct structure.
+   */
+  static const ndt::type &type();
 };
 
 } // namespace dynd

--- a/include/dynd/types/dim_fragment_type.hpp
+++ b/include/dynd/types/dim_fragment_type.hpp
@@ -20,7 +20,7 @@ namespace dynd {
 enum {
   dim_fragment_var = -1,
   dim_fragment_fixed_sym = -2
-                           // values >= 0 mean fixed[N]
+  // values >= 0 mean fixed[N]
 };
 
 namespace ndt {
@@ -41,10 +41,7 @@ namespace ndt {
      *   -2 : strided
      *   N >= 0 : fixed[N]
      */
-    inline const intptr_t *get_tagged_dims() const
-    {
-      return m_tagged_dims.get();
-    }
+    inline const intptr_t *get_tagged_dims() const { return m_tagged_dims.get(); }
 
     /**
      * Broadcasts this dim_fragment with some dimensions of
@@ -58,20 +55,15 @@ namespace ndt {
      */
     type apply_to_dtype(const type &dtp) const;
 
-    void print_data(std::ostream &o, const char *arrmeta,
-                    const char *data) const;
+    void print_data(std::ostream &o, const char *arrmeta, const char *data) const;
 
     void print_type(std::ostream &o) const;
 
-    type apply_linear_index(intptr_t nindices, const irange *indices,
-                            size_t current_i, const type &root_tp,
+    type apply_linear_index(intptr_t nindices, const irange *indices, size_t current_i, const type &root_tp,
                             bool leading_dimension) const;
-    intptr_t apply_linear_index(intptr_t nindices, const irange *indices,
-                                const char *arrmeta, const type &result_tp,
-                                char *out_arrmeta,
-                                const intrusive_ptr<memory_block_data> &embedded_reference,
-                                size_t current_i, const type &root_tp,
-                                bool leading_dimension, char **inout_data,
+    intptr_t apply_linear_index(intptr_t nindices, const irange *indices, const char *arrmeta, const type &result_tp,
+                                char *out_arrmeta, const intrusive_ptr<memory_block_data> &embedded_reference,
+                                size_t current_i, const type &root_tp, bool leading_dimension, char **inout_data,
                                 intrusive_ptr<memory_block_data> &inout_dataref) const;
 
     intptr_t get_dim_size(const char *arrmeta, const char *data) const;
@@ -83,9 +75,8 @@ namespace ndt {
     void arrmeta_default_construct(char *arrmeta, bool blockref_alloc) const;
     void arrmeta_copy_construct(char *dst_arrmeta, const char *src_arrmeta,
                                 const intrusive_ptr<memory_block_data> &embedded_reference) const;
-    size_t
-    arrmeta_copy_construct_onedim(char *dst_arrmeta, const char *src_arrmeta,
-                                  const intrusive_ptr<memory_block_data> &embedded_reference) const;
+    size_t arrmeta_copy_construct_onedim(char *dst_arrmeta, const char *src_arrmeta,
+                                         const intrusive_ptr<memory_block_data> &embedded_reference) const;
     void arrmeta_destruct(char *arrmeta) const;
 
     virtual type with_element_type(const type &element_tp) const;
@@ -99,7 +90,8 @@ namespace ndt {
   {
     if (ndim > 0) {
       return type(new dim_fragment_type(ndim, tagged_dims), false);
-    } else {
+    }
+    else {
       return make_dim_fragment();
     }
   }
@@ -109,7 +101,8 @@ namespace ndt {
   {
     if (ndim > 0) {
       return type(new dim_fragment_type(ndim, tp), false);
-    } else {
+    }
+    else {
       return make_dim_fragment();
     }
   }

--- a/include/dynd/types/fixed_bytes_kind_type.hpp
+++ b/include/dynd/types/fixed_bytes_kind_type.hpp
@@ -19,8 +19,7 @@ namespace ndt {
 
     size_t get_default_data_size() const;
 
-    void print_data(std::ostream &o, const char *arrmeta,
-                    const char *data) const;
+    void print_data(std::ostream &o, const char *arrmeta, const char *data) const;
 
     void print_type(std::ostream &o) const;
 
@@ -30,8 +29,7 @@ namespace ndt {
 
     bool is_lossless_assignment(const type &dst_tp, const type &src_tp) const;
 
-    void get_bytes_range(const char **out_begin, const char **out_end,
-                         const char *arrmeta, const char *data) const;
+    void get_bytes_range(const char **out_begin, const char **out_end, const char *arrmeta, const char *data) const;
 
     bool operator==(const base_type &rhs) const;
 
@@ -41,15 +39,12 @@ namespace ndt {
     void arrmeta_reset_buffers(char *arrmeta) const;
     void arrmeta_finalize_buffers(char *arrmeta) const;
     void arrmeta_destruct(char *arrmeta) const;
-    void arrmeta_debug_print(const char *arrmeta, std::ostream &o,
-                             const std::string &indent) const;
+    void arrmeta_debug_print(const char *arrmeta, std::ostream &o, const std::string &indent) const;
 
     void data_destruct(const char *arrmeta, char *data) const;
-    void data_destruct_strided(const char *arrmeta, char *data, intptr_t stride,
-                               size_t count) const;
+    void data_destruct_strided(const char *arrmeta, char *data, intptr_t stride, size_t count) const;
 
-    bool match(const char *arrmeta, const type &candidate_tp,
-               const char *candidate_arrmeta,
+    bool match(const char *arrmeta, const type &candidate_tp, const char *candidate_arrmeta,
                std::map<std::string, type> &tp_vars) const;
 
     static type make() { return type(new fixed_bytes_kind_type(), false); }

--- a/include/dynd/types/fixed_string_kind_type.hpp
+++ b/include/dynd/types/fixed_string_kind_type.hpp
@@ -49,10 +49,7 @@ namespace ndt {
     bool match(const char *arrmeta, const type &candidate_tp, const char *candidate_arrmeta,
                std::map<std::string, type> &tp_vars) const;
 
-    static type make()
-    {
-      return type(new fixed_string_kind_type(), false);
-    }
+    static type make() { return type(new fixed_string_kind_type(), false); }
   };
 
 } // namespace dynd::ndt

--- a/include/dynd/types/int_kind_sym_type.hpp
+++ b/include/dynd/types/int_kind_sym_type.hpp
@@ -18,17 +18,14 @@ namespace ndt {
 
     size_t get_default_data_size() const;
 
-    void print_data(std::ostream &o, const char *arrmeta,
-                    const char *data) const;
+    void print_data(std::ostream &o, const char *arrmeta, const char *data) const;
 
     void print_type(std::ostream &o) const;
 
     bool is_expression() const;
     bool is_unique_data_owner(const char *arrmeta) const;
-    void transform_child_types(type_transform_fn_t transform_fn,
-                               intptr_t arrmeta_offset, void *extra,
-                               type &out_transformed_tp,
-                               bool &out_was_transformed) const;
+    void transform_child_types(type_transform_fn_t transform_fn, intptr_t arrmeta_offset, void *extra,
+                               type &out_transformed_tp, bool &out_was_transformed) const;
     type get_canonical_type() const;
 
     bool is_lossless_assignment(const type &dst_tp, const type &src_tp) const;
@@ -41,25 +38,18 @@ namespace ndt {
     void arrmeta_reset_buffers(char *arrmeta) const;
     void arrmeta_finalize_buffers(char *arrmeta) const;
     void arrmeta_destruct(char *arrmeta) const;
-    void arrmeta_debug_print(const char *arrmeta, std::ostream &o,
-                             const std::string &indent) const;
-    size_t
-    arrmeta_copy_construct_onedim(char *dst_arrmeta, const char *src_arrmeta,
-                                  memory_block_data *embedded_reference) const;
+    void arrmeta_debug_print(const char *arrmeta, std::ostream &o, const std::string &indent) const;
+    size_t arrmeta_copy_construct_onedim(char *dst_arrmeta, const char *src_arrmeta,
+                                         memory_block_data *embedded_reference) const;
 
     void data_destruct(const char *arrmeta, char *data) const;
-    void data_destruct_strided(const char *arrmeta, char *data, intptr_t stride,
-                               size_t count) const;
+    void data_destruct_strided(const char *arrmeta, char *data, intptr_t stride, size_t count) const;
 
-    bool match(const char *arrmeta, const type &candidate_tp,
-               const char *candidate_arrmeta,
+    bool match(const char *arrmeta, const type &candidate_tp, const char *candidate_arrmeta,
                std::map<std::string, type> &tp_vars) const;
   };
 
-  inline type make_int_kind_sym()
-  {
-    return type(new int_kind_sym_type(), false);
-  }
+  inline type make_int_kind_sym() { return type(new int_kind_sym_type(), false); }
 
 } // namespace dynd::ndt
 } // namespace dynd

--- a/include/dynd/types/kind_sym_type.hpp
+++ b/include/dynd/types/kind_sym_type.hpp
@@ -20,17 +20,14 @@ namespace ndt {
 
     size_t get_default_data_size() const;
 
-    void print_data(std::ostream &o, const char *arrmeta,
-                    const char *data) const;
+    void print_data(std::ostream &o, const char *arrmeta, const char *data) const;
 
     void print_type(std::ostream &o) const;
 
     bool is_expression() const;
     bool is_unique_data_owner(const char *arrmeta) const;
-    void transform_child_types(type_transform_fn_t transform_fn,
-                               intptr_t arrmeta_offset, void *extra,
-                               type &out_transformed_tp,
-                               bool &out_was_transformed) const;
+    void transform_child_types(type_transform_fn_t transform_fn, intptr_t arrmeta_offset, void *extra,
+                               type &out_transformed_tp, bool &out_was_transformed) const;
     type get_canonical_type() const;
 
     bool is_lossless_assignment(const type &dst_tp, const type &src_tp) const;
@@ -43,25 +40,18 @@ namespace ndt {
     void arrmeta_reset_buffers(char *arrmeta) const;
     void arrmeta_finalize_buffers(char *arrmeta) const;
     void arrmeta_destruct(char *arrmeta) const;
-    void arrmeta_debug_print(const char *arrmeta, std::ostream &o,
-                             const std::string &indent) const;
-    size_t
-    arrmeta_copy_construct_onedim(char *dst_arrmeta, const char *src_arrmeta,
-                                  memory_block_data *embedded_reference) const;
+    void arrmeta_debug_print(const char *arrmeta, std::ostream &o, const std::string &indent) const;
+    size_t arrmeta_copy_construct_onedim(char *dst_arrmeta, const char *src_arrmeta,
+                                         memory_block_data *embedded_reference) const;
 
     void data_destruct(const char *arrmeta, char *data) const;
-    void data_destruct_strided(const char *arrmeta, char *data, intptr_t stride,
-                               size_t count) const;
+    void data_destruct_strided(const char *arrmeta, char *data, intptr_t stride, size_t count) const;
 
-    bool match(const char *arrmeta, const type &candidate_tp,
-               const char *candidate_arrmeta,
+    bool match(const char *arrmeta, const type &candidate_tp, const char *candidate_arrmeta,
                std::map<std::string, type> &tp_vars) const;
   };
 
-  inline type make_kind_sym(type_kind_t kind)
-  {
-    return type(new kind_sym_type(kind), false);
-  }
+  inline type make_kind_sym(type_kind_t kind) { return type(new kind_sym_type(kind), false); }
 
 } // namespace dynd::ndt
 } // namespace dynd

--- a/include/dynd/types/pow_dimsym_type.hpp
+++ b/include/dynd/types/pow_dimsym_type.hpp
@@ -19,8 +19,7 @@ namespace ndt {
     std::string m_exponent;
 
   public:
-    pow_dimsym_type(const type &base_tp, const std::string &exponent,
-                    const type &element_type);
+    pow_dimsym_type(const type &base_tp, const std::string &exponent, const type &element_type);
 
     virtual ~pow_dimsym_type() {}
 
@@ -28,20 +27,15 @@ namespace ndt {
 
     const std::string &get_exponent() const { return m_exponent; }
 
-    void print_data(std::ostream &o, const char *arrmeta,
-                    const char *data) const;
+    void print_data(std::ostream &o, const char *arrmeta, const char *data) const;
 
     void print_type(std::ostream &o) const;
 
-    type apply_linear_index(intptr_t nindices, const irange *indices,
-                            size_t current_i, const type &root_tp,
+    type apply_linear_index(intptr_t nindices, const irange *indices, size_t current_i, const type &root_tp,
                             bool leading_dimension) const;
-    intptr_t apply_linear_index(intptr_t nindices, const irange *indices,
-                                const char *arrmeta, const type &result_tp,
-                                char *out_arrmeta,
-                                const intrusive_ptr<memory_block_data> &embedded_reference,
-                                size_t current_i, const type &root_tp,
-                                bool leading_dimension, char **inout_data,
+    intptr_t apply_linear_index(intptr_t nindices, const irange *indices, const char *arrmeta, const type &result_tp,
+                                char *out_arrmeta, const intrusive_ptr<memory_block_data> &embedded_reference,
+                                size_t current_i, const type &root_tp, bool leading_dimension, char **inout_data,
                                 intrusive_ptr<memory_block_data> &inout_dataref) const;
 
     intptr_t get_dim_size(const char *arrmeta, const char *data) const;
@@ -53,21 +47,18 @@ namespace ndt {
     void arrmeta_default_construct(char *arrmeta, bool blockref_alloc) const;
     void arrmeta_copy_construct(char *dst_arrmeta, const char *src_arrmeta,
                                 const intrusive_ptr<memory_block_data> &embedded_reference) const;
-    size_t
-    arrmeta_copy_construct_onedim(char *dst_arrmeta, const char *src_arrmeta,
-                                  const intrusive_ptr<memory_block_data> &embedded_reference) const;
+    size_t arrmeta_copy_construct_onedim(char *dst_arrmeta, const char *src_arrmeta,
+                                         const intrusive_ptr<memory_block_data> &embedded_reference) const;
     void arrmeta_destruct(char *arrmeta) const;
 
-    bool match(const char *arrmeta, const type &candidate_tp,
-               const char *candidate_arrmeta,
+    bool match(const char *arrmeta, const type &candidate_tp, const char *candidate_arrmeta,
                std::map<std::string, type> &tp_vars) const;
 
     virtual type with_element_type(const type &element_tp) const;
   }; // class pow_dimsym_type
 
   /** Makes a dimensional power type with the specified base and exponent */
-  inline type make_pow_dimsym(const type &base_tp, const std::string &exponent,
-                              const type &element_type)
+  inline type make_pow_dimsym(const type &base_tp, const std::string &exponent, const type &element_type)
   {
     return type(new pow_dimsym_type(base_tp, exponent, element_type), false);
   }

--- a/include/dynd/types/scalar_kind_type.hpp
+++ b/include/dynd/types/scalar_kind_type.hpp
@@ -18,8 +18,7 @@ namespace ndt {
 
     bool operator==(const base_type &rhs) const;
 
-    bool match(const char *arrmeta, const type &candidate_tp,
-               const char *candidate_arrmeta,
+    bool match(const char *arrmeta, const type &candidate_tp, const char *candidate_arrmeta,
                std::map<std::string, type> &tp_vars) const;
 
     void print_type(std::ostream &o) const;

--- a/include/dynd/types/substitute_shape.hpp
+++ b/include/dynd/types/substitute_shape.hpp
@@ -9,19 +9,19 @@
 
 #include <dynd/type.hpp>
 
-namespace dynd { namespace ndt {
+namespace dynd {
+namespace ndt {
 
-/**
- * Substitutes a shape into a pattern type.
- *
- * For example, can combine a type "Fixed * Fixed * int32" with
- * a shape (3, 6) to produce the type "3 * 6 * int32".
- *
- * \param pattern  A symbolic type within which to substitute the shape.
- * \param ndim  Number of dimensions in the shape.
- * \param shape  The dimensions to substitute.
- */
-DYND_API ndt::type substitute_shape(const ndt::type &pattern, intptr_t ndim,
-                           const intptr_t *shape);
-
-}} // namespace dynd::ndt
+  /**
+   * Substitutes a shape into a pattern type.
+   *
+   * For example, can combine a type "Fixed * Fixed * int32" with
+   * a shape (3, 6) to produce the type "3 * 6 * int32".
+   *
+   * \param pattern  A symbolic type within which to substitute the shape.
+   * \param ndim  Number of dimensions in the shape.
+   * \param shape  The dimensions to substitute.
+   */
+  DYND_API ndt::type substitute_shape(const ndt::type &pattern, intptr_t ndim, const intptr_t *shape);
+}
+} // namespace dynd::ndt

--- a/include/dynd/types/time_util.hpp
+++ b/include/dynd/types/time_util.hpp
@@ -25,102 +25,90 @@
 namespace dynd {
 
 namespace ndt {
-    class type;
+  class type;
 } // namespace ndt
 
 struct DYND_API time_hmst {
-    int8_t hour;
-    int8_t minute;
-    int8_t second;
-    int32_t tick;
+  int8_t hour;
+  int8_t minute;
+  int8_t second;
+  int32_t tick;
 
-    static inline bool is_valid(int hour, int minute, int second, int tick) {
-        return hour >= 0 && hour < 24 && minute >= 0 && minute < 60 &&
-               second >= 0 && second <= 60 && // leap second can == 60
-               tick >= 0 && tick < DYND_TICKS_PER_SECOND;
-    }
+  static inline bool is_valid(int hour, int minute, int second, int tick)
+  {
+    return hour >= 0 && hour < 24 && minute >= 0 && minute < 60 && second >= 0 &&
+           second <= 60 && // leap second can == 60
+           tick >= 0 && tick < DYND_TICKS_PER_SECOND;
+  }
 
-    inline bool is_valid() const {
-        return is_valid(hour, minute, second, tick);
-    }
+  inline bool is_valid() const { return is_valid(hour, minute, second, tick); }
 
-    inline bool is_na() const {
-        return hour == -128;
-    }
+  inline bool is_na() const { return hour == -128; }
 
-    /**
-     * Converts the hmst to a ticks offset from midnight.
-     */
-    static int64_t to_ticks(int hour, int minute, int second, int tick);
+  /**
+   * Converts the hmst to a ticks offset from midnight.
+   */
+  static int64_t to_ticks(int hour, int minute, int second, int tick);
 
-    /**
-     * Converts the hmst to a ticks offset from midnight.
-     */
-    int64_t to_ticks() const {
-        return to_ticks(hour, minute, second, tick);
-    }
+  /**
+   * Converts the hmst to a ticks offset from midnight.
+   */
+  int64_t to_ticks() const { return to_ticks(hour, minute, second, tick); }
 
-    /**
-     * Converts the hmst into an ISO 8601 string, or "" if it
-     * is invalid. Uses the shortest representation, except for
-     * having at least minutes. ##:##:##.#####.
-     */
-    static std::string to_str(int hour, int minute, int second, int tick);
+  /**
+   * Converts the hmst into an ISO 8601 string, or "" if it
+   * is invalid. Uses the shortest representation, except for
+   * having at least minutes. ##:##:##.#####.
+   */
+  static std::string to_str(int hour, int minute, int second, int tick);
 
-    /**
-     * Converts the hmst into an ISO 8601 string, or "" if it
-     * is invalid. Uses the shortest representation, except for
-     * having at least minutes. ##:##:##.#####.
-     */
-    inline std::string to_str() const {
-        return to_str(hour, minute, second, tick);
-    }
+  /**
+   * Converts the hmst into an ISO 8601 string, or "" if it
+   * is invalid. Uses the shortest representation, except for
+   * having at least minutes. ##:##:##.#####.
+   */
+  inline std::string to_str() const { return to_str(hour, minute, second, tick); }
 
-    /**
-     * Sets the hmst from a ticks value.
-     *
-     * \param ticks  A ticks offset from midnight.
-     */
-    void set_from_ticks(int64_t ticks);
+  /**
+   * Sets the hmst from a ticks value.
+   *
+   * \param ticks  A ticks offset from midnight.
+   */
+  void set_from_ticks(int64_t ticks);
 
-    /**
-     * Sets the hmst to NA.
-     */
-    inline void set_to_zero() {
-        memset(this, 0, sizeof(*this));
-    }
+  /**
+   * Sets the hmst to NA.
+   */
+  inline void set_to_zero() { memset(this, 0, sizeof(*this)); }
 
-    /**
-     * Sets the hmst to NA.
-     */
-    inline void set_to_na() {
-        hour = -128;
-    }
-    void set_from_str(const char *begin, const char *end,
-                      const char *&out_tz_begin, const char *&out_tz_end);
-    /**
-     * Sets the hmst from a string.
-     *
-     * \param s  Date string.
-     *
-     * \returns  The time zone, if any, found in the string
-     */
-    inline std::string set_from_str(const std::string& s) {
-        const char *tz_begin = NULL, *tz_end = NULL;
-        set_from_str(s.data(), s.data() + s.size(), tz_begin, tz_end);
-        return std::string(tz_begin, tz_end);
-    }
+  /**
+   * Sets the hmst to NA.
+   */
+  inline void set_to_na() { hour = -128; }
+  void set_from_str(const char *begin, const char *end, const char *&out_tz_begin, const char *&out_tz_end);
+  /**
+   * Sets the hmst from a string.
+   *
+   * \param s  Date string.
+   *
+   * \returns  The time zone, if any, found in the string
+   */
+  inline std::string set_from_str(const std::string &s)
+  {
+    const char *tz_begin = NULL, *tz_end = NULL;
+    set_from_str(s.data(), s.data() + s.size(), tz_begin, tz_end);
+    return std::string(tz_begin, tz_end);
+  }
 
+  /**
+   * Returns the current time in the local time zone.
+   */
+  static time_hmst get_current_local_time();
 
-    /**
-     * Returns the current time in the local time zone.
-     */
-    static time_hmst get_current_local_time();
-
-    /**
-     * Returns an ndt::type corresponding to the time_hmst structure.
-     */
-    static const ndt::type& type();
+  /**
+   * Returns an ndt::type corresponding to the time_hmst structure.
+   */
+  static const ndt::type &type();
 };
 
 } // namespace dynd

--- a/include/dynd/types/type_alignment.hpp
+++ b/include/dynd/types/type_alignment.hpp
@@ -7,21 +7,22 @@
 
 #include <dynd/type.hpp>
 
-namespace dynd { namespace ndt {
+namespace dynd {
+namespace ndt {
 
-/**
- * Uses an appropriate view<..., bytes<>> type
- * to put the type on top of unaligned storage.
- */
-DYND_API ndt::type make_unaligned(const ndt::type& value_type);
+  /**
+   * Uses an appropriate view<..., bytes<>> type
+   * to put the type on top of unaligned storage.
+   */
+  DYND_API ndt::type make_unaligned(const ndt::type &value_type);
 
-/**
- * Reduces a type's alignment requirements to 1.
- */
-template<typename T>
-ndt::type make_unaligned()
-{
+  /**
+   * Reduces a type's alignment requirements to 1.
+   */
+  template <typename T>
+  ndt::type make_unaligned()
+  {
     return make_unaligned(make_type<T>());
+  }
 }
-
-}} // namespace dynd::ndt
+} // namespace dynd::ndt

--- a/include/dynd/types/typevar_constructed_type.hpp
+++ b/include/dynd/types/typevar_constructed_type.hpp
@@ -28,22 +28,17 @@ namespace ndt {
 
     void get_vars(std::unordered_set<std::string> &vars) const;
 
-    void print_data(std::ostream &o, const char *arrmeta,
-                    const char *data) const;
+    void print_data(std::ostream &o, const char *arrmeta, const char *data) const;
 
     void print_type(std::ostream &o) const;
 
     intptr_t get_dim_size(const char *arrmeta, const char *data) const;
 
-    type apply_linear_index(intptr_t nindices, const irange *indices,
-                            size_t current_i, const type &root_tp,
+    type apply_linear_index(intptr_t nindices, const irange *indices, size_t current_i, const type &root_tp,
                             bool leading_dimension) const;
-    intptr_t apply_linear_index(intptr_t nindices, const irange *indices,
-                                const char *arrmeta, const type &result_tp,
-                                char *out_arrmeta,
-                                const intrusive_ptr<memory_block_data> &embedded_reference,
-                                size_t current_i, const type &root_tp,
-                                bool leading_dimension, char **inout_data,
+    intptr_t apply_linear_index(intptr_t nindices, const irange *indices, const char *arrmeta, const type &result_tp,
+                                char *out_arrmeta, const intrusive_ptr<memory_block_data> &embedded_reference,
+                                size_t current_i, const type &root_tp, bool leading_dimension, char **inout_data,
                                 intrusive_ptr<memory_block_data> &inout_dataref) const;
 
     bool is_lossless_assignment(const type &dst_tp, const type &src_tp) const;
@@ -55,8 +50,7 @@ namespace ndt {
                                 const intrusive_ptr<memory_block_data> &embedded_reference) const;
     void arrmeta_destruct(char *arrmeta) const;
 
-    bool match(const char *arrmeta, const type &candidate_tp,
-               const char *candidate_arrmeta,
+    bool match(const char *arrmeta, const type &candidate_tp, const char *candidate_arrmeta,
                std::map<std::string, type> &tp_vars) const;
 
     /*

--- a/src/dynd/types/any_kind_type.cpp
+++ b/src/dynd/types/any_kind_type.cpp
@@ -12,8 +12,7 @@ using namespace std;
 using namespace dynd;
 
 ndt::any_kind_type::any_kind_type()
-    : base_type(any_kind_id, kind_kind, 0, 1,
-                type_flag_symbolic | type_flag_variadic, 0, 0, 0)
+    : base_type(any_kind_id, kind_kind, 0, 1, type_flag_symbolic | type_flag_variadic, 0, 0, 0)
 {
 }
 
@@ -26,8 +25,7 @@ size_t ndt::any_kind_type::get_default_data_size() const
   throw runtime_error(ss.str());
 }
 
-void ndt::any_kind_type::print_data(std::ostream &DYND_UNUSED(o),
-                                    const char *DYND_UNUSED(arrmeta),
+void ndt::any_kind_type::print_data(std::ostream &DYND_UNUSED(o), const char *DYND_UNUSED(arrmeta),
                                     const char *DYND_UNUSED(data)) const
 {
   throw type_error("Cannot store data of symbolic any kind type");
@@ -37,49 +35,35 @@ void ndt::any_kind_type::print_type(std::ostream &o) const { o << "Any"; }
 
 bool ndt::any_kind_type::is_expression() const { return false; }
 
-bool
-ndt::any_kind_type::is_unique_data_owner(const char *DYND_UNUSED(arrmeta)) const
-{
-  return false;
-}
+bool ndt::any_kind_type::is_unique_data_owner(const char *DYND_UNUSED(arrmeta)) const { return false; }
 
-void ndt::any_kind_type::transform_child_types(
-    type_transform_fn_t DYND_UNUSED(transform_fn),
-    intptr_t DYND_UNUSED(arrmeta_offset), void *DYND_UNUSED(extra),
-    type &out_transformed_tp, bool &DYND_UNUSED(out_was_transformed)) const
+void ndt::any_kind_type::transform_child_types(type_transform_fn_t DYND_UNUSED(transform_fn),
+                                               intptr_t DYND_UNUSED(arrmeta_offset), void *DYND_UNUSED(extra),
+                                               type &out_transformed_tp, bool &DYND_UNUSED(out_was_transformed)) const
 {
   out_transformed_tp = type(this, true);
 }
 
-ndt::type ndt::any_kind_type::get_canonical_type() const
+ndt::type ndt::any_kind_type::get_canonical_type() const { return type(this, true); }
+
+ndt::type ndt::any_kind_type::at_single(intptr_t DYND_UNUSED(i0), const char **DYND_UNUSED(inout_arrmeta),
+                                        const char **DYND_UNUSED(inout_data)) const
 {
   return type(this, true);
 }
 
-ndt::type
-ndt::any_kind_type::at_single(intptr_t DYND_UNUSED(i0),
-                              const char **DYND_UNUSED(inout_arrmeta),
-                              const char **DYND_UNUSED(inout_data)) const
+ndt::type ndt::any_kind_type::get_type_at_dimension(char **DYND_UNUSED(inout_arrmeta), intptr_t DYND_UNUSED(i),
+                                                    intptr_t DYND_UNUSED(total_ndim)) const
 {
   return type(this, true);
 }
 
-ndt::type ndt::any_kind_type::get_type_at_dimension(
-    char **DYND_UNUSED(inout_arrmeta), intptr_t DYND_UNUSED(i),
-    intptr_t DYND_UNUSED(total_ndim)) const
-{
-  return type(this, true);
-}
-
-intptr_t ndt::any_kind_type::get_dim_size(const char *DYND_UNUSED(arrmeta),
-                                          const char *DYND_UNUSED(data)) const
+intptr_t ndt::any_kind_type::get_dim_size(const char *DYND_UNUSED(arrmeta), const char *DYND_UNUSED(data)) const
 {
   return -1;
 }
 
-void ndt::any_kind_type::get_shape(intptr_t ndim, intptr_t i,
-                                   intptr_t *out_shape,
-                                   const char *DYND_UNUSED(arrmeta),
+void ndt::any_kind_type::get_shape(intptr_t ndim, intptr_t i, intptr_t *out_shape, const char *DYND_UNUSED(arrmeta),
                                    const char *DYND_UNUSED(data)) const
 {
   for (; i < ndim; ++i) {
@@ -87,8 +71,7 @@ void ndt::any_kind_type::get_shape(intptr_t ndim, intptr_t i,
   }
 }
 
-bool ndt::any_kind_type::is_lossless_assignment(
-    const type &DYND_UNUSED(dst_tp), const type &DYND_UNUSED(src_tp)) const
+bool ndt::any_kind_type::is_lossless_assignment(const type &DYND_UNUSED(dst_tp), const type &DYND_UNUSED(src_tp)) const
 {
   return false;
 }
@@ -97,17 +80,16 @@ bool ndt::any_kind_type::operator==(const base_type &rhs) const
 {
   if (this == &rhs) {
     return true;
-  } else {
+  }
+  else {
     return rhs.get_id() == any_kind_id;
   }
 }
 
-void ndt::any_kind_type::arrmeta_default_construct(
-    char *DYND_UNUSED(arrmeta), bool DYND_UNUSED(blockref_alloc)) const
+void ndt::any_kind_type::arrmeta_default_construct(char *DYND_UNUSED(arrmeta), bool DYND_UNUSED(blockref_alloc)) const
 {
   stringstream ss;
-  ss << "Cannot default construct arrmeta for symbolic type "
-     << type(this, true);
+  ss << "Cannot default construct arrmeta for symbolic type " << type(this, true);
   throw runtime_error(ss.str());
 }
 
@@ -120,57 +102,47 @@ void ndt::any_kind_type::arrmeta_copy_construct(
   throw runtime_error(ss.str());
 }
 
-size_t ndt::any_kind_type::arrmeta_copy_construct_onedim(
-    char *DYND_UNUSED(dst_arrmeta), const char *DYND_UNUSED(src_arrmeta),
-    memory_block_data *DYND_UNUSED(embedded_reference)) const
+size_t ndt::any_kind_type::arrmeta_copy_construct_onedim(char *DYND_UNUSED(dst_arrmeta),
+                                                         const char *DYND_UNUSED(src_arrmeta),
+                                                         memory_block_data *DYND_UNUSED(embedded_reference)) const
 {
   stringstream ss;
   ss << "Cannot copy construct arrmeta for symbolic type " << type(this, true);
   throw runtime_error(ss.str());
 }
 
-void ndt::any_kind_type::arrmeta_reset_buffers(char *DYND_UNUSED(arrmeta)) const
-{
-}
+void ndt::any_kind_type::arrmeta_reset_buffers(char *DYND_UNUSED(arrmeta)) const {}
 
-void
-ndt::any_kind_type::arrmeta_finalize_buffers(char *DYND_UNUSED(arrmeta)) const
-{
-}
+void ndt::any_kind_type::arrmeta_finalize_buffers(char *DYND_UNUSED(arrmeta)) const {}
 
 void ndt::any_kind_type::arrmeta_destruct(char *DYND_UNUSED(arrmeta)) const {}
 
-void ndt::any_kind_type::arrmeta_debug_print(
-    const char *DYND_UNUSED(arrmeta), std::ostream &DYND_UNUSED(o),
-    const std::string &DYND_UNUSED(indent)) const
+void ndt::any_kind_type::arrmeta_debug_print(const char *DYND_UNUSED(arrmeta), std::ostream &DYND_UNUSED(o),
+                                             const std::string &DYND_UNUSED(indent)) const
 {
   stringstream ss;
   ss << "Cannot have arrmeta for symbolic type " << type(this, true);
   throw runtime_error(ss.str());
 }
 
-void ndt::any_kind_type::data_destruct(const char *DYND_UNUSED(arrmeta),
-                                       char *DYND_UNUSED(data)) const
+void ndt::any_kind_type::data_destruct(const char *DYND_UNUSED(arrmeta), char *DYND_UNUSED(data)) const
 {
   stringstream ss;
   ss << "Cannot have data for symbolic type " << type(this, true);
   throw runtime_error(ss.str());
 }
 
-void ndt::any_kind_type::data_destruct_strided(const char *DYND_UNUSED(arrmeta),
-                                               char *DYND_UNUSED(data),
-                                               intptr_t DYND_UNUSED(stride),
-                                               size_t DYND_UNUSED(count)) const
+void ndt::any_kind_type::data_destruct_strided(const char *DYND_UNUSED(arrmeta), char *DYND_UNUSED(data),
+                                               intptr_t DYND_UNUSED(stride), size_t DYND_UNUSED(count)) const
 {
   stringstream ss;
   ss << "Cannot have data for symbolic type " << type(this, true);
   throw runtime_error(ss.str());
 }
 
-bool ndt::any_kind_type::match(
-    const char *DYND_UNUSED(arrmeta), const type &DYND_UNUSED(candidate_tp),
-    const char *DYND_UNUSED(candidate_arrmeta),
-    std::map<std::string, type> &DYND_UNUSED(tp_vars)) const
+bool ndt::any_kind_type::match(const char *DYND_UNUSED(arrmeta), const type &DYND_UNUSED(candidate_tp),
+                               const char *DYND_UNUSED(candidate_arrmeta),
+                               std::map<std::string, type> &DYND_UNUSED(tp_vars)) const
 {
   // "Any" matches against everything
   return true;

--- a/src/dynd/types/array_type.cpp
+++ b/src/dynd/types/array_type.cpp
@@ -17,9 +17,7 @@ ndt::array_type::array_type(const type &value_tp)
 {
 }
 
-ndt::array_type::~array_type()
-{
-}
+ndt::array_type::~array_type() {}
 
 bool ndt::array_type::operator==(const base_type &rhs) const
 {
@@ -30,10 +28,7 @@ bool ndt::array_type::operator==(const base_type &rhs) const
   return rhs.get_id() == array_id;
 }
 
-void ndt::array_type::data_construct(const char *DYND_UNUSED(arrmeta), char *data) const
-{
-  new (data) nd::array();
-}
+void ndt::array_type::data_construct(const char *DYND_UNUSED(arrmeta), char *data) const { new (data) nd::array(); }
 
 void ndt::array_type::data_destruct(const char *DYND_UNUSED(arrmeta), char *data) const
 {
@@ -45,15 +40,13 @@ void ndt::array_type::print_data(std::ostream &o, const char *DYND_UNUSED(arrmet
   const nd::array &a = *reinterpret_cast<const nd::array *>(data);
   if (a.is_null()) {
     o << "null";
-  } else {
+  }
+  else {
     a.get_type().print_data(o, a.get()->metadata(), a.cdata());
   }
 }
 
-void ndt::array_type::print_type(ostream &o) const
-{
-  o << "array[" << m_value_tp << "]";
-}
+void ndt::array_type::print_type(ostream &o) const { o << "array[" << m_value_tp << "]"; }
 
 ndt::type ndt::array_type::with_replaced_storage_type(const type &) const
 {

--- a/src/dynd/types/base_bytes_type.cpp
+++ b/src/dynd/types/base_bytes_type.cpp
@@ -10,7 +10,4 @@ using namespace dynd;
 
 ndt::base_bytes_type::~base_bytes_type() {}
 
-size_t ndt::base_bytes_type::get_iterdata_size(intptr_t DYND_UNUSED(ndim)) const
-{
-  return 0;
-}
+size_t ndt::base_bytes_type::get_iterdata_size(intptr_t DYND_UNUSED(ndim)) const { return 0; }

--- a/src/dynd/types/base_dim_type.cpp
+++ b/src/dynd/types/base_dim_type.cpp
@@ -10,9 +10,7 @@
 using namespace std;
 using namespace dynd;
 
-ndt::base_dim_type::~base_dim_type()
-{
-}
+ndt::base_dim_type::~base_dim_type() {}
 
 void ndt::base_dim_type::get_element_types(std::size_t ndim, const type **element_tp) const
 {

--- a/src/dynd/types/base_type.cpp
+++ b/src/dynd/types/base_type.cpp
@@ -271,46 +271,16 @@ bool ndt::base_type::reverse_adapt_type(const type &DYND_UNUSED(value_tp), const
 
 // Some information about the builtin types
 
-DYND_API uint8_t ndt::detail::builtin_data_sizes[builtin_id_count] = {0,
-                                                                      sizeof(bool1),
-                                                                      sizeof(int8),
-                                                                      sizeof(int16),
-                                                                      sizeof(int32),
-                                                                      sizeof(int64),
-                                                                      sizeof(int128),
-                                                                      sizeof(uint8),
-                                                                      sizeof(uint16),
-                                                                      sizeof(uint32),
-                                                                      sizeof(uint64),
-                                                                      sizeof(uint128),
-                                                                      sizeof(float16),
-                                                                      sizeof(float32),
-                                                                      sizeof(float64),
-                                                                      sizeof(float128),
-                                                                      sizeof(dynd::complex<float>),
-                                                                      sizeof(dynd::complex<double>),
-                                                                      0};
+DYND_API uint8_t ndt::detail::builtin_data_sizes[builtin_id_count] = {
+    0, sizeof(bool1), sizeof(int8), sizeof(int16), sizeof(int32), sizeof(int64), sizeof(int128), sizeof(uint8),
+    sizeof(uint16), sizeof(uint32), sizeof(uint64), sizeof(uint128), sizeof(float16), sizeof(float32), sizeof(float64),
+    sizeof(float128), sizeof(dynd::complex<float>), sizeof(dynd::complex<double>), 0};
 
 DYND_API uint8_t ndt::detail::builtin_kinds[builtin_id_count] = {
     void_kind, bool_kind, sint_kind, sint_kind, sint_kind, sint_kind, sint_kind,    uint_kind,    uint_kind, uint_kind,
     uint_kind, uint_kind, real_kind, real_kind, real_kind, real_kind, complex_kind, complex_kind, void_kind};
 
-DYND_API uint8_t ndt::detail::builtin_data_alignments[builtin_id_count] = {1,
-                                                                           1,
-                                                                           alignof(int8),
-                                                                           alignof(int16),
-                                                                           alignof(int32),
-                                                                           alignof(int64),
-                                                                           alignof(int128),
-                                                                           alignof(uint8),
-                                                                           alignof(uint16),
-                                                                           alignof(uint32),
-                                                                           alignof(uint64),
-                                                                           alignof(uint128),
-                                                                           alignof(float16),
-                                                                           alignof(float32),
-                                                                           alignof(float64),
-                                                                           alignof(float128),
-                                                                           alignof(dynd::complex<float>),
-                                                                           alignof(dynd::complex<double>),
-                                                                           1};
+DYND_API uint8_t ndt::detail::builtin_data_alignments[builtin_id_count] = {
+    1, 1, alignof(int8), alignof(int16), alignof(int32), alignof(int64), alignof(int128), alignof(uint8),
+    alignof(uint16), alignof(uint32), alignof(uint64), alignof(uint128), alignof(float16), alignof(float32),
+    alignof(float64), alignof(float128), alignof(dynd::complex<float>), alignof(dynd::complex<double>), 1};

--- a/src/dynd/types/busdate_type.cpp
+++ b/src/dynd/types/busdate_type.cpp
@@ -14,10 +14,8 @@
 using namespace std;
 using namespace dynd;
 
-ndt::busdate_type::busdate_type(busdate_roll_t roll, const bool *weekmask,
-                                const nd::array &holidays)
-    : base_type(busdate_id, datetime_kind, 4, 4, type_flag_none, 0, 0, 0),
-      m_roll(roll)
+ndt::busdate_type::busdate_type(busdate_roll_t roll, const bool *weekmask, const nd::array &holidays)
+    : base_type(busdate_id, datetime_kind, 4, 4, type_flag_none, 0, 0, 0), m_roll(roll)
 {
   memcpy(m_workweek, weekmask, sizeof(m_workweek));
   m_busdays_in_weekmask = 0;
@@ -31,9 +29,7 @@ ndt::busdate_type::busdate_type(busdate_roll_t roll, const bool *weekmask,
   }
 }
 
-ndt::busdate_type::~busdate_type()
-{
-}
+ndt::busdate_type::~busdate_type() {}
 
 void ndt::busdate_type::print_workweek(std::ostream &o) const
 {
@@ -58,26 +54,25 @@ void ndt::busdate_type::print_holidays(std::ostream & /*o*/) const
   throw std::runtime_error("busdate_type::print_holidays to be implemented");
 }
 
-void ndt::busdate_type::print_data(std::ostream &o,
-                                   const char *DYND_UNUSED(arrmeta),
-                                   const char *data) const
+void ndt::busdate_type::print_data(std::ostream &o, const char *DYND_UNUSED(arrmeta), const char *data) const
 {
   date_ymd ymd;
   ymd.set_from_days(*reinterpret_cast<const int32_t *>(data));
   std::string s = ymd.to_str();
   if (s.empty()) {
     o << "NA";
-  } else {
+  }
+  else {
     o << s;
   }
 }
 
 void ndt::busdate_type::print_type(std::ostream &o) const
 {
-  if (m_roll == busdate_roll_following && is_default_workweek() &&
-      m_holidays.is_null()) {
+  if (m_roll == busdate_roll_following && is_default_workweek() && m_holidays.is_null()) {
     o << "busdate";
-  } else {
+  }
+  else {
     bool comma = false;
     o << "date<";
     if (m_roll != busdate_roll_following) {
@@ -102,23 +97,24 @@ void ndt::busdate_type::print_type(std::ostream &o) const
   }
 }
 
-bool ndt::busdate_type::is_lossless_assignment(const type &dst_tp,
-                                               const type &src_tp) const
+bool ndt::busdate_type::is_lossless_assignment(const type &dst_tp, const type &src_tp) const
 {
   if (dst_tp.extended() == this) {
     if (src_tp.extended() == this) {
       return true;
-    } else if (src_tp.get_id() == date_id) {
-      const busdate_type *src_fs =
-          static_cast<const busdate_type *>(src_tp.extended());
+    }
+    else if (src_tp.get_id() == date_id) {
+      const busdate_type *src_fs = static_cast<const busdate_type *>(src_tp.extended());
       // No need to compare the roll policy, just the weekmask and holidays
       // determine this
       return memcmp(m_workweek, src_fs->m_workweek, sizeof(m_workweek)) == 0 &&
              m_holidays.equals_exact(src_fs->m_holidays);
-    } else {
+    }
+    else {
       return false;
     }
-  } else {
+  }
+  else {
     return false;
   }
 }
@@ -127,12 +123,13 @@ bool ndt::busdate_type::operator==(const base_type &rhs) const
 {
   if (this == &rhs) {
     return true;
-  } else if (rhs.get_id() != busdate_id) {
+  }
+  else if (rhs.get_id() != busdate_id) {
     return false;
-  } else {
+  }
+  else {
     const busdate_type *dt = static_cast<const busdate_type *>(&rhs);
-    return m_roll == dt->m_roll &&
-           memcmp(m_workweek, dt->m_workweek, sizeof(m_workweek)) == 0 &&
+    return m_roll == dt->m_roll && memcmp(m_workweek, dt->m_workweek, sizeof(m_workweek)) == 0 &&
            m_holidays.equals_exact(dt->m_holidays);
   }
 }

--- a/src/dynd/types/bytes_type.cpp
+++ b/src/dynd/types/bytes_type.cpp
@@ -15,8 +15,8 @@ using namespace std;
 using namespace dynd;
 
 ndt::bytes_type::bytes_type(size_t alignment)
-    : base_bytes_type(bytes_id, bytes_kind, sizeof(bytes), alignof(bytes),
-                      type_flag_zeroinit | type_flag_destructor, 0),
+    : base_bytes_type(bytes_id, bytes_kind, sizeof(bytes), alignof(bytes), type_flag_zeroinit | type_flag_destructor,
+                      0),
       m_alignment(alignment)
 {
   if (alignment != 1 && alignment != 2 && alignment != 4 && alignment != 8 && alignment != 16) {

--- a/src/dynd/types/c_contiguous_type.cpp
+++ b/src/dynd/types/c_contiguous_type.cpp
@@ -11,87 +11,71 @@ using namespace dynd;
 ndt::c_contiguous_type::c_contiguous_type(const type &child_tp)
     : base_type(c_contiguous_id, kind_kind, 0, 1,
                 type_flag_symbolic |
-                    (child_tp.get_flags() & (type_flags_value_inherited |
-                                             type_flags_operand_inherited)),
+                    (child_tp.get_flags() & (type_flags_value_inherited | type_flags_operand_inherited)),
                 0, child_tp.get_ndim(), 0),
       m_child_tp(child_tp)
 {
   // Restrict c_contiguous_type to fixed_dim_type (and, eventually, tuple_type
   // and struct_type)
   if (m_child_tp.get_id() != fixed_dim_id) {
-    throw std::invalid_argument(
-        "c_contiguous_type must have a child that is a fixed_dim_type");
+    throw std::invalid_argument("c_contiguous_type must have a child that is a fixed_dim_type");
   }
 }
 
-void ndt::c_contiguous_type::print_data(std::ostream &o, const char *arrmeta,
-                                        const char *data) const
+void ndt::c_contiguous_type::print_data(std::ostream &o, const char *arrmeta, const char *data) const
 {
   m_child_tp.print_data(o, arrmeta, data);
 }
 
-void ndt::c_contiguous_type::print_type(std::ostream &o) const
-{
-  o << "C[" << m_child_tp << "]";
-}
+void ndt::c_contiguous_type::print_type(std::ostream &o) const { o << "C[" << m_child_tp << "]"; }
 
-void ndt::c_contiguous_type::get_shape(intptr_t ndim, intptr_t i,
-                                       intptr_t *out_shape, const char *arrmeta,
+void ndt::c_contiguous_type::get_shape(intptr_t ndim, intptr_t i, intptr_t *out_shape, const char *arrmeta,
                                        const char *data) const
 {
   m_child_tp.extended()->get_shape(ndim, i, out_shape, arrmeta, data);
 }
 
-ndt::type ndt::c_contiguous_type::apply_linear_index(
-    intptr_t nindices, const irange *indices, size_t current_i,
-    const type &root_tp, bool leading_dimension) const
+ndt::type ndt::c_contiguous_type::apply_linear_index(intptr_t nindices, const irange *indices, size_t current_i,
+                                                     const type &root_tp, bool leading_dimension) const
 {
   if (nindices == 0) {
     return type(this, true);
   }
 
-  type child_tp = m_child_tp.extended()->apply_linear_index(
-      nindices, indices, current_i, root_tp, leading_dimension);
+  type child_tp = m_child_tp.extended()->apply_linear_index(nindices, indices, current_i, root_tp, leading_dimension);
 
   // TODO: We can preserve c_contiguous in some cases
   return child_tp;
 }
 
-intptr_t ndt::c_contiguous_type::apply_linear_index(
-    intptr_t nindices, const irange *indices, const char *arrmeta,
-    const type &result_type, char *out_arrmeta,
-    const intrusive_ptr<memory_block_data> &embedded_reference, size_t current_i,
-    const type &root_tp, bool leading_dimension, char **inout_data,
-    intrusive_ptr<memory_block_data> &inout_dataref) const
+intptr_t ndt::c_contiguous_type::apply_linear_index(intptr_t nindices, const irange *indices, const char *arrmeta,
+                                                    const type &result_type, char *out_arrmeta,
+                                                    const intrusive_ptr<memory_block_data> &embedded_reference,
+                                                    size_t current_i, const type &root_tp, bool leading_dimension,
+                                                    char **inout_data,
+                                                    intrusive_ptr<memory_block_data> &inout_dataref) const
 {
   if (m_child_tp.is_builtin()) {
     return 0;
   }
 
   return m_child_tp.extended()->apply_linear_index(
-      nindices, indices, arrmeta,
-      result_type.extended<c_contiguous_type>()->m_child_tp, out_arrmeta,
-      embedded_reference, current_i, root_tp, leading_dimension, inout_data,
-      inout_dataref);
+      nindices, indices, arrmeta, result_type.extended<c_contiguous_type>()->m_child_tp, out_arrmeta,
+      embedded_reference, current_i, root_tp, leading_dimension, inout_data, inout_dataref);
 }
 
-ndt::type ndt::c_contiguous_type::at_single(intptr_t i0,
-                                            const char **inout_arrmeta,
-                                            const char **inout_data) const
+ndt::type ndt::c_contiguous_type::at_single(intptr_t i0, const char **inout_arrmeta, const char **inout_data) const
 {
   return make(m_child_tp.extended()->at_single(i0, inout_arrmeta, inout_data));
 }
 
-ndt::type
-ndt::c_contiguous_type::get_type_at_dimension(char **inout_arrmeta, intptr_t i,
-                                              intptr_t total_ndim) const
+ndt::type ndt::c_contiguous_type::get_type_at_dimension(char **inout_arrmeta, intptr_t i, intptr_t total_ndim) const
 {
   if (i == 0) {
     return type(this, true);
   }
 
-  type child_tp = m_child_tp.extended()->get_type_at_dimension(inout_arrmeta, i,
-                                                               total_ndim);
+  type child_tp = m_child_tp.extended()->get_type_at_dimension(inout_arrmeta, i, total_ndim);
   if (child_tp.is_builtin()) {
     return child_tp;
   }
@@ -99,30 +83,27 @@ ndt::c_contiguous_type::get_type_at_dimension(char **inout_arrmeta, intptr_t i,
   return make(child_tp);
 }
 
-bool
-ndt::c_contiguous_type::is_c_contiguous(const char *DYND_UNUSED(arrmeta)) const
-{
-  return true;
-}
+bool ndt::c_contiguous_type::is_c_contiguous(const char *DYND_UNUSED(arrmeta)) const { return true; }
 
 bool ndt::c_contiguous_type::operator==(const base_type &rhs) const
 {
   if (this == &rhs) {
     return true;
-  } else if (rhs.get_id() != c_contiguous_id) {
+  }
+  else if (rhs.get_id() != c_contiguous_id) {
     return false;
-  } else {
+  }
+  else {
     const c_contiguous_type *tp = static_cast<const c_contiguous_type *>(&rhs);
     return m_child_tp == tp->m_child_tp;
   }
 }
 
-void ndt::c_contiguous_type::arrmeta_default_construct(
-    char *DYND_UNUSED(arrmeta), bool DYND_UNUSED(blockref_alloc)) const
+void ndt::c_contiguous_type::arrmeta_default_construct(char *DYND_UNUSED(arrmeta),
+                                                       bool DYND_UNUSED(blockref_alloc)) const
 {
   stringstream ss;
-  ss << "Cannot default construct arrmeta for symbolic type "
-     << type(this, true);
+  ss << "Cannot default construct arrmeta for symbolic type " << type(this, true);
   throw runtime_error(ss.str());
 }
 
@@ -135,19 +116,14 @@ void ndt::c_contiguous_type::arrmeta_copy_construct(
   throw runtime_error(ss.str());
 }
 
-void ndt::c_contiguous_type::arrmeta_destruct(char *DYND_UNUSED(arrmeta)) const
-{
-}
+void ndt::c_contiguous_type::arrmeta_destruct(char *DYND_UNUSED(arrmeta)) const {}
 
-bool ndt::c_contiguous_type::match(const char *arrmeta,
-                                   const type &candidate_tp,
-                                   const char *candidate_arrmeta,
+bool ndt::c_contiguous_type::match(const char *arrmeta, const type &candidate_tp, const char *candidate_arrmeta,
                                    std::map<std::string, type> &tp_vars) const
 {
   if (candidate_tp.get_id() == c_contiguous_id) {
-    return m_child_tp.match(
-        arrmeta, candidate_tp.extended<c_contiguous_type>()->m_child_tp,
-        candidate_arrmeta, tp_vars);
+    return m_child_tp.match(arrmeta, candidate_tp.extended<c_contiguous_type>()->m_child_tp, candidate_arrmeta,
+                            tp_vars);
   }
 
   return candidate_tp.is_c_contiguous(candidate_arrmeta) &&

--- a/src/dynd/types/callable_type.cpp
+++ b/src/dynd/types/callable_type.cpp
@@ -41,15 +41,13 @@ ndt::callable_type::callable_type(const type &ret_type, const type &pos_types, c
   if (m_pos_tuple.get_id() != tuple_id) {
     stringstream ss;
     ss << "dynd callable positional arg types require a tuple type, got a "
-          "type \""
-       << m_pos_tuple << "\"";
+          "type \"" << m_pos_tuple << "\"";
     throw invalid_argument(ss.str());
   }
   if (m_kwd_struct.get_id() != struct_id) {
     stringstream ss;
     ss << "dynd callable keyword arg types require a struct type, got a "
-          "type \""
-       << m_kwd_struct << "\"";
+          "type \"" << m_kwd_struct << "\"";
     throw invalid_argument(ss.str());
   }
 

--- a/src/dynd/types/categorical_kind_type.cpp
+++ b/src/dynd/types/categorical_kind_type.cpp
@@ -12,14 +12,11 @@ using namespace std;
 using namespace dynd;
 
 ndt::categorical_kind_type::categorical_kind_type()
-    : base_type(categorical_id, kind_kind, 0, 0, type_flag_symbolic, 0, 0,
-                0)
+    : base_type(categorical_id, kind_kind, 0, 0, type_flag_symbolic, 0, 0, 0)
 {
 }
 
-ndt::categorical_kind_type::~categorical_kind_type()
-{
-}
+ndt::categorical_kind_type::~categorical_kind_type() {}
 
 size_t ndt::categorical_kind_type::get_default_data_size() const
 {
@@ -28,36 +25,22 @@ size_t ndt::categorical_kind_type::get_default_data_size() const
   throw runtime_error(ss.str());
 }
 
-void ndt::categorical_kind_type::print_data(std::ostream &DYND_UNUSED(o),
-                                            const char *DYND_UNUSED(arrmeta),
+void ndt::categorical_kind_type::print_data(std::ostream &DYND_UNUSED(o), const char *DYND_UNUSED(arrmeta),
                                             const char *DYND_UNUSED(data)) const
 {
   throw type_error("Cannot store data of symbolic categorical_kind type");
 }
 
-void ndt::categorical_kind_type::print_type(std::ostream &o) const
-{
-  o << "Categorical";
-}
+void ndt::categorical_kind_type::print_type(std::ostream &o) const { o << "Categorical"; }
 
-bool ndt::categorical_kind_type::is_expression() const
-{
-  return false;
-}
+bool ndt::categorical_kind_type::is_expression() const { return false; }
 
-bool ndt::categorical_kind_type::is_unique_data_owner(
-    const char *DYND_UNUSED(arrmeta)) const
-{
-  return false;
-}
+bool ndt::categorical_kind_type::is_unique_data_owner(const char *DYND_UNUSED(arrmeta)) const { return false; }
 
-ndt::type ndt::categorical_kind_type::get_canonical_type() const
-{
-  return type(this, true);
-}
+ndt::type ndt::categorical_kind_type::get_canonical_type() const { return type(this, true); }
 
-bool ndt::categorical_kind_type::is_lossless_assignment(
-    const type &DYND_UNUSED(dst_tp), const type &DYND_UNUSED(src_tp)) const
+bool ndt::categorical_kind_type::is_lossless_assignment(const type &DYND_UNUSED(dst_tp),
+                                                        const type &DYND_UNUSED(src_tp)) const
 {
   return false;
 }
@@ -66,18 +49,17 @@ bool ndt::categorical_kind_type::operator==(const base_type &rhs) const
 {
   if (this == &rhs) {
     return true;
-  } else {
-    return rhs.get_kind() == kind_kind &&
-           rhs.get_id() == categorical_id;
+  }
+  else {
+    return rhs.get_kind() == kind_kind && rhs.get_id() == categorical_id;
   }
 }
 
-void ndt::categorical_kind_type::arrmeta_default_construct(
-    char *DYND_UNUSED(arrmeta), bool DYND_UNUSED(blockref_alloc)) const
+void ndt::categorical_kind_type::arrmeta_default_construct(char *DYND_UNUSED(arrmeta),
+                                                           bool DYND_UNUSED(blockref_alloc)) const
 {
   stringstream ss;
-  ss << "Cannot default construct arrmeta for symbolic type "
-     << type(this, true);
+  ss << "Cannot default construct arrmeta for symbolic type " << type(this, true);
   throw runtime_error(ss.str());
 }
 
@@ -90,51 +72,38 @@ void ndt::categorical_kind_type::arrmeta_copy_construct(
   throw runtime_error(ss.str());
 }
 
-void ndt::categorical_kind_type::arrmeta_reset_buffers(
-    char *DYND_UNUSED(arrmeta)) const
-{
-}
+void ndt::categorical_kind_type::arrmeta_reset_buffers(char *DYND_UNUSED(arrmeta)) const {}
 
-void ndt::categorical_kind_type::arrmeta_finalize_buffers(
-    char *DYND_UNUSED(arrmeta)) const
-{
-}
+void ndt::categorical_kind_type::arrmeta_finalize_buffers(char *DYND_UNUSED(arrmeta)) const {}
 
-void
-ndt::categorical_kind_type::arrmeta_destruct(char *DYND_UNUSED(arrmeta)) const
-{
-}
+void ndt::categorical_kind_type::arrmeta_destruct(char *DYND_UNUSED(arrmeta)) const {}
 
-void ndt::categorical_kind_type::arrmeta_debug_print(
-    const char *DYND_UNUSED(arrmeta), std::ostream &DYND_UNUSED(o),
-    const std::string &DYND_UNUSED(indent)) const
+void ndt::categorical_kind_type::arrmeta_debug_print(const char *DYND_UNUSED(arrmeta), std::ostream &DYND_UNUSED(o),
+                                                     const std::string &DYND_UNUSED(indent)) const
 {
   stringstream ss;
   ss << "Cannot have arrmeta for symbolic type " << type(this, true);
   throw runtime_error(ss.str());
 }
 
-void ndt::categorical_kind_type::data_destruct(const char *DYND_UNUSED(arrmeta),
-                                               char *DYND_UNUSED(data)) const
+void ndt::categorical_kind_type::data_destruct(const char *DYND_UNUSED(arrmeta), char *DYND_UNUSED(data)) const
 {
   stringstream ss;
   ss << "Cannot have data for symbolic type " << type(this, true);
   throw runtime_error(ss.str());
 }
 
-void ndt::categorical_kind_type::data_destruct_strided(
-    const char *DYND_UNUSED(arrmeta), char *DYND_UNUSED(data),
-    intptr_t DYND_UNUSED(stride), size_t DYND_UNUSED(count)) const
+void ndt::categorical_kind_type::data_destruct_strided(const char *DYND_UNUSED(arrmeta), char *DYND_UNUSED(data),
+                                                       intptr_t DYND_UNUSED(stride), size_t DYND_UNUSED(count)) const
 {
   stringstream ss;
   ss << "Cannot have data for symbolic type " << type(this, true);
   throw runtime_error(ss.str());
 }
 
-bool ndt::categorical_kind_type::match(
-    const char *DYND_UNUSED(arrmeta), const type &candidate_tp,
-    const char *DYND_UNUSED(candidate_arrmeta),
-    std::map<std::string, type> &DYND_UNUSED(tp_vars)) const
+bool ndt::categorical_kind_type::match(const char *DYND_UNUSED(arrmeta), const type &candidate_tp,
+                                       const char *DYND_UNUSED(candidate_arrmeta),
+                                       std::map<std::string, type> &DYND_UNUSED(tp_vars)) const
 {
   return candidate_tp.get_id() == categorical_id;
 }

--- a/src/dynd/types/convert_type.cpp
+++ b/src/dynd/types/convert_type.cpp
@@ -90,25 +90,23 @@ ndt::type ndt::convert_type::with_replaced_storage_type(const type &replacement_
     if (m_operand_type != replacement_type.value_type()) {
       std::stringstream ss;
       ss << "Cannot chain expression types, because the conversion's "
-            "storage type, "
-         << m_operand_type << ", does not match the replacement's value type, " << replacement_type.value_type();
+            "storage type, " << m_operand_type << ", does not match the replacement's value type, "
+         << replacement_type.value_type();
       throw std::runtime_error(ss.str());
     }
     return type(new convert_type(m_value_type, replacement_type), false);
   }
 }
 
-void ndt::convert_type::make_operand_to_value_assignment_kernel(nd::kernel_builder *ckb,
-                                                                const char *dst_arrmeta, const char *src_arrmeta,
-                                                                kernel_request_t kernreq,
+void ndt::convert_type::make_operand_to_value_assignment_kernel(nd::kernel_builder *ckb, const char *dst_arrmeta,
+                                                                const char *src_arrmeta, kernel_request_t kernreq,
                                                                 const eval::eval_context *ectx) const
 {
   ::make_assignment_kernel(ckb, m_value_type, dst_arrmeta, m_operand_type.value_type(), src_arrmeta, kernreq, ectx);
 }
 
-void ndt::convert_type::make_value_to_operand_assignment_kernel(nd::kernel_builder *ckb,
-                                                                const char *dst_arrmeta, const char *src_arrmeta,
-                                                                kernel_request_t kernreq,
+void ndt::convert_type::make_value_to_operand_assignment_kernel(nd::kernel_builder *ckb, const char *dst_arrmeta,
+                                                                const char *src_arrmeta, kernel_request_t kernreq,
                                                                 const eval::eval_context *ectx) const
 {
   ::make_assignment_kernel(ckb, m_operand_type.value_type(), dst_arrmeta, m_value_type, src_arrmeta, kernreq, ectx);

--- a/src/dynd/types/cuda_host_type.cpp
+++ b/src/dynd/types/cuda_host_type.cpp
@@ -11,8 +11,8 @@ using namespace dynd;
 #ifdef DYND_CUDA
 
 cuda_host_type::cuda_host_type(const ndt::type &element_tp, unsigned int cuda_host_flags)
-    : base_memory_type(cuda_host_id, element_tp, element_tp.get_data_size(),
-                       get_cuda_device_data_alignment(element_tp), 0, element_tp.get_flags()),
+    : base_memory_type(cuda_host_id, element_tp, element_tp.get_data_size(), get_cuda_device_data_alignment(element_tp),
+                       0, element_tp.get_flags()),
       m_cuda_host_flags(cuda_host_flags)
 {
 }

--- a/src/dynd/types/date_util.cpp
+++ b/src/dynd/types/date_util.cpp
@@ -14,13 +14,11 @@ using namespace std;
 using namespace dynd;
 
 const int date_ymd::month_lengths[2][12] = {
-    {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31},
-    {31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31},
+    {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}, {31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31},
 };
 
-const int date_ymd::month_starts[2][13] = {
-    {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365},
-    {0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366}};
+const int date_ymd::month_starts[2][13] = {{0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365},
+                                           {0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366}};
 
 std::ostream &dynd::operator<<(std::ostream &o, date_parse_order_t date_order)
 {
@@ -45,17 +43,17 @@ int32_t date_ymd::to_days(int year, int month, int day)
     int result = (year - 1970) * 365;
     // Use the inclusion-exclusion principle to count leap years
     if (result >= 0) {
-      result += ((year - (1968 + 1)) / 4) - ((year - (1900 + 1)) / 100) +
-                ((year - (1600 + 1)) / 400);
-    } else {
-      result +=
-          ((year - 1972) / 4) - ((year - 2000) / 100) + ((year - 2000) / 400);
+      result += ((year - (1968 + 1)) / 4) - ((year - (1900 + 1)) / 100) + ((year - (1600 + 1)) / 400);
+    }
+    else {
+      result += ((year - 1972) / 4) - ((year - 2000) / 100) + ((year - 2000) / 400);
     }
     // Add in the months and days
     result += month_starts[is_leap_year(year)][month - 1];
     result += day - 1;
     return result;
-  } else {
+  }
+  else {
     return DYND_DATE_NA;
   }
 }
@@ -77,12 +75,14 @@ std::string date_ymd::to_str(int year, int month, int day)
       s[7] = '-';
       s[8] = '0' + (day / 10);
       s[9] = '0' + (day % 10);
-    } else {
+    }
+    else {
       // Expanded ISO 8601 date, using +/- 6 digit year
       s.resize(13);
       if (year >= 0) {
         s[0] = '+';
-      } else {
+      }
+      else {
         s[0] = '-';
         year = -year;
       }
@@ -113,9 +113,9 @@ void date_ymd::set_from_days(int32_t days)
     if (days >= 0) {
       yearcalc = 400 * (days / (400 * 365 + 100 - 4 + 1));
       days = days % (400 * 365 + 100 - 4 + 1);
-    } else {
-      yearcalc =
-          400 * ((days - (400 * 365 + 100 - 4)) / (400 * 365 + 100 - 4 + 1));
+    }
+    else {
+      yearcalc = 400 * ((days - (400 * 365 + 100 - 4)) / (400 * 365 + 100 - 4 + 1));
       days = days % (400 * 365 + 100 - 4 + 1);
       if (days < 0) {
         days += (400 * 365 + 100 - 4 + 1);
@@ -138,23 +138,21 @@ void date_ymd::set_from_days(int32_t days)
     }
     // Search for the month
     const int *monthstart = month_starts[is_leap_year(yearcalc)];
-    const int *monthfound =
-        std::upper_bound(monthstart + 1, monthstart + 13, days);
+    const int *monthfound = std::upper_bound(monthstart + 1, monthstart + 13, days);
     // Set the ymd
     year = yearcalc;
     month = static_cast<int8_t>(monthfound - monthstart);
     day = days - *(monthfound - 1) + 1;
-  } else {
+  }
+  else {
     year = 0;
     month = -128;
     day = 0;
   }
 }
 
-void date_ymd::set_from_str(const char *begin, const char *end,
-                            date_parse_order_t ambig = date_parse_no_ambig,
-                            int century_window = 70,
-                            assign_error_mode errmode = assign_error_fractional)
+void date_ymd::set_from_str(const char *begin, const char *end, date_parse_order_t ambig = date_parse_no_ambig,
+                            int century_window = 70, assign_error_mode errmode = assign_error_fractional)
 {
   if (!string_to_date(begin, end, *this, ambig, century_window, errmode)) {
     stringstream ss;
@@ -172,7 +170,8 @@ int date_ymd::resolve_2digit_year_fixed_window(int year, int year_start)
 
   if (year >= year_start_in_century) {
     return century_start + year;
-  } else {
+  }
+  else {
     return century_start + 100 + year;
   }
 }
@@ -190,9 +189,9 @@ int date_ymd::resolve_2digit_year_sliding_window(int year, int years_ago)
 #endif
   if (rawtime >= 0) {
     current_date_days = static_cast<int32_t>(rawtime / DYND_SECONDS_PER_DAY);
-  } else {
-    current_date_days = static_cast<int32_t>(
-        (rawtime - (DYND_SECONDS_PER_DAY - 1)) / DYND_SECONDS_PER_DAY);
+  }
+  else {
+    current_date_days = static_cast<int32_t>((rawtime - (DYND_SECONDS_PER_DAY - 1)) / DYND_SECONDS_PER_DAY);
   }
   date_ymd current_date;
   current_date.set_from_days(current_date_days);
@@ -205,9 +204,11 @@ int date_ymd::resolve_2digit_year(int year, int century_window)
 {
   if (century_window >= 1 && century_window <= 99) {
     return date_ymd::resolve_2digit_year_sliding_window(year, century_window);
-  } else if (century_window >= 1000) {
+  }
+  else if (century_window >= 1000) {
     return date_ymd::resolve_2digit_year_fixed_window(year, century_window);
-  } else {
+  }
+  else {
     stringstream ss;
     ss << "invalid century_window value " << century_window
        << ", must be 1-99 for a sliding window, or >= 1000 for a fixed "
@@ -243,9 +244,8 @@ date_ymd date_ymd::get_current_local_date()
 
 const ndt::type &date_ymd::type()
 {
-  static ndt::type tp = ndt::struct_type::make({"year", "month", "day"},
-                                               std::vector<ndt::type>{ndt::make_type<int16_t>(),
-                                                                      ndt::make_type<int8_t>(),
-                                                                      ndt::make_type<int8_t>()});
+  static ndt::type tp = ndt::struct_type::make(
+      {"year", "month", "day"},
+      std::vector<ndt::type>{ndt::make_type<int16_t>(), ndt::make_type<int8_t>(), ndt::make_type<int8_t>()});
   return tp;
 }

--- a/src/dynd/types/datetime_parser.cpp
+++ b/src/dynd/types/datetime_parser.cpp
@@ -15,242 +15,237 @@ using namespace std;
 using namespace dynd;
 
 // Fri Dec 19 15:10:11 1997, Fri 19 Dec 15:10:11 1997
-static bool parse_postgres_datetime(const char *&begin, const char *end,
-                                    datetime_struct &out_dt)
+static bool parse_postgres_datetime(const char *&begin, const char *end, datetime_struct &out_dt)
 {
-    saved_begin_state sbs(begin);
+  saved_begin_state sbs(begin);
 
-    // "Fri "
-    int weekday;
-    if (!parse_str_weekday_no_ws(begin, end, weekday)) {
-        return sbs.fail();
-    }
+  // "Fri "
+  int weekday;
+  if (!parse_str_weekday_no_ws(begin, end, weekday)) {
+    return sbs.fail();
+  }
+  if (!skip_required_whitespace(begin, end)) {
+    return sbs.fail();
+  }
+  // "Dec 19 " or "19 Dec "
+  int month, day;
+  if (parse_1or2digit_int_no_ws(begin, end, day)) {
     if (!skip_required_whitespace(begin, end)) {
-        return sbs.fail();
+      return sbs.fail();
     }
-    // "Dec 19 " or "19 Dec "
-    int month, day;
-    if (parse_1or2digit_int_no_ws(begin, end, day)) {
-        if (!skip_required_whitespace(begin, end)) {
-            return sbs.fail();
-        }
-        if (!parse_str_month_no_ws(begin, end, month)) {
-            return sbs.fail();
-        }
-    } else if (parse_str_month_no_ws(begin, end, month)) {
-        if (!skip_required_whitespace(begin, end)) {
-            return sbs.fail();
-        }
-        if (!parse_1or2digit_int_no_ws(begin, end, day)) {
-            return sbs.fail();
-        }
-    } else {
-        return sbs.fail();
+    if (!parse_str_month_no_ws(begin, end, month)) {
+      return sbs.fail();
     }
+  }
+  else if (parse_str_month_no_ws(begin, end, month)) {
     if (!skip_required_whitespace(begin, end)) {
-        return sbs.fail();
+      return sbs.fail();
     }
-    // "15:10:11 "
-    if (!parse_time_no_tz(begin, end, out_dt.hmst)) {
-        return sbs.fail();
+    if (!parse_1or2digit_int_no_ws(begin, end, day)) {
+      return sbs.fail();
     }
-    if (!skip_required_whitespace(begin, end)) {
-        return sbs.fail();
-    }
-    // "1997"
-    int year;
-    if (!parse_4digit_int_no_ws(begin, end, year)) {
-        return sbs.fail();
-    }
-    if (date_ymd::is_valid(year, month, day)) {
-        out_dt.ymd.year = year;
-        out_dt.ymd.month = month;
-        out_dt.ymd.day = day;
-        if (out_dt.ymd.get_weekday() != weekday) {
-            return sbs.fail();
-        }
-        return sbs.succeed();
-    } else {
-        return sbs.fail();
-    }
-}
-
-// 19971219151011
-static bool parse_iso8601_nodashes_datetime(const char *&begin, const char *end,
-                                            datetime_struct &out_dt)
-{
-    saved_begin_state sbs(begin);
-    // YYYY
-    int year;
-    if (!parse_4digit_int_no_ws(begin, end, year)) {
-        return sbs.fail();
-    }
-    // MM
-    int month;
-    if (!parse_2digit_int_no_ws(begin, end, month)) {
-        return sbs.fail();
-    }
-    // DD
-    int day;
-    if (!parse_2digit_int_no_ws(begin, end, day)) {
-        return sbs.fail();
-    }
-    // Validate the date
-    if (!date_ymd::is_valid(year, month, day)) {
-        return sbs.fail();
-    }
-
-    // HH
-    bool done = false;
-    int hour;
-    if (!parse_2digit_int_no_ws(begin, end, hour)) {
-        hour = 0;
-        done = true;
-    }
-    // MM
-    int minute;
-    if (!done && !parse_2digit_int_no_ws(begin, end, minute)) {
-        minute = 0;
-        done = true;
-    }
-    // SS
-    int second;
-    if (!done && !parse_2digit_int_no_ws(begin, end, second)) {
-        second = 0;
-        done = true;
-    }
-    // .SS*
-    int tick = 0;
-    if (!parse_token_no_ws(begin, end, '.')) {
-        done = true;
-    }
-    if (!done && begin < end && isdigit(*begin)) {
-        tick = (*begin - '0');
-        ++begin;
-        for (int i = 1; i < 7; ++i) {
-            tick *= 10;
-            if (begin < end && isdigit(*begin)) {
-                tick += (*begin - '0');
-                ++begin;
-            }
-        }
-        // Swallow any additional decimal digits, truncating to ticks
-        while (begin < end && isdigit(*begin)) {
-            ++begin;
-        }
-    }
-
-    // Validate the time
-    if (!time_hmst::is_valid(hour, minute, second, tick)) {
-        return sbs.fail();
-    }
-
+  }
+  else {
+    return sbs.fail();
+  }
+  if (!skip_required_whitespace(begin, end)) {
+    return sbs.fail();
+  }
+  // "15:10:11 "
+  if (!parse_time_no_tz(begin, end, out_dt.hmst)) {
+    return sbs.fail();
+  }
+  if (!skip_required_whitespace(begin, end)) {
+    return sbs.fail();
+  }
+  // "1997"
+  int year;
+  if (!parse_4digit_int_no_ws(begin, end, year)) {
+    return sbs.fail();
+  }
+  if (date_ymd::is_valid(year, month, day)) {
     out_dt.ymd.year = year;
     out_dt.ymd.month = month;
     out_dt.ymd.day = day;
-    out_dt.hmst.hour = hour;
-    out_dt.hmst.minute = minute;
-    out_dt.hmst.second = second;
-    out_dt.hmst.tick = tick;
+    if (out_dt.ymd.get_weekday() != weekday) {
+      return sbs.fail();
+    }
     return sbs.succeed();
+  }
+  else {
+    return sbs.fail();
+  }
+}
+
+// 19971219151011
+static bool parse_iso8601_nodashes_datetime(const char *&begin, const char *end, datetime_struct &out_dt)
+{
+  saved_begin_state sbs(begin);
+  // YYYY
+  int year;
+  if (!parse_4digit_int_no_ws(begin, end, year)) {
+    return sbs.fail();
+  }
+  // MM
+  int month;
+  if (!parse_2digit_int_no_ws(begin, end, month)) {
+    return sbs.fail();
+  }
+  // DD
+  int day;
+  if (!parse_2digit_int_no_ws(begin, end, day)) {
+    return sbs.fail();
+  }
+  // Validate the date
+  if (!date_ymd::is_valid(year, month, day)) {
+    return sbs.fail();
+  }
+
+  // HH
+  bool done = false;
+  int hour;
+  if (!parse_2digit_int_no_ws(begin, end, hour)) {
+    hour = 0;
+    done = true;
+  }
+  // MM
+  int minute;
+  if (!done && !parse_2digit_int_no_ws(begin, end, minute)) {
+    minute = 0;
+    done = true;
+  }
+  // SS
+  int second;
+  if (!done && !parse_2digit_int_no_ws(begin, end, second)) {
+    second = 0;
+    done = true;
+  }
+  // .SS*
+  int tick = 0;
+  if (!parse_token_no_ws(begin, end, '.')) {
+    done = true;
+  }
+  if (!done && begin < end && isdigit(*begin)) {
+    tick = (*begin - '0');
+    ++begin;
+    for (int i = 1; i < 7; ++i) {
+      tick *= 10;
+      if (begin < end && isdigit(*begin)) {
+        tick += (*begin - '0');
+        ++begin;
+      }
+    }
+    // Swallow any additional decimal digits, truncating to ticks
+    while (begin < end && isdigit(*begin)) {
+      ++begin;
+    }
+  }
+
+  // Validate the time
+  if (!time_hmst::is_valid(hour, minute, second, tick)) {
+    return sbs.fail();
+  }
+
+  out_dt.ymd.year = year;
+  out_dt.ymd.month = month;
+  out_dt.ymd.day = day;
+  out_dt.hmst.hour = hour;
+  out_dt.hmst.minute = minute;
+  out_dt.hmst.second = second;
+  out_dt.hmst.tick = tick;
+  return sbs.succeed();
 }
 
 // <date> T <time>, <date>:<time>, <date> <time>
 // optionally followed by a timezone specifier
-static bool parse_date_time_datetime(const char *&begin, const char *end,
-                                     datetime_struct &out_dt,
-                                     date_parse_order_t ambig,
-                                     int century_window,
-                                     const char *&out_tz_begin,
+static bool parse_date_time_datetime(const char *&begin, const char *end, datetime_struct &out_dt,
+                                     date_parse_order_t ambig, int century_window, const char *&out_tz_begin,
                                      const char *&out_tz_end)
 {
-    saved_begin_state sbs(begin);
+  saved_begin_state sbs(begin);
 
-    if (!parse_date(begin, end, out_dt.ymd, ambig, century_window)) {
-        return sbs.fail();
+  if (!parse_date(begin, end, out_dt.ymd, ambig, century_window)) {
+    return sbs.fail();
+  }
+  // "T", ":', or whitespace may separate a date and a time
+  if (parse_token(begin, end, 'T')) {
+    // Allow whitespace around the T
+    skip_whitespace(begin, end);
+  }
+  else if (!parse_token_no_ws(begin, end, ':')) {
+    if (!skip_required_whitespace(begin, end)) {
+      out_dt.hmst.set_to_zero();
+      return sbs.succeed();
     }
-    // "T", ":', or whitespace may separate a date and a time
-    if (parse_token(begin, end, 'T')) {
-      // Allow whitespace around the T
-      skip_whitespace(begin, end);
-    } else if (!parse_token_no_ws(begin, end, ':')) {
-      if (!skip_required_whitespace(begin, end)) {
-        out_dt.hmst.set_to_zero();
-        return sbs.succeed();
-      }
-      if (begin == end) {
-        // If there was just the date, set the rest to zero
-        out_dt.hmst.set_to_zero();
-        return sbs.succeed();
-      }
+    if (begin == end) {
+      // If there was just the date, set the rest to zero
+      out_dt.hmst.set_to_zero();
+      return sbs.succeed();
     }
-    if (!parse_time(begin, end, out_dt.hmst, out_tz_begin, out_tz_end)) {
-        // In most cases we don't accept just an hour as a time, but for
-        // ISO dash-formatted dates, we do, so try again as that.
-        begin = sbs.saved_begin();
-        if (!parse_iso8601_dashes_date(begin, end, out_dt.ymd)) {
-            return sbs.fail();
-        }
-        // Either a "T" or whitespace may separate a date and a time
-        if (!parse_token_no_ws(begin, end, 'T') &&
-                !skip_required_whitespace(begin, end)) {
-            return sbs.fail();
-        }
-        int hour;
-        // Require a 2 digit hour followed by a non-digit
-        if (!parse_2digit_int_no_ws(begin, end, hour) ||
-                (begin < end && isdigit(*begin))) {
-            return sbs.fail();
-        }
-        if (time_hmst::is_valid(hour, 0, 0, 0)) {
-            out_dt.hmst.hour = hour;
-            out_dt.hmst.minute = 0;
-            out_dt.hmst.second = 0;
-            out_dt.hmst.tick = 0;
-            return sbs.succeed();
-        } else {
-            return sbs.fail();
-        }
+  }
+  if (!parse_time(begin, end, out_dt.hmst, out_tz_begin, out_tz_end)) {
+    // In most cases we don't accept just an hour as a time, but for
+    // ISO dash-formatted dates, we do, so try again as that.
+    begin = sbs.saved_begin();
+    if (!parse_iso8601_dashes_date(begin, end, out_dt.ymd)) {
+      return sbs.fail();
     }
-    return sbs.succeed();
+    // Either a "T" or whitespace may separate a date and a time
+    if (!parse_token_no_ws(begin, end, 'T') && !skip_required_whitespace(begin, end)) {
+      return sbs.fail();
+    }
+    int hour;
+    // Require a 2 digit hour followed by a non-digit
+    if (!parse_2digit_int_no_ws(begin, end, hour) || (begin < end && isdigit(*begin))) {
+      return sbs.fail();
+    }
+    if (time_hmst::is_valid(hour, 0, 0, 0)) {
+      out_dt.hmst.hour = hour;
+      out_dt.hmst.minute = 0;
+      out_dt.hmst.second = 0;
+      out_dt.hmst.tick = 0;
+      return sbs.succeed();
+    }
+    else {
+      return sbs.fail();
+    }
+  }
+  return sbs.succeed();
 }
 
-bool dynd::parse_datetime(const char *&begin, const char *end,
-                           date_parse_order_t ambig, int century_window,
-                           datetime_struct &out_dt, const char *&out_tz_begin,
-                           const char *&out_tz_end)
+bool dynd::parse_datetime(const char *&begin, const char *end, date_parse_order_t ambig, int century_window,
+                          datetime_struct &out_dt, const char *&out_tz_begin, const char *&out_tz_end)
 {
-    if (parse_date_time_datetime(begin, end, out_dt, ambig, century_window,
-                                 out_tz_begin, out_tz_end)) {
-        // <date>T<time>, <date> <time>
-    } else if (parse_postgres_datetime(begin, end, out_dt)) {
-        // Fri Dec 19 15:10:11 1997, Fri 19 Dec 15:10:11 1997
-    } else if (parse_iso8601_nodashes_datetime(begin, end, out_dt)) {
-        // 19971219151011
-    } else {
-        return false;
-    }
-    return true;
+  if (parse_date_time_datetime(begin, end, out_dt, ambig, century_window, out_tz_begin, out_tz_end)) {
+    // <date>T<time>, <date> <time>
+  }
+  else if (parse_postgres_datetime(begin, end, out_dt)) {
+    // Fri Dec 19 15:10:11 1997, Fri 19 Dec 15:10:11 1997
+  }
+  else if (parse_iso8601_nodashes_datetime(begin, end, out_dt)) {
+    // 19971219151011
+  }
+  else {
+    return false;
+  }
+  return true;
 }
 
-bool dynd::string_to_datetime(const char *begin, const char *end,
-                              date_parse_order_t ambig, int century_window,
-                              assign_error_mode errmode,
-                              datetime_struct &out_dt,
-                              const char *&out_tz_begin,
+bool dynd::string_to_datetime(const char *begin, const char *end, date_parse_order_t ambig, int century_window,
+                              assign_error_mode errmode, datetime_struct &out_dt, const char *&out_tz_begin,
                               const char *&out_tz_end)
 {
-    datetime_struct dt;
-    skip_whitespace(begin, end);
-    if (!parse_datetime(begin, end, ambig, century_window, dt, out_tz_begin,
-                        out_tz_end)) {
-        return false;
-    }
-    skip_whitespace(begin, end);
-    if (begin == end || errmode == assign_error_nocheck) {
-        out_dt = dt;
-        return true;
-    } else {
-        return false;
-    }
+  datetime_struct dt;
+  skip_whitespace(begin, end);
+  if (!parse_datetime(begin, end, ambig, century_window, dt, out_tz_begin, out_tz_end)) {
+    return false;
+  }
+  skip_whitespace(begin, end);
+  if (begin == end || errmode == assign_error_nocheck) {
+    out_dt = dt;
+    return true;
+  }
+  else {
+    return false;
+  }
 }

--- a/src/dynd/types/datetime_util.cpp
+++ b/src/dynd/types/datetime_util.cpp
@@ -17,7 +17,8 @@ std::string datetime_struct::to_str() const
 {
   if (is_valid()) {
     return ymd.to_str() + "T" + hmst.to_str();
-  } else {
+  }
+  else {
     return std::string();
   }
 }
@@ -39,6 +40,6 @@ const ndt::type &datetime_struct::type()
   static ndt::type tp = ndt::struct_type::make(
       {"year", "month", "day", "hour", "minute", "second", "tick"},
       {ndt::make_type<int16_t>(), ndt::make_type<int8_t>(), ndt::make_type<int8_t>(), ndt::make_type<int8_t>(),
-       ndt::make_type<int8_t>(),  ndt::make_type<int8_t>(), ndt::make_type<int32_t>()});
+       ndt::make_type<int8_t>(), ndt::make_type<int8_t>(), ndt::make_type<int32_t>()});
   return tp;
 }

--- a/src/dynd/types/fixed_bytes_kind_type.cpp
+++ b/src/dynd/types/fixed_bytes_kind_type.cpp
@@ -12,14 +12,11 @@ using namespace std;
 using namespace dynd;
 
 ndt::fixed_bytes_kind_type::fixed_bytes_kind_type()
-    : base_bytes_type(fixed_bytes_id, kind_kind, 0, 0, type_flag_symbolic,
-                      0)
+    : base_bytes_type(fixed_bytes_id, kind_kind, 0, 0, type_flag_symbolic, 0)
 {
 }
 
-ndt::fixed_bytes_kind_type::~fixed_bytes_kind_type()
-{
-}
+ndt::fixed_bytes_kind_type::~fixed_bytes_kind_type() {}
 
 size_t ndt::fixed_bytes_kind_type::get_default_data_size() const
 {
@@ -28,43 +25,28 @@ size_t ndt::fixed_bytes_kind_type::get_default_data_size() const
   throw runtime_error(ss.str());
 }
 
-void ndt::fixed_bytes_kind_type::print_data(std::ostream &DYND_UNUSED(o),
-                                            const char *DYND_UNUSED(arrmeta),
+void ndt::fixed_bytes_kind_type::print_data(std::ostream &DYND_UNUSED(o), const char *DYND_UNUSED(arrmeta),
                                             const char *DYND_UNUSED(data)) const
 {
   throw type_error("Cannot store data of symbolic fixed_bytes_kind type");
 }
 
-void ndt::fixed_bytes_kind_type::print_type(std::ostream &o) const
-{
-  o << "FixedBytes";
-}
+void ndt::fixed_bytes_kind_type::print_type(std::ostream &o) const { o << "FixedBytes"; }
 
-bool ndt::fixed_bytes_kind_type::is_expression() const
-{
-  return false;
-}
+bool ndt::fixed_bytes_kind_type::is_expression() const { return false; }
 
-bool ndt::fixed_bytes_kind_type::is_unique_data_owner(
-    const char *DYND_UNUSED(arrmeta)) const
+bool ndt::fixed_bytes_kind_type::is_unique_data_owner(const char *DYND_UNUSED(arrmeta)) const { return false; }
+
+ndt::type ndt::fixed_bytes_kind_type::get_canonical_type() const { return type(this, true); }
+
+bool ndt::fixed_bytes_kind_type::is_lossless_assignment(const type &DYND_UNUSED(dst_tp),
+                                                        const type &DYND_UNUSED(src_tp)) const
 {
   return false;
 }
 
-ndt::type ndt::fixed_bytes_kind_type::get_canonical_type() const
-{
-  return type(this, true);
-}
-
-bool ndt::fixed_bytes_kind_type::is_lossless_assignment(
-    const type &DYND_UNUSED(dst_tp), const type &DYND_UNUSED(src_tp)) const
-{
-  return false;
-}
-
-void ndt::fixed_bytes_kind_type::get_bytes_range(
-    const char **DYND_UNUSED(out_begin), const char **DYND_UNUSED(out_end),
-    const char *DYND_UNUSED(arrmeta), const char *DYND_UNUSED(data)) const
+void ndt::fixed_bytes_kind_type::get_bytes_range(const char **DYND_UNUSED(out_begin), const char **DYND_UNUSED(out_end),
+                                                 const char *DYND_UNUSED(arrmeta), const char *DYND_UNUSED(data)) const
 {
   stringstream ss;
   ss << "Cannot get bytes range for symbolic type " << ndt::type(this, true);
@@ -75,18 +57,17 @@ bool ndt::fixed_bytes_kind_type::operator==(const base_type &rhs) const
 {
   if (this == &rhs) {
     return true;
-  } else {
-    return rhs.get_kind() == kind_kind &&
-           rhs.get_id() == fixed_bytes_id;
+  }
+  else {
+    return rhs.get_kind() == kind_kind && rhs.get_id() == fixed_bytes_id;
   }
 }
 
-void ndt::fixed_bytes_kind_type::arrmeta_default_construct(
-    char *DYND_UNUSED(arrmeta), bool DYND_UNUSED(blockref_alloc)) const
+void ndt::fixed_bytes_kind_type::arrmeta_default_construct(char *DYND_UNUSED(arrmeta),
+                                                           bool DYND_UNUSED(blockref_alloc)) const
 {
   stringstream ss;
-  ss << "Cannot default construct arrmeta for symbolic type "
-     << type(this, true);
+  ss << "Cannot default construct arrmeta for symbolic type " << type(this, true);
   throw runtime_error(ss.str());
 }
 
@@ -99,51 +80,38 @@ void ndt::fixed_bytes_kind_type::arrmeta_copy_construct(
   throw runtime_error(ss.str());
 }
 
-void ndt::fixed_bytes_kind_type::arrmeta_reset_buffers(
-    char *DYND_UNUSED(arrmeta)) const
-{
-}
+void ndt::fixed_bytes_kind_type::arrmeta_reset_buffers(char *DYND_UNUSED(arrmeta)) const {}
 
-void ndt::fixed_bytes_kind_type::arrmeta_finalize_buffers(
-    char *DYND_UNUSED(arrmeta)) const
-{
-}
+void ndt::fixed_bytes_kind_type::arrmeta_finalize_buffers(char *DYND_UNUSED(arrmeta)) const {}
 
-void
-ndt::fixed_bytes_kind_type::arrmeta_destruct(char *DYND_UNUSED(arrmeta)) const
-{
-}
+void ndt::fixed_bytes_kind_type::arrmeta_destruct(char *DYND_UNUSED(arrmeta)) const {}
 
-void ndt::fixed_bytes_kind_type::arrmeta_debug_print(
-    const char *DYND_UNUSED(arrmeta), std::ostream &DYND_UNUSED(o),
-    const std::string &DYND_UNUSED(indent)) const
+void ndt::fixed_bytes_kind_type::arrmeta_debug_print(const char *DYND_UNUSED(arrmeta), std::ostream &DYND_UNUSED(o),
+                                                     const std::string &DYND_UNUSED(indent)) const
 {
   stringstream ss;
   ss << "Cannot have arrmeta for symbolic type " << type(this, true);
   throw runtime_error(ss.str());
 }
 
-void ndt::fixed_bytes_kind_type::data_destruct(const char *DYND_UNUSED(arrmeta),
-                                               char *DYND_UNUSED(data)) const
+void ndt::fixed_bytes_kind_type::data_destruct(const char *DYND_UNUSED(arrmeta), char *DYND_UNUSED(data)) const
 {
   stringstream ss;
   ss << "Cannot have data for symbolic type " << type(this, true);
   throw runtime_error(ss.str());
 }
 
-void ndt::fixed_bytes_kind_type::data_destruct_strided(
-    const char *DYND_UNUSED(arrmeta), char *DYND_UNUSED(data),
-    intptr_t DYND_UNUSED(stride), size_t DYND_UNUSED(count)) const
+void ndt::fixed_bytes_kind_type::data_destruct_strided(const char *DYND_UNUSED(arrmeta), char *DYND_UNUSED(data),
+                                                       intptr_t DYND_UNUSED(stride), size_t DYND_UNUSED(count)) const
 {
   stringstream ss;
   ss << "Cannot have data for symbolic type " << type(this, true);
   throw runtime_error(ss.str());
 }
 
-bool ndt::fixed_bytes_kind_type::match(
-    const char *DYND_UNUSED(arrmeta), const type &candidate_tp,
-    const char *DYND_UNUSED(candidate_arrmeta),
-    std::map<std::string, type> &DYND_UNUSED(tp_vars)) const
+bool ndt::fixed_bytes_kind_type::match(const char *DYND_UNUSED(arrmeta), const type &candidate_tp,
+                                       const char *DYND_UNUSED(candidate_arrmeta),
+                                       std::map<std::string, type> &DYND_UNUSED(tp_vars)) const
 {
   return candidate_tp.get_id() == fixed_bytes_id;
 }

--- a/src/dynd/types/fixed_string_kind_type.cpp
+++ b/src/dynd/types/fixed_string_kind_type.cpp
@@ -16,9 +16,7 @@ ndt::fixed_string_kind_type::fixed_string_kind_type()
 {
 }
 
-ndt::fixed_string_kind_type::~fixed_string_kind_type()
-{
-}
+ndt::fixed_string_kind_type::~fixed_string_kind_type() {}
 
 size_t ndt::fixed_string_kind_type::get_default_data_size() const
 {
@@ -33,25 +31,13 @@ void ndt::fixed_string_kind_type::print_data(std::ostream &DYND_UNUSED(o), const
   throw type_error("Cannot store data of symbolic fixed_string_kind type");
 }
 
-void ndt::fixed_string_kind_type::print_type(std::ostream &o) const
-{
-  o << "FixedString";
-}
+void ndt::fixed_string_kind_type::print_type(std::ostream &o) const { o << "FixedString"; }
 
-bool ndt::fixed_string_kind_type::is_expression() const
-{
-  return false;
-}
+bool ndt::fixed_string_kind_type::is_expression() const { return false; }
 
-bool ndt::fixed_string_kind_type::is_unique_data_owner(const char *DYND_UNUSED(arrmeta)) const
-{
-  return false;
-}
+bool ndt::fixed_string_kind_type::is_unique_data_owner(const char *DYND_UNUSED(arrmeta)) const { return false; }
 
-ndt::type ndt::fixed_string_kind_type::get_canonical_type() const
-{
-  return type(this, true);
-}
+ndt::type ndt::fixed_string_kind_type::get_canonical_type() const { return type(this, true); }
 
 bool ndt::fixed_string_kind_type::is_lossless_assignment(const type &DYND_UNUSED(dst_tp),
                                                          const type &DYND_UNUSED(src_tp)) const
@@ -79,7 +65,8 @@ bool ndt::fixed_string_kind_type::operator==(const base_type &rhs) const
 {
   if (this == &rhs) {
     return true;
-  } else {
+  }
+  else {
     return rhs.get_kind() == kind_kind && rhs.get_id() == fixed_string_id;
   }
 }
@@ -92,26 +79,20 @@ void ndt::fixed_string_kind_type::arrmeta_default_construct(char *DYND_UNUSED(ar
   throw runtime_error(ss.str());
 }
 
-void ndt::fixed_string_kind_type::arrmeta_copy_construct(char *DYND_UNUSED(dst_arrmeta),
-                                                         const char *DYND_UNUSED(src_arrmeta),
-                                                         const intrusive_ptr<memory_block_data> &DYND_UNUSED(embedded_reference)) const
+void ndt::fixed_string_kind_type::arrmeta_copy_construct(
+    char *DYND_UNUSED(dst_arrmeta), const char *DYND_UNUSED(src_arrmeta),
+    const intrusive_ptr<memory_block_data> &DYND_UNUSED(embedded_reference)) const
 {
   stringstream ss;
   ss << "Cannot copy construct arrmeta for symbolic type " << type(this, true);
   throw runtime_error(ss.str());
 }
 
-void ndt::fixed_string_kind_type::arrmeta_reset_buffers(char *DYND_UNUSED(arrmeta)) const
-{
-}
+void ndt::fixed_string_kind_type::arrmeta_reset_buffers(char *DYND_UNUSED(arrmeta)) const {}
 
-void ndt::fixed_string_kind_type::arrmeta_finalize_buffers(char *DYND_UNUSED(arrmeta)) const
-{
-}
+void ndt::fixed_string_kind_type::arrmeta_finalize_buffers(char *DYND_UNUSED(arrmeta)) const {}
 
-void ndt::fixed_string_kind_type::arrmeta_destruct(char *DYND_UNUSED(arrmeta)) const
-{
-}
+void ndt::fixed_string_kind_type::arrmeta_destruct(char *DYND_UNUSED(arrmeta)) const {}
 
 void ndt::fixed_string_kind_type::arrmeta_debug_print(const char *DYND_UNUSED(arrmeta), std::ostream &DYND_UNUSED(o),
                                                       const std::string &DYND_UNUSED(indent)) const

--- a/src/dynd/types/int_kind_sym_type.cpp
+++ b/src/dynd/types/int_kind_sym_type.cpp
@@ -11,10 +11,7 @@
 using namespace std;
 using namespace dynd;
 
-ndt::int_kind_sym_type::int_kind_sym_type()
-    : base_type(int_sym_id, kind_kind, 0, 1, type_flag_symbolic, 0, 0, 0)
-{
-}
+ndt::int_kind_sym_type::int_kind_sym_type() : base_type(int_sym_id, kind_kind, 0, 1, type_flag_symbolic, 0, 0, 0) {}
 
 ndt::int_kind_sym_type::~int_kind_sym_type() {}
 
@@ -25,8 +22,7 @@ size_t ndt::int_kind_sym_type::get_default_data_size() const
   throw runtime_error(ss.str());
 }
 
-void ndt::int_kind_sym_type::print_data(std::ostream &DYND_UNUSED(o),
-                                        const char *DYND_UNUSED(arrmeta),
+void ndt::int_kind_sym_type::print_data(std::ostream &DYND_UNUSED(o), const char *DYND_UNUSED(arrmeta),
                                         const char *DYND_UNUSED(data)) const
 {
   throw type_error("Cannot store data of symbolic kind_sym type");
@@ -36,27 +32,20 @@ void ndt::int_kind_sym_type::print_type(std::ostream &o) const { o << "Int"; }
 
 bool ndt::int_kind_sym_type::is_expression() const { return false; }
 
-bool ndt::int_kind_sym_type::is_unique_data_owner(
-    const char *DYND_UNUSED(arrmeta)) const
-{
-  return false;
-}
+bool ndt::int_kind_sym_type::is_unique_data_owner(const char *DYND_UNUSED(arrmeta)) const { return false; }
 
-void ndt::int_kind_sym_type::transform_child_types(
-    type_transform_fn_t DYND_UNUSED(transform_fn),
-    intptr_t DYND_UNUSED(arrmeta_offset), void *DYND_UNUSED(extra),
-    type &out_transformed_tp, bool &DYND_UNUSED(out_was_transformed)) const
+void ndt::int_kind_sym_type::transform_child_types(type_transform_fn_t DYND_UNUSED(transform_fn),
+                                                   intptr_t DYND_UNUSED(arrmeta_offset), void *DYND_UNUSED(extra),
+                                                   type &out_transformed_tp,
+                                                   bool &DYND_UNUSED(out_was_transformed)) const
 {
   out_transformed_tp = type(this, true);
 }
 
-ndt::type ndt::int_kind_sym_type::get_canonical_type() const
-{
-  return type(this, true);
-}
+ndt::type ndt::int_kind_sym_type::get_canonical_type() const { return type(this, true); }
 
-bool ndt::int_kind_sym_type::is_lossless_assignment(
-    const type &DYND_UNUSED(dst_tp), const type &DYND_UNUSED(src_tp)) const
+bool ndt::int_kind_sym_type::is_lossless_assignment(const type &DYND_UNUSED(dst_tp),
+                                                    const type &DYND_UNUSED(src_tp)) const
 {
   return false;
 }
@@ -65,17 +54,17 @@ bool ndt::int_kind_sym_type::operator==(const base_type &rhs) const
 {
   if (this == &rhs) {
     return true;
-  } else {
+  }
+  else {
     return rhs.get_id() == int_sym_id;
   }
 }
 
-void ndt::int_kind_sym_type::arrmeta_default_construct(
-    char *DYND_UNUSED(arrmeta), bool DYND_UNUSED(blockref_alloc)) const
+void ndt::int_kind_sym_type::arrmeta_default_construct(char *DYND_UNUSED(arrmeta),
+                                                       bool DYND_UNUSED(blockref_alloc)) const
 {
   stringstream ss;
-  ss << "Cannot default construct arrmeta for symbolic type "
-     << type(this, true);
+  ss << "Cannot default construct arrmeta for symbolic type " << type(this, true);
   throw runtime_error(ss.str());
 }
 
@@ -88,59 +77,47 @@ void ndt::int_kind_sym_type::arrmeta_copy_construct(
   throw runtime_error(ss.str());
 }
 
-size_t ndt::int_kind_sym_type::arrmeta_copy_construct_onedim(
-    char *DYND_UNUSED(dst_arrmeta), const char *DYND_UNUSED(src_arrmeta),
-    memory_block_data *DYND_UNUSED(embedded_reference)) const
+size_t ndt::int_kind_sym_type::arrmeta_copy_construct_onedim(char *DYND_UNUSED(dst_arrmeta),
+                                                             const char *DYND_UNUSED(src_arrmeta),
+                                                             memory_block_data *DYND_UNUSED(embedded_reference)) const
 {
   stringstream ss;
   ss << "Cannot copy construct arrmeta for symbolic type " << type(this, true);
   throw runtime_error(ss.str());
 }
 
-void
-ndt::int_kind_sym_type::arrmeta_reset_buffers(char *DYND_UNUSED(arrmeta)) const
-{
-}
+void ndt::int_kind_sym_type::arrmeta_reset_buffers(char *DYND_UNUSED(arrmeta)) const {}
 
-void ndt::int_kind_sym_type::arrmeta_finalize_buffers(
-    char *DYND_UNUSED(arrmeta)) const
-{
-}
+void ndt::int_kind_sym_type::arrmeta_finalize_buffers(char *DYND_UNUSED(arrmeta)) const {}
 
-void ndt::int_kind_sym_type::arrmeta_destruct(char *DYND_UNUSED(arrmeta)) const
-{
-}
+void ndt::int_kind_sym_type::arrmeta_destruct(char *DYND_UNUSED(arrmeta)) const {}
 
-void ndt::int_kind_sym_type::arrmeta_debug_print(
-    const char *DYND_UNUSED(arrmeta), std::ostream &DYND_UNUSED(o),
-    const std::string &DYND_UNUSED(indent)) const
+void ndt::int_kind_sym_type::arrmeta_debug_print(const char *DYND_UNUSED(arrmeta), std::ostream &DYND_UNUSED(o),
+                                                 const std::string &DYND_UNUSED(indent)) const
 {
   stringstream ss;
   ss << "Cannot have arrmeta for symbolic type " << type(this, true);
   throw runtime_error(ss.str());
 }
 
-void ndt::int_kind_sym_type::data_destruct(const char *DYND_UNUSED(arrmeta),
-                                           char *DYND_UNUSED(data)) const
+void ndt::int_kind_sym_type::data_destruct(const char *DYND_UNUSED(arrmeta), char *DYND_UNUSED(data)) const
 {
   stringstream ss;
   ss << "Cannot have data for symbolic type " << type(this, true);
   throw runtime_error(ss.str());
 }
 
-void ndt::int_kind_sym_type::data_destruct_strided(
-    const char *DYND_UNUSED(arrmeta), char *DYND_UNUSED(data),
-    intptr_t DYND_UNUSED(stride), size_t DYND_UNUSED(count)) const
+void ndt::int_kind_sym_type::data_destruct_strided(const char *DYND_UNUSED(arrmeta), char *DYND_UNUSED(data),
+                                                   intptr_t DYND_UNUSED(stride), size_t DYND_UNUSED(count)) const
 {
   stringstream ss;
   ss << "Cannot have data for symbolic type " << type(this, true);
   throw runtime_error(ss.str());
 }
 
-bool ndt::int_kind_sym_type::match(
-    const char *DYND_UNUSED(arrmeta), const type &candidate_tp,
-    const char *DYND_UNUSED(candidate_arrmeta),
-    std::map<std::string, type> &DYND_UNUSED(tp_vars)) const
+bool ndt::int_kind_sym_type::match(const char *DYND_UNUSED(arrmeta), const type &candidate_tp,
+                                   const char *DYND_UNUSED(candidate_arrmeta),
+                                   std::map<std::string, type> &DYND_UNUSED(tp_vars)) const
 {
   // Matches against the 'kind' of the candidate type
   type_kind_t kind = candidate_tp.get_kind();

--- a/src/dynd/types/kind_sym_type.cpp
+++ b/src/dynd/types/kind_sym_type.cpp
@@ -12,13 +12,11 @@ using namespace std;
 using namespace dynd;
 
 ndt::kind_sym_type::kind_sym_type(type_kind_t kind)
-    : base_type(kind_sym_id, kind_kind, 0, 1, type_flag_symbolic, 0, 0, 0),
-      m_kind(kind)
+    : base_type(kind_sym_id, kind_kind, 0, 1, type_flag_symbolic, 0, 0, 0), m_kind(kind)
 {
   if (kind < bool_kind || kind > tuple_kind) {
     stringstream ss;
-    ss << "Out of range kind " << kind
-       << " passed to kind_sym_type constructor";
+    ss << "Out of range kind " << kind << " passed to kind_sym_type constructor";
     throw invalid_argument(ss.str());
   }
 }
@@ -32,8 +30,7 @@ size_t ndt::kind_sym_type::get_default_data_size() const
   throw runtime_error(ss.str());
 }
 
-void ndt::kind_sym_type::print_data(std::ostream &DYND_UNUSED(o),
-                                    const char *DYND_UNUSED(arrmeta),
+void ndt::kind_sym_type::print_data(std::ostream &DYND_UNUSED(o), const char *DYND_UNUSED(arrmeta),
                                     const char *DYND_UNUSED(data)) const
 {
   throw type_error("Cannot store data of symbolic kind_sym type");
@@ -43,27 +40,18 @@ void ndt::kind_sym_type::print_type(std::ostream &o) const { o << m_kind; }
 
 bool ndt::kind_sym_type::is_expression() const { return false; }
 
-bool
-ndt::kind_sym_type::is_unique_data_owner(const char *DYND_UNUSED(arrmeta)) const
-{
-  return false;
-}
+bool ndt::kind_sym_type::is_unique_data_owner(const char *DYND_UNUSED(arrmeta)) const { return false; }
 
-void ndt::kind_sym_type::transform_child_types(
-    type_transform_fn_t DYND_UNUSED(transform_fn),
-    intptr_t DYND_UNUSED(arrmeta_offset), void *DYND_UNUSED(extra),
-    type &out_transformed_tp, bool &DYND_UNUSED(out_was_transformed)) const
+void ndt::kind_sym_type::transform_child_types(type_transform_fn_t DYND_UNUSED(transform_fn),
+                                               intptr_t DYND_UNUSED(arrmeta_offset), void *DYND_UNUSED(extra),
+                                               type &out_transformed_tp, bool &DYND_UNUSED(out_was_transformed)) const
 {
   out_transformed_tp = type(this, true);
 }
 
-ndt::type ndt::kind_sym_type::get_canonical_type() const
-{
-  return type(this, true);
-}
+ndt::type ndt::kind_sym_type::get_canonical_type() const { return type(this, true); }
 
-bool ndt::kind_sym_type::is_lossless_assignment(
-    const type &DYND_UNUSED(dst_tp), const type &DYND_UNUSED(src_tp)) const
+bool ndt::kind_sym_type::is_lossless_assignment(const type &DYND_UNUSED(dst_tp), const type &DYND_UNUSED(src_tp)) const
 {
   return false;
 }
@@ -72,18 +60,16 @@ bool ndt::kind_sym_type::operator==(const base_type &rhs) const
 {
   if (this == &rhs) {
     return true;
-  } else {
-    return rhs.get_id() == kind_sym_id &&
-           m_kind == static_cast<const kind_sym_type &>(rhs).m_kind;
+  }
+  else {
+    return rhs.get_id() == kind_sym_id && m_kind == static_cast<const kind_sym_type &>(rhs).m_kind;
   }
 }
 
-void ndt::kind_sym_type::arrmeta_default_construct(
-    char *DYND_UNUSED(arrmeta), bool DYND_UNUSED(blockref_alloc)) const
+void ndt::kind_sym_type::arrmeta_default_construct(char *DYND_UNUSED(arrmeta), bool DYND_UNUSED(blockref_alloc)) const
 {
   stringstream ss;
-  ss << "Cannot default construct arrmeta for symbolic type "
-     << type(this, true);
+  ss << "Cannot default construct arrmeta for symbolic type " << type(this, true);
   throw runtime_error(ss.str());
 }
 
@@ -96,57 +82,47 @@ void ndt::kind_sym_type::arrmeta_copy_construct(
   throw runtime_error(ss.str());
 }
 
-size_t ndt::kind_sym_type::arrmeta_copy_construct_onedim(
-    char *DYND_UNUSED(dst_arrmeta), const char *DYND_UNUSED(src_arrmeta),
-    memory_block_data *DYND_UNUSED(embedded_reference)) const
+size_t ndt::kind_sym_type::arrmeta_copy_construct_onedim(char *DYND_UNUSED(dst_arrmeta),
+                                                         const char *DYND_UNUSED(src_arrmeta),
+                                                         memory_block_data *DYND_UNUSED(embedded_reference)) const
 {
   stringstream ss;
   ss << "Cannot copy construct arrmeta for symbolic type " << type(this, true);
   throw runtime_error(ss.str());
 }
 
-void ndt::kind_sym_type::arrmeta_reset_buffers(char *DYND_UNUSED(arrmeta)) const
-{
-}
+void ndt::kind_sym_type::arrmeta_reset_buffers(char *DYND_UNUSED(arrmeta)) const {}
 
-void
-ndt::kind_sym_type::arrmeta_finalize_buffers(char *DYND_UNUSED(arrmeta)) const
-{
-}
+void ndt::kind_sym_type::arrmeta_finalize_buffers(char *DYND_UNUSED(arrmeta)) const {}
 
 void ndt::kind_sym_type::arrmeta_destruct(char *DYND_UNUSED(arrmeta)) const {}
 
-void ndt::kind_sym_type::arrmeta_debug_print(
-    const char *DYND_UNUSED(arrmeta), std::ostream &DYND_UNUSED(o),
-    const std::string &DYND_UNUSED(indent)) const
+void ndt::kind_sym_type::arrmeta_debug_print(const char *DYND_UNUSED(arrmeta), std::ostream &DYND_UNUSED(o),
+                                             const std::string &DYND_UNUSED(indent)) const
 {
   stringstream ss;
   ss << "Cannot have arrmeta for symbolic type " << type(this, true);
   throw runtime_error(ss.str());
 }
 
-void ndt::kind_sym_type::data_destruct(const char *DYND_UNUSED(arrmeta),
-                                       char *DYND_UNUSED(data)) const
+void ndt::kind_sym_type::data_destruct(const char *DYND_UNUSED(arrmeta), char *DYND_UNUSED(data)) const
 {
   stringstream ss;
   ss << "Cannot have data for symbolic type " << type(this, true);
   throw runtime_error(ss.str());
 }
 
-void ndt::kind_sym_type::data_destruct_strided(const char *DYND_UNUSED(arrmeta),
-                                               char *DYND_UNUSED(data),
-                                               intptr_t DYND_UNUSED(stride),
-                                               size_t DYND_UNUSED(count)) const
+void ndt::kind_sym_type::data_destruct_strided(const char *DYND_UNUSED(arrmeta), char *DYND_UNUSED(data),
+                                               intptr_t DYND_UNUSED(stride), size_t DYND_UNUSED(count)) const
 {
   stringstream ss;
   ss << "Cannot have data for symbolic type " << type(this, true);
   throw runtime_error(ss.str());
 }
 
-bool ndt::kind_sym_type::match(
-    const char *DYND_UNUSED(arrmeta), const type &candidate_tp,
-    const char *DYND_UNUSED(candidate_arrmeta),
-    std::map<std::string, type> &DYND_UNUSED(tp_vars)) const
+bool ndt::kind_sym_type::match(const char *DYND_UNUSED(arrmeta), const type &candidate_tp,
+                               const char *DYND_UNUSED(candidate_arrmeta),
+                               std::map<std::string, type> &DYND_UNUSED(tp_vars)) const
 {
   // Matches against the 'kind' of the candidate type
   return candidate_tp.get_kind() == m_kind;

--- a/src/dynd/types/pow_dimsym_type.cpp
+++ b/src/dynd/types/pow_dimsym_type.cpp
@@ -12,25 +12,19 @@
 using namespace std;
 using namespace dynd;
 
-ndt::pow_dimsym_type::pow_dimsym_type(const type &base_tp,
-                                      const std::string &exponent,
-                                      const type &element_type)
-    : base_dim_type(pow_dimsym_id, pattern_kind, element_type, 0, 1, 0,
-                    type_flag_symbolic, false),
-      m_base_tp(base_tp), m_exponent(exponent)
+ndt::pow_dimsym_type::pow_dimsym_type(const type &base_tp, const std::string &exponent, const type &element_type)
+    : base_dim_type(pow_dimsym_id, pattern_kind, element_type, 0, 1, 0, type_flag_symbolic, false), m_base_tp(base_tp),
+      m_exponent(exponent)
 {
-  if (base_tp.is_scalar() ||
-      base_tp.extended<base_dim_type>()->get_element_type().get_id() !=
-          void_id) {
+  if (base_tp.is_scalar() || base_tp.extended<base_dim_type>()->get_element_type().get_id() != void_id) {
     stringstream ss;
-    ss << "dynd base type for dimensional power symbolic type is not valid: "
-       << base_tp;
+    ss << "dynd base type for dimensional power symbolic type is not valid: " << base_tp;
     throw type_error(ss.str());
   }
   if (m_exponent.empty()) {
     throw type_error("dynd typevar name cannot be null");
-  } else if (!is_valid_typevar_name(m_exponent.c_str(),
-                                    m_exponent.c_str() + m_exponent.size())) {
+  }
+  else if (!is_valid_typevar_name(m_exponent.c_str(), m_exponent.c_str() + m_exponent.size())) {
     stringstream ss;
     ss << "dynd typevar name ";
     print_escaped_utf8_string(ss, m_exponent);
@@ -39,8 +33,7 @@ ndt::pow_dimsym_type::pow_dimsym_type(const type &base_tp,
   }
 }
 
-void ndt::pow_dimsym_type::print_data(std::ostream &DYND_UNUSED(o),
-                                      const char *DYND_UNUSED(arrmeta),
+void ndt::pow_dimsym_type::print_data(std::ostream &DYND_UNUSED(o), const char *DYND_UNUSED(arrmeta),
                                       const char *DYND_UNUSED(data)) const
 {
   throw type_error("Cannot store data of typevar type");
@@ -52,7 +45,8 @@ void ndt::pow_dimsym_type::print_type(std::ostream &o) const
   case fixed_dim_id:
     if (m_base_tp.get_kind() == kind_kind) {
       o << "Fixed";
-    } else {
+    }
+    else {
       o << m_base_tp.extended<fixed_dim_type>()->get_fixed_dim_size();
     }
     break;
@@ -69,34 +63,30 @@ void ndt::pow_dimsym_type::print_type(std::ostream &o) const
   o << "**" << m_exponent << " * " << get_element_type();
 }
 
-ndt::type ndt::pow_dimsym_type::apply_linear_index(
-    intptr_t DYND_UNUSED(nindices), const irange *DYND_UNUSED(indices),
-    size_t DYND_UNUSED(current_i), const type &DYND_UNUSED(root_tp),
-    bool DYND_UNUSED(leading_dimension)) const
+ndt::type ndt::pow_dimsym_type::apply_linear_index(intptr_t DYND_UNUSED(nindices), const irange *DYND_UNUSED(indices),
+                                                   size_t DYND_UNUSED(current_i), const type &DYND_UNUSED(root_tp),
+                                                   bool DYND_UNUSED(leading_dimension)) const
 {
   throw type_error("Cannot store data of typevar type");
 }
 
 intptr_t ndt::pow_dimsym_type::apply_linear_index(
-    intptr_t DYND_UNUSED(nindices), const irange *DYND_UNUSED(indices),
-    const char *DYND_UNUSED(arrmeta), const type &DYND_UNUSED(result_tp),
-    char *DYND_UNUSED(out_arrmeta),
-    const intrusive_ptr<memory_block_data> &DYND_UNUSED(embedded_reference),
-    size_t DYND_UNUSED(current_i), const type &DYND_UNUSED(root_tp),
-    bool DYND_UNUSED(leading_dimension), char **DYND_UNUSED(inout_data),
+    intptr_t DYND_UNUSED(nindices), const irange *DYND_UNUSED(indices), const char *DYND_UNUSED(arrmeta),
+    const type &DYND_UNUSED(result_tp), char *DYND_UNUSED(out_arrmeta),
+    const intrusive_ptr<memory_block_data> &DYND_UNUSED(embedded_reference), size_t DYND_UNUSED(current_i),
+    const type &DYND_UNUSED(root_tp), bool DYND_UNUSED(leading_dimension), char **DYND_UNUSED(inout_data),
     intrusive_ptr<memory_block_data> &DYND_UNUSED(inout_dataref)) const
 {
   throw type_error("Cannot store data of typevar type");
 }
 
-intptr_t ndt::pow_dimsym_type::get_dim_size(const char *DYND_UNUSED(arrmeta),
-                                            const char *DYND_UNUSED(data)) const
+intptr_t ndt::pow_dimsym_type::get_dim_size(const char *DYND_UNUSED(arrmeta), const char *DYND_UNUSED(data)) const
 {
   return -1;
 }
 
-bool ndt::pow_dimsym_type::is_lossless_assignment(
-    const type &DYND_UNUSED(dst_tp), const type &DYND_UNUSED(src_tp)) const
+bool ndt::pow_dimsym_type::is_lossless_assignment(const type &DYND_UNUSED(dst_tp),
+                                                  const type &DYND_UNUSED(src_tp)) const
 {
   return false;
 }
@@ -105,17 +95,17 @@ bool ndt::pow_dimsym_type::operator==(const base_type &rhs) const
 {
   if (this == &rhs) {
     return true;
-  } else if (rhs.get_id() != pow_dimsym_id) {
+  }
+  else if (rhs.get_id() != pow_dimsym_id) {
     return false;
-  } else {
+  }
+  else {
     const pow_dimsym_type *tvt = static_cast<const pow_dimsym_type *>(&rhs);
-    return m_exponent == tvt->m_exponent && m_base_tp == tvt->m_base_tp &&
-           m_element_tp == tvt->m_element_tp;
+    return m_exponent == tvt->m_exponent && m_base_tp == tvt->m_base_tp && m_element_tp == tvt->m_element_tp;
   }
 }
 
-void ndt::pow_dimsym_type::arrmeta_default_construct(
-    char *DYND_UNUSED(arrmeta), bool DYND_UNUSED(blockref_alloc)) const
+void ndt::pow_dimsym_type::arrmeta_default_construct(char *DYND_UNUSED(arrmeta), bool DYND_UNUSED(blockref_alloc)) const
 {
   throw type_error("Cannot store data of typevar type");
 }
@@ -139,32 +129,25 @@ void ndt::pow_dimsym_type::arrmeta_destruct(char *DYND_UNUSED(arrmeta)) const
   throw type_error("Cannot store data of typevar type");
 }
 
-bool ndt::pow_dimsym_type::match(const char *arrmeta, const type &candidate_tp,
-                                 const char *candidate_arrmeta,
+bool ndt::pow_dimsym_type::match(const char *arrmeta, const type &candidate_tp, const char *candidate_arrmeta,
                                  std::map<std::string, type> &tp_vars) const
 {
   if (candidate_tp.get_id() == typevar_constructed_id) {
-    return candidate_tp.extended<typevar_constructed_type>()->match(
-        candidate_arrmeta, type(this, true), arrmeta, tp_vars);
+    return candidate_tp.extended<typevar_constructed_type>()->match(candidate_arrmeta, type(this, true), arrmeta,
+                                                                    tp_vars);
   }
 
   if (candidate_tp.get_id() == pow_dimsym_id) {
-    if (m_base_tp.match(
-            arrmeta, candidate_tp.extended<pow_dimsym_type>()->get_base_type(),
-            NULL, tp_vars)) {
+    if (m_base_tp.match(arrmeta, candidate_tp.extended<pow_dimsym_type>()->get_base_type(), NULL, tp_vars)) {
 
-      get_element_type().match(
-          arrmeta, candidate_tp.extended<pow_dimsym_type>()->get_element_type(),
-          NULL, tp_vars);
-      type &tv_type =
-          tp_vars[candidate_tp.extended<pow_dimsym_type>()->get_exponent()];
+      get_element_type().match(arrmeta, candidate_tp.extended<pow_dimsym_type>()->get_element_type(), NULL, tp_vars);
+      type &tv_type = tp_vars[candidate_tp.extended<pow_dimsym_type>()->get_exponent()];
       if (tv_type.is_null()) {
         // This typevar hasn't been seen yet
-        tv_type = typevar_dim_type::make(
-            candidate_tp.extended<pow_dimsym_type>()->get_exponent(),
-            make_type<void>());
+        tv_type = typevar_dim_type::make(candidate_tp.extended<pow_dimsym_type>()->get_exponent(), make_type<void>());
         return true;
-      } else {
+      }
+      else {
         // Make sure the type matches previous
         // instances of the type var
         return tv_type.get_id() == typevar_dim_id &&
@@ -172,25 +155,29 @@ bool ndt::pow_dimsym_type::match(const char *arrmeta, const type &candidate_tp,
                    candidate_tp.extended<pow_dimsym_type>()->get_exponent();
       }
     }
-  } else if (candidate_tp.get_ndim() == 0) {
+  }
+  else if (candidate_tp.get_ndim() == 0) {
     if (get_element_type().get_ndim() == 0) {
       // Look up to see if the exponent typevar is already matched
       type &tv_type = tp_vars[get_exponent()];
       if (tv_type.is_null()) {
         // Fill in the exponent by the number of dimensions left
         tv_type = make_fixed_dim(0, make_type<void>());
-      } else if (tv_type.get_id() == fixed_dim_id) {
+      }
+      else if (tv_type.get_id() == fixed_dim_id) {
         // Make sure the exponent already seen matches the number of
         // dimensions left in the concrete type
         if (tv_type.extended<fixed_dim_type>()->get_fixed_dim_size() != 0) {
           return false;
         }
-      } else {
+      }
+      else {
         // The exponent is always the dim_size inside a fixed_dim_type
         return false;
       }
       return m_element_tp.match(arrmeta, candidate_tp, NULL, tp_vars);
-    } else {
+    }
+    else {
       return false;
     }
   }
@@ -202,21 +189,24 @@ bool ndt::pow_dimsym_type::match(const char *arrmeta, const type &candidate_tp,
     // Fill in the exponent by the number of dimensions left
     exponent = candidate_tp.get_ndim() - get_element_type().get_ndim();
     tv_type = make_fixed_dim(exponent, make_type<void>());
-  } else if (tv_type.get_id() == fixed_dim_id) {
+  }
+  else if (tv_type.get_id() == fixed_dim_id) {
     // Make sure the exponent already seen matches the number of
     // dimensions left in the concrete type
     exponent = tv_type.extended<fixed_dim_type>()->get_fixed_dim_size();
     if (exponent != candidate_tp.get_ndim() - get_element_type().get_ndim()) {
       return false;
     }
-  } else {
+  }
+  else {
     // The exponent is always the dim_size inside a fixed_dim_type
     return false;
   }
   // If the exponent is zero, the base doesn't matter, just match the rest
   if (exponent == 0) {
     return m_element_tp.match(arrmeta, candidate_tp, NULL, tp_vars);
-  } else if (exponent < 0) {
+  }
+  else if (exponent < 0) {
     return false;
   }
   // Get the base type
@@ -228,12 +218,13 @@ bool ndt::pow_dimsym_type::match(const char *arrmeta, const type &candidate_tp,
       // dimension type
       btv_type = candidate_tp;
       base_tp = candidate_tp;
-    } else if (btv_type.get_ndim() > 0 &&
-               btv_type.get_id() != dim_fragment_id) {
+    }
+    else if (btv_type.get_ndim() > 0 && btv_type.get_id() != dim_fragment_id) {
       // Continue matching after substituting in the typevar for
       // the base type
       base_tp = btv_type;
-    } else {
+    }
+    else {
       // Doesn't match if the typevar has a dim fragment or dtype in it
       return false;
     }
@@ -246,24 +237,22 @@ bool ndt::pow_dimsym_type::match(const char *arrmeta, const type &candidate_tp,
       for (intptr_t i = 0; i < exponent; ++i) {
         switch (concrete_subtype.get_id()) {
         case fixed_dim_id:
-          concrete_subtype =
-              concrete_subtype.extended<base_dim_type>()->get_element_type();
+          concrete_subtype = concrete_subtype.extended<base_dim_type>()->get_element_type();
           break;
         default:
           return false;
         }
       }
       break;
-    } else {
-      intptr_t dim_size =
-          base_tp.extended<fixed_dim_type>()->get_fixed_dim_size();
+    }
+    else {
+      intptr_t dim_size = base_tp.extended<fixed_dim_type>()->get_fixed_dim_size();
       for (intptr_t i = 0; i < exponent; ++i) {
         if (concrete_subtype.get_id() == fixed_dim_id &&
-            concrete_subtype.extended<fixed_dim_type>()->get_fixed_dim_size() ==
-                dim_size) {
-          concrete_subtype =
-              concrete_subtype.extended<base_dim_type>()->get_element_type();
-        } else {
+            concrete_subtype.extended<fixed_dim_type>()->get_fixed_dim_size() == dim_size) {
+          concrete_subtype = concrete_subtype.extended<base_dim_type>()->get_element_type();
+        }
+        else {
           return false;
         }
       }
@@ -273,8 +262,7 @@ bool ndt::pow_dimsym_type::match(const char *arrmeta, const type &candidate_tp,
   case var_dim_id:
     for (intptr_t i = 0; i < exponent; ++i) {
       if (concrete_subtype.get_id() == var_dim_id) {
-        concrete_subtype =
-            concrete_subtype.extended<base_dim_type>()->get_element_type();
+        concrete_subtype = concrete_subtype.extended<base_dim_type>()->get_element_type();
       }
     }
     break;

--- a/src/dynd/types/scalar_kind_type.cpp
+++ b/src/dynd/types/scalar_kind_type.cpp
@@ -8,31 +8,21 @@
 using namespace std;
 using namespace dynd;
 
-ndt::scalar_kind_type::scalar_kind_type()
-    : base_type(scalar_kind_id, kind_kind, 0, 0, type_flag_symbolic, 0, 0,
-                0)
-{
-}
+ndt::scalar_kind_type::scalar_kind_type() : base_type(scalar_kind_id, kind_kind, 0, 0, type_flag_symbolic, 0, 0, 0) {}
 
-ndt::scalar_kind_type::~scalar_kind_type()
-{
-}
+ndt::scalar_kind_type::~scalar_kind_type() {}
 
 bool ndt::scalar_kind_type::operator==(const base_type &other) const
 {
   return this == &other || other.get_id() == scalar_kind_id;
 }
 
-bool ndt::scalar_kind_type::match(
-    const char *DYND_UNUSED(arrmeta), const type &candidate_tp,
-    const char *DYND_UNUSED(candidate_arrmeta),
-    std::map<std::string, type> &DYND_UNUSED(tp_vars)) const
+bool ndt::scalar_kind_type::match(const char *DYND_UNUSED(arrmeta), const type &candidate_tp,
+                                  const char *DYND_UNUSED(candidate_arrmeta),
+                                  std::map<std::string, type> &DYND_UNUSED(tp_vars)) const
 {
   // Match against any scalar
   return candidate_tp.is_scalar();
 }
 
-void ndt::scalar_kind_type::print_type(ostream &o) const
-{
-  o << "Scalar";
-}
+void ndt::scalar_kind_type::print_type(ostream &o) const { o << "Scalar"; }

--- a/src/dynd/types/struct_type.cpp
+++ b/src/dynd/types/struct_type.cpp
@@ -123,8 +123,7 @@ void ndt::struct_type::transform_child_types(type_transform_fn_t transform_fn, i
   }
 
   for (intptr_t i = 0, i_end = m_field_count; i != i_end; ++i) {
-    transform_fn(get_field_type(i), arrmeta_offset + get_arrmeta_offset(i), extra, tmp_field_types[i],
-                 was_transformed);
+    transform_fn(get_field_type(i), arrmeta_offset + get_arrmeta_offset(i), extra, tmp_field_types[i], was_transformed);
   }
   if (was_transformed) {
     out_transformed_tp = struct_type::make(m_field_names, tmp_field_types, m_variadic);

--- a/src/dynd/types/substitute_shape.cpp
+++ b/src/dynd/types/substitute_shape.cpp
@@ -21,7 +21,6 @@
 using namespace std;
 using namespace dynd;
 
-
 namespace {
 struct substitute_shape_data {
   intptr_t ndim, i;
@@ -38,10 +37,8 @@ struct substitute_shape_data {
   }
 };
 
-static void substitute_shape_visitor(const ndt::type &tp,
-                                     intptr_t DYND_UNUSED(arrmeta_offset),
-                                     void *extra, ndt::type &out_transformed_tp,
-                                     bool &out_was_transformed)
+static void substitute_shape_visitor(const ndt::type &tp, intptr_t DYND_UNUSED(arrmeta_offset), void *extra,
+                                     ndt::type &out_transformed_tp, bool &out_was_transformed)
 {
   substitute_shape_data *ssd = reinterpret_cast<substitute_shape_data *>(extra);
   intptr_t ndim = ssd->ndim, i = ssd->i;
@@ -62,15 +59,14 @@ static void substitute_shape_visitor(const ndt::type &tp,
         else {
           ssd->throw_error();
         }
-      } else {
-        if (dim_size < 0 ||
-            dim_size == tp.extended<ndt::fixed_dim_type>()->get_fixed_dim_size()) {
+      }
+      else {
+        if (dim_size < 0 || dim_size == tp.extended<ndt::fixed_dim_type>()->get_fixed_dim_size()) {
           if (!out_was_transformed) {
             out_transformed_tp = tp;
           }
           else {
-            out_transformed_tp = ndt::make_fixed_dim(
-                tp.extended<ndt::fixed_dim_type>()->get_fixed_dim_size(), subtp);
+            out_transformed_tp = ndt::make_fixed_dim(tp.extended<ndt::fixed_dim_type>()->get_fixed_dim_size(), subtp);
           }
         }
         else {
@@ -92,9 +88,7 @@ static void substitute_shape_visitor(const ndt::type &tp,
   }
   // In non-dimension case, preserve everything
   else if (i < ndim) {
-    tp.extended()->transform_child_types(&substitute_shape_visitor, 0, extra,
-                                         out_transformed_tp,
-                                         out_was_transformed);
+    tp.extended()->transform_child_types(&substitute_shape_visitor, 0, extra, out_transformed_tp, out_was_transformed);
   }
   else {
     out_transformed_tp = tp;
@@ -102,8 +96,7 @@ static void substitute_shape_visitor(const ndt::type &tp,
 }
 } // anonymous namespace
 
-ndt::type ndt::substitute_shape(const ndt::type &pattern, intptr_t ndim,
-                                const intptr_t *shape)
+ndt::type ndt::substitute_shape(const ndt::type &pattern, intptr_t ndim, const intptr_t *shape)
 {
   substitute_shape_data ssd;
   ssd.ndim = ndim;

--- a/src/dynd/types/substitute_typevars.cpp
+++ b/src/dynd/types/substitute_typevars.cpp
@@ -29,8 +29,7 @@ using namespace dynd;
  * Substitutes the field types for contiguous array of types
  */
 static std::vector<ndt::type> substitute_type_array(const nd::array &type_array,
-                                                    const std::map<std::string, ndt::type> &typevars,
-                                                    bool concrete)
+                                                    const std::map<std::string, ndt::type> &typevars, bool concrete)
 {
   intptr_t field_count = type_array.get_dim_size();
   const ndt::type *field_types = reinterpret_cast<const ndt::type *>(type_array.cdata());
@@ -64,12 +63,14 @@ ndt::type ndt::detail::internal_substitute(const ndt::type &pattern, const std::
       if (!concrete) {
         return ndt::make_fixed_dim_kind(
             ndt::substitute(pattern.extended<base_dim_type>()->get_element_type(), typevars, concrete));
-      } else {
+      }
+      else {
         throw invalid_argument("The dynd pattern type includes a symbolic "
                                "'fixed' dimension, which is not concrete as "
                                "requested");
       }
-    } else {
+    }
+    else {
       return ndt::make_fixed_dim(
           pattern.extended<fixed_dim_type>()->get_fixed_dim_size(),
           ndt::substitute(pattern.extended<fixed_dim_type>()->get_element_type(), typevars, concrete));
@@ -116,17 +117,20 @@ ndt::type ndt::detail::internal_substitute(const ndt::type &pattern, const std::
       }
       if (!concrete || !it->second.is_symbolic()) {
         return it->second;
-      } else {
+      }
+      else {
         stringstream ss;
         ss << "The substitution for dynd typevar " << pattern << ", " << it->second << ", is not concrete as required";
         throw invalid_argument(ss.str());
       }
-    } else {
+    }
+    else {
       if (concrete) {
         stringstream ss;
         ss << "No substitution type for dynd type var " << pattern << " was available";
         throw invalid_argument(ss.str());
-      } else {
+      }
+      else {
         return pattern;
       }
     }
@@ -146,7 +150,8 @@ ndt::type ndt::detail::internal_substitute(const ndt::type &pattern, const std::
           if (it->second.get_kind() == kind_kind) {
             return ndt::make_fixed_dim_kind(
                 ndt::substitute(pattern.extended<typevar_dim_type>()->get_element_type(), typevars, concrete));
-          } else {
+          }
+          else {
             return ndt::make_fixed_dim(
                 it->second.extended<fixed_dim_type>()->get_fixed_dim_size(),
                 ndt::substitute(pattern.extended<typevar_dim_type>()->get_element_type(), typevars, concrete));
@@ -161,17 +166,20 @@ ndt::type ndt::detail::internal_substitute(const ndt::type &pattern, const std::
           throw invalid_argument(ss.str());
         }
         }
-      } else {
+      }
+      else {
         stringstream ss;
         ss << "The substitution for dynd typevar " << pattern << ", " << it->second << ", is not concrete as required";
         throw invalid_argument(ss.str());
       }
-    } else {
+    }
+    else {
       if (concrete) {
         stringstream ss;
         ss << "No substitution type for dynd typevar " << pattern << " was available";
         throw invalid_argument(ss.str());
-      } else {
+      }
+      else {
         return ndt::typevar_dim_type::make(
             pattern.extended<typevar_dim_type>()->get_name(),
             ndt::substitute(pattern.extended<typevar_dim_type>()->get_element_type(), typevars, concrete));
@@ -186,7 +194,8 @@ ndt::type ndt::detail::internal_substitute(const ndt::type &pattern, const std::
     if (tv_type != typevars.end()) {
       if (tv_type->second.get_id() == fixed_dim_id) {
         exponent = tv_type->second.extended<fixed_dim_type>()->get_fixed_dim_size();
-      } else if (tv_type->second.get_id() == typevar_dim_id) {
+      }
+      else if (tv_type->second.get_id() == typevar_dim_id) {
         // If it's a typevar, substitute the new name in
         exponent_name = tv_type->second.extended<typevar_dim_type>()->get_name();
         if (concrete) {
@@ -195,7 +204,8 @@ ndt::type ndt::detail::internal_substitute(const ndt::type &pattern, const std::
              << ", is not concrete as required";
           throw invalid_argument(ss.str());
         }
-      } else {
+      }
+      else {
         stringstream ss;
         ss << "The substitution for dynd typevar " << exponent_name << ", " << tv_type->second
            << ", is not a fixed_dim integer as required";
@@ -219,10 +229,12 @@ ndt::type ndt::detail::internal_substitute(const ndt::type &pattern, const std::
           ss << "No substitution type for dynd typevar " << base_tp << " was available";
           throw invalid_argument(ss.str());
         }
-      } else if (btv_type->second.get_ndim() > 0 && btv_type->second.get_id() != dim_fragment_id) {
+      }
+      else if (btv_type->second.get_ndim() > 0 && btv_type->second.get_id() != dim_fragment_id) {
         // Swap in for the base type
         base_tp = btv_type->second;
-      } else {
+      }
+      else {
         stringstream ss;
         ss << "The substitution for dynd typevar " << base_tp << ", " << btv_type->second
            << ", is not a substitutable dimension type";
@@ -233,9 +245,11 @@ ndt::type ndt::detail::internal_substitute(const ndt::type &pattern, const std::
     ndt::type result = ndt::substitute(pattern.extended<pow_dimsym_type>()->get_element_type(), typevars, concrete);
     if (exponent == 0) {
       return result;
-    } else if (exponent < 0) {
+    }
+    else if (exponent < 0) {
       return ndt::make_pow_dimsym(base_tp, exponent_name, result);
-    } else {
+    }
+    else {
       switch (base_tp.get_id()) {
       case fixed_dim_id: {
         if (base_tp.get_kind() == kind_kind) {
@@ -248,7 +262,8 @@ ndt::type ndt::detail::internal_substitute(const ndt::type &pattern, const std::
             result = ndt::make_fixed_dim_kind(result);
           }
           return result;
-        } else {
+        }
+        else {
           intptr_t dim_size = base_tp.extended<fixed_dim_type>()->get_fixed_dim_size();
           for (intptr_t i = 0; i < exponent; ++i) {
             result = ndt::make_fixed_dim(dim_size, result);
@@ -284,24 +299,28 @@ ndt::type ndt::detail::internal_substitute(const ndt::type &pattern, const std::
         if (it->second.get_id() == dim_fragment_id) {
           return it->second.extended<dim_fragment_type>()->apply_to_dtype(
               ndt::substitute(pattern.extended<ellipsis_dim_type>()->get_element_type(), typevars, concrete));
-        } else {
+        }
+        else {
           stringstream ss;
           ss << "The substitution for dynd typevar " << pattern << ", " << it->second
              << ", is not a dim fragment as required";
           throw invalid_argument(ss.str());
         }
-      } else {
+      }
+      else {
         if (concrete) {
           stringstream ss;
           ss << "No substitution type for dynd typevar " << pattern << " was available";
           throw invalid_argument(ss.str());
-        } else {
+        }
+        else {
           return ndt::make_ellipsis_dim(
               pattern.extended<ellipsis_dim_type>()->get_name(),
               ndt::substitute(pattern.extended<ellipsis_dim_type>()->get_element_type(), typevars, concrete));
         }
       }
-    } else {
+    }
+    else {
       throw invalid_argument("Cannot substitute into an unnamed ellipsis typevar");
     }
   }
@@ -310,7 +329,8 @@ ndt::type ndt::detail::internal_substitute(const ndt::type &pattern, const std::
       stringstream ss;
       ss << "The dynd type " << pattern << " is not concrete as required";
       throw invalid_argument(ss.str());
-    } else {
+    }
+    else {
       return pattern;
     }
   }
@@ -319,7 +339,8 @@ ndt::type ndt::detail::internal_substitute(const ndt::type &pattern, const std::
       stringstream ss;
       ss << "The dynd type " << pattern << " is not concrete as required";
       throw invalid_argument(ss.str());
-    } else {
+    }
+    else {
       return pattern;
     }
   }

--- a/src/dynd/types/time_util.cpp
+++ b/src/dynd/types/time_util.cpp
@@ -17,9 +17,10 @@ using namespace dynd;
 int64_t time_hmst::to_ticks(int hour, int minute, int second, int tick)
 {
   if (is_valid(hour, minute, second, tick)) {
-    return static_cast<int64_t>(tick) + second * DYND_TICKS_PER_SECOND +
-           minute * DYND_TICKS_PER_MINUTE + hour * DYND_TICKS_PER_HOUR;
-  } else {
+    return static_cast<int64_t>(tick) + second * DYND_TICKS_PER_SECOND + minute * DYND_TICKS_PER_MINUTE +
+           hour * DYND_TICKS_PER_HOUR;
+  }
+  else {
     return DYND_TIME_NA;
   }
 }
@@ -48,10 +49,12 @@ std::string time_hmst::to_str(int hour, int minute, int second, int tick)
           ++i;
         }
         s.resize(i);
-      } else {
+      }
+      else {
         s.resize(8);
       }
-    } else {
+    }
+    else {
       s.resize(5);
     }
   }
@@ -67,13 +70,13 @@ void time_hmst::set_from_ticks(int64_t ticks)
     ticks = ticks / 60;
     minute = static_cast<int8_t>(ticks % 60);
     hour = static_cast<int8_t>(ticks / 60);
-  } else {
+  }
+  else {
     set_to_na();
   }
 }
 
-void time_hmst::set_from_str(const char *begin, const char *end,
-                             const char *&out_tz_begin, const char *&out_tz_end)
+void time_hmst::set_from_str(const char *begin, const char *end, const char *&out_tz_begin, const char *&out_tz_end)
 {
   if (!string_to_time(begin, end, *this, out_tz_begin, out_tz_end)) {
     stringstream ss;
@@ -115,7 +118,6 @@ const ndt::type &time_hmst::type()
 {
   static ndt::type tp = ndt::struct_type::make(
       {"hour", "minute", "second", "tick"},
-      {ndt::make_type<int8_t>(), ndt::make_type<int8_t>(),
-       ndt::make_type<int8_t>(), ndt::make_type<int32_t>()});
+      {ndt::make_type<int8_t>(), ndt::make_type<int8_t>(), ndt::make_type<int8_t>(), ndt::make_type<int32_t>()});
   return tp;
 }

--- a/src/dynd/types/type_alignment.cpp
+++ b/src/dynd/types/type_alignment.cpp
@@ -16,8 +16,9 @@ ndt::type ndt::make_unaligned(const ndt::type &value_type)
   if (value_type.get_data_alignment() > 1) {
     // Only do something if it requires alignment
     if (value_type.get_kind() != expr_kind) {
-//      return make_type<adapt_type>(value_type, ndt::make_fixed_bytes(value_type.get_data_size(), 1), nd::callable(),
-  //                                 nd::callable());
+      //      return make_type<adapt_type>(value_type, ndt::make_fixed_bytes(value_type.get_data_size(), 1),
+      //      nd::callable(),
+      //                                 nd::callable());
       return ndt::view_type::make(value_type, ndt::make_fixed_bytes(value_type.get_data_size(), 1));
     }
     else {

--- a/src/dynd/types/typevar_constructed_type.cpp
+++ b/src/dynd/types/typevar_constructed_type.cpp
@@ -11,16 +11,16 @@
 using namespace std;
 using namespace dynd;
 
-ndt::typevar_constructed_type::typevar_constructed_type(const std::string &name,
-                                                        const type &arg)
-    : base_type(typevar_constructed_id, pattern_kind, 0, 1,
-                type_flag_symbolic, 0, arg.get_ndim(), arg.get_strided_ndim()),
+ndt::typevar_constructed_type::typevar_constructed_type(const std::string &name, const type &arg)
+    : base_type(typevar_constructed_id, pattern_kind, 0, 1, type_flag_symbolic, 0, arg.get_ndim(),
+                arg.get_strided_ndim()),
       m_name(name), m_arg(arg)
 {
   //  static ndt::type args_pattern("((...), {...})");
   if (m_name.empty()) {
     throw type_error("dynd typevar name cannot be null");
-  } else if (!is_valid_typevar_name(m_name.c_str(), m_name.c_str() + m_name.size())) {
+  }
+  else if (!is_valid_typevar_name(m_name.c_str(), m_name.c_str() + m_name.size())) {
     stringstream ss;
     ss << "dynd typevar name ";
     print_escaped_utf8_string(ss, m_name);
@@ -35,17 +35,14 @@ ndt::typevar_constructed_type::typevar_constructed_type(const std::string &name,
   //}
 }
 
-void ndt::typevar_constructed_type::get_vars(
-    std::unordered_set<std::string> &vars) const
+void ndt::typevar_constructed_type::get_vars(std::unordered_set<std::string> &vars) const
 {
   vars.insert(m_name);
   m_arg.get_vars(vars);
 }
 
-void
-ndt::typevar_constructed_type::print_data(std::ostream &DYND_UNUSED(o),
-                                          const char *DYND_UNUSED(arrmeta),
-                                          const char *DYND_UNUSED(data)) const
+void ndt::typevar_constructed_type::print_data(std::ostream &DYND_UNUSED(o), const char *DYND_UNUSED(arrmeta),
+                                               const char *DYND_UNUSED(data)) const
 {
   throw type_error("Cannot store data of typevar_constructed type");
 }
@@ -56,41 +53,38 @@ void ndt::typevar_constructed_type::print_type(std::ostream &o) const
   o << m_name << "[" << m_arg << "]";
 }
 
-intptr_t
-ndt::typevar_constructed_type::get_dim_size(const char *DYND_UNUSED(arrmeta),
-                                            const char *DYND_UNUSED(data)) const
+intptr_t ndt::typevar_constructed_type::get_dim_size(const char *DYND_UNUSED(arrmeta),
+                                                     const char *DYND_UNUSED(data)) const
 {
   return -1;
 }
 
-ndt::type ndt::typevar_constructed_type::apply_linear_index(
-    intptr_t DYND_UNUSED(nindices), const irange *DYND_UNUSED(indices),
-    size_t DYND_UNUSED(current_i), const type &DYND_UNUSED(root_tp),
-    bool DYND_UNUSED(leading_dimension)) const
+ndt::type ndt::typevar_constructed_type::apply_linear_index(intptr_t DYND_UNUSED(nindices),
+                                                            const irange *DYND_UNUSED(indices),
+                                                            size_t DYND_UNUSED(current_i),
+                                                            const type &DYND_UNUSED(root_tp),
+                                                            bool DYND_UNUSED(leading_dimension)) const
 {
   throw type_error("Cannot store data of typevar_constructed type");
 }
 
 intptr_t ndt::typevar_constructed_type::apply_linear_index(
-    intptr_t DYND_UNUSED(nindices), const irange *DYND_UNUSED(indices),
-    const char *DYND_UNUSED(arrmeta), const type &DYND_UNUSED(result_tp),
-    char *DYND_UNUSED(out_arrmeta),
-    const intrusive_ptr<memory_block_data> &DYND_UNUSED(embedded_reference),
-    size_t DYND_UNUSED(current_i), const type &DYND_UNUSED(root_tp),
-    bool DYND_UNUSED(leading_dimension), char **DYND_UNUSED(inout_data),
+    intptr_t DYND_UNUSED(nindices), const irange *DYND_UNUSED(indices), const char *DYND_UNUSED(arrmeta),
+    const type &DYND_UNUSED(result_tp), char *DYND_UNUSED(out_arrmeta),
+    const intrusive_ptr<memory_block_data> &DYND_UNUSED(embedded_reference), size_t DYND_UNUSED(current_i),
+    const type &DYND_UNUSED(root_tp), bool DYND_UNUSED(leading_dimension), char **DYND_UNUSED(inout_data),
     intrusive_ptr<memory_block_data> &DYND_UNUSED(inout_dataref)) const
 {
   throw type_error("Cannot store data of typevar_constructed type");
 }
 
-bool
-ndt::typevar_constructed_type::is_lossless_assignment(const type &dst_tp,
-                                                      const type &src_tp) const
+bool ndt::typevar_constructed_type::is_lossless_assignment(const type &dst_tp, const type &src_tp) const
 {
   if (dst_tp.extended() == this) {
     if (src_tp.extended() == this) {
       return true;
-    } else if (src_tp.get_id() == typevar_constructed_id) {
+    }
+    else if (src_tp.get_id() == typevar_constructed_id) {
       return *dst_tp.extended() == *src_tp.extended();
     }
   }
@@ -102,17 +96,18 @@ bool ndt::typevar_constructed_type::operator==(const base_type &rhs) const
 {
   if (this == &rhs) {
     return true;
-  } else if (rhs.get_id() != typevar_constructed_id) {
+  }
+  else if (rhs.get_id() != typevar_constructed_id) {
     return false;
-  } else {
-    const typevar_constructed_type *tvt =
-        static_cast<const typevar_constructed_type *>(&rhs);
+  }
+  else {
+    const typevar_constructed_type *tvt = static_cast<const typevar_constructed_type *>(&rhs);
     return m_name == tvt->m_name && m_arg == tvt->m_arg;
   }
 }
 
-void ndt::typevar_constructed_type::arrmeta_default_construct(
-    char *DYND_UNUSED(arrmeta), bool DYND_UNUSED(blockref_alloc)) const
+void ndt::typevar_constructed_type::arrmeta_default_construct(char *DYND_UNUSED(arrmeta),
+                                                              bool DYND_UNUSED(blockref_alloc)) const
 {
   throw type_error("Cannot store data of typevar_constructed type");
 }
@@ -124,20 +119,16 @@ void ndt::typevar_constructed_type::arrmeta_copy_construct(
   throw type_error("Cannot store data of typevar_constructed type");
 }
 
-void ndt::typevar_constructed_type::arrmeta_destruct(
-    char *DYND_UNUSED(arrmeta)) const
+void ndt::typevar_constructed_type::arrmeta_destruct(char *DYND_UNUSED(arrmeta)) const
 {
   throw type_error("Cannot store data of typevar_constructed type");
 }
 
-bool ndt::typevar_constructed_type::match(
-    const char *arrmeta, const type &candidate_tp,
-    const char *candidate_arrmeta, std::map<std::string, type> &tp_vars) const
+bool ndt::typevar_constructed_type::match(const char *arrmeta, const type &candidate_tp, const char *candidate_arrmeta,
+                                          std::map<std::string, type> &tp_vars) const
 {
   if (candidate_tp.get_id() == typevar_constructed_id) {
-    return m_arg.match(arrmeta,
-                       candidate_tp.extended<typevar_constructed_type>()->m_arg,
-                       candidate_arrmeta, tp_vars);
+    return m_arg.match(arrmeta, candidate_tp.extended<typevar_constructed_type>()->m_arg, candidate_arrmeta, tp_vars);
   }
 
   if (candidate_tp.get_kind() != memory_kind) {
@@ -154,14 +145,11 @@ bool ndt::typevar_constructed_type::match(
   type &tv_type = tp_vars[m_name];
   if (tv_type.is_null()) {
     // This typevar hasn't been seen yet
-    tv_type =
-        candidate_tp.extended<base_memory_type>()->with_replaced_storage_type(
-            make_type<void>());
+    tv_type = candidate_tp.extended<base_memory_type>()->with_replaced_storage_type(make_type<void>());
   }
 
-  return m_arg.match(
-      arrmeta, candidate_tp.extended<base_memory_type>()->get_element_type(),
-      candidate_arrmeta, tp_vars);
+  return m_arg.match(arrmeta, candidate_tp.extended<base_memory_type>()->get_element_type(), candidate_arrmeta,
+                     tp_vars);
 }
 
 /*


### PR DESCRIPTION
This is the result of applying clang-format (version 3.6!) to types/*.   Some
results (see: src/dynd/types/type_alignment.cpp) are not formatted perfectly,
but I checked the output for correctness with a crude shell script and a bit
of manual intervention.



