### PR TITLE
Remove nd::array from types (Part 2).

### DIFF
--- a/include/dynd/kernels/parse_kernel.hpp
+++ b/include/dynd/kernels/parse_kernel.hpp
@@ -332,7 +332,7 @@ namespace nd {
       {
         intptr_t ckb_offset = ckb->m_size;
         size_t field_count = dst_tp.extended<ndt::struct_type>()->get_field_count();
-        const size_t *arrmeta_offsets = dst_tp.extended<ndt::struct_type>()->get_arrmeta_offsets_raw();
+        const std::vector<uintptr_t> &arrmeta_offsets = dst_tp.extended<ndt::struct_type>()->get_arrmeta_offsets();
 
         intptr_t self_offset = ckb_offset;
         ckb->emplace_back<parse_kernel>(kernreq, dst_tp, field_count,

--- a/include/dynd/types/tuple_type.hpp
+++ b/include/dynd/types/tuple_type.hpp
@@ -22,15 +22,14 @@ namespace ndt {
     intptr_t m_field_count;
 
     /**
-     * Immutable contiguous array of field types. Always has type "N * type".
+     * Immutable vector of field types. Always has type "N * type".
      */
     const std::vector<type> m_field_types;
 
     /**
-     * Immutable contiguous array of arrmeta offsets. Always has type "N *
-     * intptr".
+     * Immutable vector of arrmeta offsets. Always has type "N * uintptr".
      */
-    nd::array m_arrmeta_offsets;
+    std::vector<uintptr_t> m_arrmeta_offsets;
 
     /**
      * If true, the tuple is variadic, which means it is symbolic, and matches
@@ -63,18 +62,12 @@ namespace ndt {
     const std::vector<type> &get_field_types() const { return m_field_types; }
 
     const type *get_field_types_raw() const { return &m_field_types[0]; }
-    /** The array of the field arrmeta offsets */
-    const nd::array &get_arrmeta_offsets() const { return m_arrmeta_offsets; }
-    const uintptr_t *get_arrmeta_offsets_raw() const
-    {
-      return reinterpret_cast<const uintptr_t *>(m_arrmeta_offsets.cdata());
-    }
+    /** The field arrmeta offsets */
+    const std::vector<uintptr_t> &get_arrmeta_offsets() const { return m_arrmeta_offsets; }
+    const uintptr_t *get_arrmeta_offsets_raw() const { return m_arrmeta_offsets.data(); }
 
     const type &get_field_type(intptr_t i) const { return m_field_types[i]; }
-    const uintptr_t &get_arrmeta_offset(intptr_t i) const
-    {
-      return unchecked_fixed_dim_get<uintptr_t>(m_arrmeta_offsets, i);
-    }
+    uintptr_t get_arrmeta_offset(intptr_t i) const { return m_arrmeta_offsets[i]; }
 
     bool is_variadic() const { return m_variadic; }
 

--- a/src/dynd/array.cpp
+++ b/src/dynd/array.cpp
@@ -1093,8 +1093,7 @@ nd::array nd::reshape(const nd::array &a, const nd::array &shape)
   if (old_size != size) {
     stringstream ss;
     ss << "dynd reshape: cannot reshape to a different total number of "
-          "elements, from "
-       << old_size << " to " << size;
+          "elements, from " << old_size << " to " << size;
     throw invalid_argument(ss.str());
   }
 
@@ -1168,8 +1167,7 @@ nd::array nd::combine_into_tuple(size_t field_count, const array *field_values)
 
   array result(
       reinterpret_cast<array_preamble *>(make_array_memory_block(fsd->get_arrmeta_size(), fsd->get_default_data_size(),
-                                                                 fsd->get_data_alignment(), &data_ptr)
-                                             .get()),
+                                                                 fsd->get_data_alignment(), &data_ptr).get()),
       true);
   // Set the array properties
   result.get()->tp = result_type;
@@ -1185,7 +1183,7 @@ nd::array nd::combine_into_tuple(size_t field_count, const array *field_values)
   }
 
   // Copy all the needed arrmeta
-  const uintptr_t *arrmeta_offsets = fsd->get_arrmeta_offsets_raw();
+  const std::vector<uintptr_t> &arrmeta_offsets = fsd->get_arrmeta_offsets();
   for (size_t i = 0; i != field_count; ++i) {
     pointer_type_arrmeta *pmeta;
     pmeta = reinterpret_cast<pointer_type_arrmeta *>(result.get()->metadata() + arrmeta_offsets[i]);

--- a/src/dynd/json_formatter.cpp
+++ b/src/dynd/json_formatter.cpp
@@ -234,7 +234,7 @@ static void format_json_struct(output_data &out, const ndt::type &dt, const char
   const ndt::struct_type *bsd = dt.extended<ndt::struct_type>();
   intptr_t field_count = bsd->get_field_count();
   const size_t *data_offsets = bsd->get_data_offsets(arrmeta);
-  const size_t *arrmeta_offsets = bsd->get_arrmeta_offsets_raw();
+  const std::vector<uintptr_t> &arrmeta_offsets = bsd->get_arrmeta_offsets();
 
   if (out.struct_as_list) {
     out.write('[');

--- a/src/dynd/json_parser.cpp
+++ b/src/dynd/json_parser.cpp
@@ -56,8 +56,7 @@ static void json_as_buffer(const nd::array &json, nd::array &out_tmp_ref, const 
   default: {
     stringstream ss;
     ss << "Input for JSON parsing must be either bytes (interpreted as UTF-8) "
-          "or a string, not \""
-       << json_type << "\"";
+          "or a string, not \"" << json_type << "\"";
     throw runtime_error(ss.str());
     break;
   }
@@ -243,7 +242,7 @@ static bool parse_struct_json_from_object(const ndt::type &tp, const char *arrme
   const ndt::struct_type *fsd = tp.extended<ndt::struct_type>();
   intptr_t field_count = fsd->get_field_count();
   const size_t *data_offsets = fsd->get_data_offsets(arrmeta);
-  const size_t *arrmeta_offsets = fsd->get_arrmeta_offsets_raw();
+  const std::vector<uintptr_t> &arrmeta_offsets = fsd->get_arrmeta_offsets();
 
   // Keep track of which fields we've seen
   shortvector<bool> populated_fields(field_count);
@@ -319,7 +318,7 @@ static bool parse_tuple_json_from_list(const ndt::type &tp, const char *arrmeta,
   auto fsd = tp.extended<ndt::tuple_type>();
   intptr_t field_count = fsd->get_field_count();
   const size_t *data_offsets = fsd->get_data_offsets(arrmeta);
-  const size_t *arrmeta_offsets = fsd->get_arrmeta_offsets_raw();
+  const std::vector<uintptr_t> &arrmeta_offsets = fsd->get_arrmeta_offsets();
 
   // Loop through all the fields
   for (intptr_t i = 0; i != field_count; ++i) {

--- a/src/dynd/kernels/compare_kernels.cpp
+++ b/src/dynd/kernels/compare_kernels.cpp
@@ -25,7 +25,7 @@ void nd::equal_kernel<tuple_id, tuple_id>::instantiate(char *DYND_UNUSED(static_
   ckb->emplace_back(field_count * sizeof(size_t));
 
   equal_kernel *self = ckb->get_at<equal_kernel>(self_offset);
-  const uintptr_t *arrmeta_offsets = src_tp[0].extended<ndt::tuple_type>()->get_arrmeta_offsets_raw();
+  const std::vector<uintptr_t> &arrmeta_offsets = src_tp[0].extended<ndt::tuple_type>()->get_arrmeta_offsets();
   for (size_t i = 0; i != field_count; ++i) {
     self = ckb->get_at<equal_kernel>(self_offset);
     const ndt::type &ft = src_tp[0].extended<ndt::tuple_type>()->get_field_type(i);
@@ -54,7 +54,7 @@ void nd::not_equal_kernel<tuple_id, tuple_id>::instantiate(
 
   not_equal_kernel *e = ckb->get_at<not_equal_kernel>(self_offset);
   size_t *field_kernel_offsets;
-  const uintptr_t *arrmeta_offsets = bsd->get_arrmeta_offsets_raw();
+  const std::vector<uintptr_t> &arrmeta_offsets = bsd->get_arrmeta_offsets();
   for (size_t i = 0; i != field_count; ++i) {
     const ndt::type &ft = bsd->get_field_type(i);
     // Reserve space for the child, and save the offset to this

--- a/src/dynd/kernels/struct_assignment_kernels.cpp
+++ b/src/dynd/kernels/struct_assignment_kernels.cpp
@@ -47,7 +47,7 @@ void dynd::make_struct_assignment_kernel(nd::kernel_builder *ckb, const ndt::typ
   }
 
   const ndt::type *src_fields_tp_orig = src_sd->get_field_types_raw();
-  const uintptr_t *src_arrmeta_offsets_orig = src_sd->get_arrmeta_offsets_raw();
+  const std::vector<uintptr_t> &src_arrmeta_offsets_orig = src_sd->get_arrmeta_offsets();
   const uintptr_t *src_data_offsets_orig = src_sd->get_data_offsets(src_arrmeta);
   vector<ndt::type> src_fields_tp(field_count);
   shortvector<uintptr_t> src_data_offsets(field_count);
@@ -68,7 +68,7 @@ void dynd::make_struct_assignment_kernel(nd::kernel_builder *ckb, const ndt::typ
     src_fields_arrmeta[i] = src_arrmeta + src_arrmeta_offsets_orig[src_i];
   }
 
-  const uintptr_t *dst_arrmeta_offsets = dst_sd->get_arrmeta_offsets_raw();
+  const std::vector<uintptr_t> &dst_arrmeta_offsets = dst_sd->get_arrmeta_offsets();
   shortvector<const char *> dst_fields_arrmeta(field_count);
   for (intptr_t i = 0; i != field_count; ++i) {
     dst_fields_arrmeta[i] = dst_arrmeta + dst_arrmeta_offsets[i];

--- a/src/dynd/kernels/tuple_assignment_kernels.cpp
+++ b/src/dynd/kernels/tuple_assignment_kernels.cpp
@@ -122,7 +122,7 @@ void dynd::make_tuple_identical_assignment_kernel(nd::kernel_builder *ckb, const
 
   auto sd = val_tup_tp.extended<ndt::tuple_type>();
   intptr_t field_count = sd->get_field_count();
-  const uintptr_t *arrmeta_offsets = sd->get_arrmeta_offsets_raw();
+  const std::vector<uintptr_t> &arrmeta_offsets = sd->get_arrmeta_offsets();
   shortvector<const char *> dst_fields_arrmeta(field_count);
   for (intptr_t i = 0; i != field_count; ++i) {
     dst_fields_arrmeta[i] = dst_arrmeta + arrmeta_offsets[i];
@@ -168,13 +168,13 @@ void dynd::make_tuple_assignment_kernel(nd::kernel_builder *ckb, const ndt::type
     throw type_error(ss.str());
   }
 
-  const uintptr_t *src_arrmeta_offsets = src_sd->get_arrmeta_offsets_raw();
+  const std::vector<uintptr_t> &src_arrmeta_offsets = src_sd->get_arrmeta_offsets();
   shortvector<const char *> src_fields_arrmeta(field_count);
   for (intptr_t i = 0; i != field_count; ++i) {
     src_fields_arrmeta[i] = src_arrmeta + src_arrmeta_offsets[i];
   }
 
-  const uintptr_t *dst_arrmeta_offsets = dst_sd->get_arrmeta_offsets_raw();
+  const std::vector<uintptr_t> &dst_arrmeta_offsets = dst_sd->get_arrmeta_offsets();
   shortvector<const char *> dst_fields_arrmeta(field_count);
   for (intptr_t i = 0; i != field_count; ++i) {
     dst_fields_arrmeta[i] = dst_arrmeta + dst_arrmeta_offsets[i];
@@ -206,7 +206,7 @@ void dynd::make_broadcast_to_tuple_assignment_kernel(nd::kernel_builder *ckb, co
   auto dst_sd = dst_tuple_tp.extended<ndt::tuple_type>();
   intptr_t field_count = dst_sd->get_field_count();
 
-  const uintptr_t *dst_arrmeta_offsets = dst_sd->get_arrmeta_offsets_raw();
+  const std::vector<uintptr_t> &dst_arrmeta_offsets = dst_sd->get_arrmeta_offsets();
   shortvector<const char *> dst_fields_arrmeta(field_count);
   for (intptr_t i = 0; i != field_count; ++i) {
     dst_fields_arrmeta[i] = dst_arrmeta + dst_arrmeta_offsets[i];

--- a/src/dynd/types/datashape_formatter.cpp
+++ b/src/dynd/types/datashape_formatter.cpp
@@ -27,7 +27,7 @@ static void format_struct_datashape(std::ostream &o, const ndt::type &tp, const 
   }
   const ndt::struct_type *bsd = tp.extended<ndt::struct_type>();
   size_t field_count = bsd->get_field_count();
-  const uintptr_t *arrmeta_offsets = bsd->get_arrmeta_offsets_raw();
+  const std::vector<uintptr_t> &arrmeta_offsets = bsd->get_arrmeta_offsets();
   const uintptr_t *data_offsets = NULL;
   if (data != NULL) {
     data_offsets = bsd->get_data_offsets(arrmeta);


### PR DESCRIPTION
This makes tuple_type.m_arrmeta_offsets a vector. get_arrmeta_offsets_raw() is no longer used in libdynd and could be removed.