### PR TITLE
WIP: String split kernel

### DIFF
--- a/include/dynd/kernels/string_split_kernel.hpp
+++ b/include/dynd/kernels/string_split_kernel.hpp
@@ -1,0 +1,82 @@
+//
+// Copyright (C) 2011-15 DyND Developers
+// BSD 2-Clause License, see LICENSE.txt
+//
+
+// String split kernel
+
+#pragma once
+
+#include <dynd/string.hpp>
+#include <dynd/string_search.hpp>
+#include <dynd/types/var_dim_type.hpp>
+
+namespace dynd {
+  namespace nd {
+
+    struct string_split_kernel
+      : base_kernel<string_split_kernel, 2> {
+
+      typedef string_split_kernel self_type;
+
+      memory_block_data *m_dst_memblock;
+
+      string_split_kernel(memory_block_data *dst_memblock) :
+        m_dst_memblock(dst_memblock) {
+
+      }
+
+      static void instantiate(char *DYND_UNUSED(static_data), char *DYND_UNUSED(data),
+                              kernel_builder *ckb, const ndt::type &DYND_UNUSED(dst_tp),
+                              const char *dst_arrmeta, intptr_t DYND_UNUSED(nsrc),
+                              const ndt::type *DYND_UNUSED(src_tp),
+                              const char *const *DYND_UNUSED(src_arrmeta),
+                              kernel_request_t kernreq, intptr_t DYND_UNUSED(kwd),
+                              const nd::array *DYND_UNUSED(kwds),
+                              const std::map<std::string, ndt::type> &DYND_UNUSED(tp_vars)) {
+        ckb->emplace_back<self_type>(
+          kernreq, reinterpret_cast<const ndt::var_dim_type::metadata_type *>(dst_arrmeta)->blockref.get());
+      }
+
+      void single(char *dst, char *const *src) {
+        ndt::var_dim_type::data_type *dst_v = reinterpret_cast<ndt::var_dim_type::data_type *>(dst);
+
+        const string *const *s = reinterpret_cast<const string *const *>(src);
+        const string &haystack = *(s[0]);
+        const string &needle = *(s[1]);
+
+        intptr_t count = dynd::string_count(haystack, needle);
+
+        if (count == 0) {
+          dst_v->begin = m_dst_memblock->alloc(1);
+          dst_v->size = 1;
+          string *dst_str = reinterpret_cast<string *>(dst_v->begin);
+          new(&dst_str[0]) string(haystack);
+          return;
+        }
+
+        dst_v->begin = m_dst_memblock->alloc(count + 1);
+        dst_v->size = count + 1;
+        string *dst_str = reinterpret_cast<string *>(dst_v->begin);
+
+        dynd::detail::string_splitter<string> f(dst_str, haystack, needle);
+
+        f(haystack, needle);
+        f.finish();
+      }
+    };
+
+  } // namespace nd
+
+  namespace ndt {
+
+    template<>
+    struct traits<dynd::nd::string_split_kernel> {
+      static type equivalent() {
+        return callable_type::make(ndt::make_var_dim(type(string_id)), {type(string_id), type(string_id)});
+      }
+    };
+
+  } // namespace ndt
+
+} // namespace dynd

--- a/include/dynd/kernels/string_split_kernel.hpp
+++ b/include/dynd/kernels/string_split_kernel.hpp
@@ -17,11 +17,9 @@ namespace dynd {
     struct string_split_kernel
       : base_kernel<string_split_kernel, 2> {
 
-      typedef string_split_kernel self_type;
+      intrusive_ptr<memory_block_data> m_dst_memblock;
 
-      memory_block_data *m_dst_memblock;
-
-      string_split_kernel(memory_block_data *dst_memblock) :
+      string_split_kernel(intrusive_ptr<memory_block_data> dst_memblock) :
         m_dst_memblock(dst_memblock) {
 
       }
@@ -34,8 +32,8 @@ namespace dynd {
                               kernel_request_t kernreq, intptr_t DYND_UNUSED(kwd),
                               const nd::array *DYND_UNUSED(kwds),
                               const std::map<std::string, ndt::type> &DYND_UNUSED(tp_vars)) {
-        ckb->emplace_back<self_type>(
-          kernreq, reinterpret_cast<const ndt::var_dim_type::metadata_type *>(dst_arrmeta)->blockref.get());
+        ckb->emplace_back<string_split_kernel>(
+          kernreq, reinterpret_cast<const ndt::var_dim_type::metadata_type *>(dst_arrmeta)->blockref);
       }
 
       void single(char *dst, char *const *src) {

--- a/include/dynd/kernels/string_split_kernel.hpp
+++ b/include/dynd/kernels/string_split_kernel.hpp
@@ -49,7 +49,7 @@ namespace dynd {
           dst_v->begin = m_dst_memblock->alloc(1);
           dst_v->size = 1;
           string *dst_str = reinterpret_cast<string *>(dst_v->begin);
-          new(&dst_str[0]) string(haystack);
+          dst_str[0] = haystack;
           return;
         }
 

--- a/include/dynd/string.hpp
+++ b/include/dynd/string.hpp
@@ -126,5 +126,9 @@ namespace dynd {
       static callable make();
     } string_replace;
 
+    extern DYND_API struct DYND_API string_split : declfunc<string_split> {
+      static callable make();
+    } string_split;
+
   } // namespace dynd::nd
 } // namespace dynd

--- a/include/dynd/string_search.hpp
+++ b/include/dynd/string_search.hpp
@@ -276,7 +276,7 @@ namespace dynd {
       bool handle_match(const size_t match) {
         size_t new_size = match - m_last_src_start;
 
-        new (&m_dst[m_i]) StringType(m_src + m_last_src_start, new_size);
+        m_dst[m_i].assign(m_src + m_last_src_start, new_size);
         m_last_src_start += new_size + m_split_size;
         m_i++;
 
@@ -286,7 +286,7 @@ namespace dynd {
       void finish() {
         size_t new_size = m_src_size - m_last_src_start;
 
-        new (&m_dst[m_i]) StringType(m_src + m_last_src_start, new_size);
+        m_dst[m_i].assign(m_src + m_last_src_start, new_size);
       }
     };
 

--- a/include/dynd/string_search.hpp
+++ b/include/dynd/string_search.hpp
@@ -257,7 +257,6 @@ namespace dynd {
       StringType *m_dst;
       const char *m_src;
       size_t m_src_size;
-      size_t m_n;
       size_t m_i;
       size_t m_last_src_start;
       size_t m_split_size;

--- a/include/dynd/string_search.hpp
+++ b/include/dynd/string_search.hpp
@@ -250,5 +250,45 @@ namespace dynd {
       }
     };
 
+    template<class StringType>
+    struct string_splitter :
+      public string_search_base<string_splitter<StringType>, StringType>
+    {
+      StringType *m_dst;
+      const char *m_src;
+      size_t m_src_size;
+      size_t m_n;
+      size_t m_i;
+      size_t m_last_src_start;
+      size_t m_split_size;
+
+      string_splitter(StringType *dst, const StringType &src, const StringType& split) :
+        m_dst(dst),
+        m_src(src.begin()),
+        m_src_size(src.size()),
+        m_i(0),
+        m_last_src_start(0),
+        m_split_size(split.size())
+      {
+
+      }
+
+      bool handle_match(const size_t match) {
+        size_t new_size = match - m_last_src_start;
+
+        new (&m_dst[m_i]) StringType(m_src + m_last_src_start, new_size);
+        m_last_src_start += new_size + m_split_size;
+        m_i++;
+
+        return false;
+      }
+
+      void finish() {
+        size_t new_size = m_src_size - m_last_src_start;
+
+        new (&m_dst[m_i]) StringType(m_src + m_last_src_start, new_size);
+      }
+    };
+
   } // namespace detail
 } // namespace nd

--- a/src/dynd/string.cpp
+++ b/src/dynd/string.cpp
@@ -8,6 +8,7 @@
 #include <dynd/kernels/string_count_kernel.hpp>
 #include <dynd/kernels/string_find_kernel.hpp>
 #include <dynd/kernels/string_replace_kernel.hpp>
+#include <dynd/kernels/string_split_kernel.hpp>
 #include <dynd/func/elwise.hpp>
 
 using namespace std;
@@ -47,6 +48,13 @@ namespace dynd {
     }
 
     DYND_API struct string_replace string_replace;
+
+    DYND_API callable string_split::make()
+    {
+      return functional::elwise(callable::make<string_split_kernel>());
+    }
+
+    DYND_API struct string_split string_split;
 
   } // namespace nd
 } // namespace dynd

--- a/tests/types/test_string_type.cpp
+++ b/tests/types/test_string_type.cpp
@@ -509,6 +509,42 @@ TEST(StringType, Replace)
                   nd::string_replace(a, b, c));
 }
 
+TEST(StringType, Split) {
+  nd::array a, b, c;
+
+  a = {"xaxxbxxxc", "xxxabcxxxabcxxx", "cabababc", "foobar"};
+  b = {"x",         "abc",             "ab",       ""};
+
+  c = nd::string_split(a, b);
+
+  EXPECT_EQ(1u, c(0).get_shape().size());
+  EXPECT_EQ(7, c(0).get_shape()[0]);
+  EXPECT_EQ("", c(0)(0));
+  EXPECT_EQ("a", c(0)(1));
+  EXPECT_EQ("", c(0)(2));
+  EXPECT_EQ("b", c(0)(3));
+  EXPECT_EQ("", c(0)(4));
+  EXPECT_EQ("", c(0)(5));
+  EXPECT_EQ("c", c(0)(6));
+
+  EXPECT_EQ(1u, c(1).get_shape().size());
+  EXPECT_EQ(3, c(1).get_shape()[0]);
+  EXPECT_EQ("xxx", c(1)(0));
+  EXPECT_EQ("xxx", c(1)(1));
+  EXPECT_EQ("xxx", c(1)(2));
+
+  EXPECT_EQ(1u, c(2).get_shape().size());
+  EXPECT_EQ(4, c(2).get_shape()[0]);
+  EXPECT_EQ("c", c(2)(0));
+  EXPECT_EQ("", c(2)(1));
+  EXPECT_EQ("", c(2)(2));
+  EXPECT_EQ("c", c(2)(3));
+
+  EXPECT_EQ(1u, c(3).get_shape().size());
+  EXPECT_EQ(1, c(3).get_shape()[0]);
+  EXPECT_EQ("foobar", c(3)(0));
+}
+
 template <class T>
 static bool ascii_T_compare(const char *x, const T *y, intptr_t count)
 {


### PR DESCRIPTION
This just implements splitting on literal strings.  A commonly used feature in Python stdlib is to split on any contiguous whitespace, which this doesn't currently support, and is complicated if you want to support Unicode properly on utf-8 strings (since some whitespace characters are at codepoints > 127).  We should probably clarify the needed feature set in that regard, because it may make the most sense in the long run to just hook into a third-party regex engine to do that kind of thing.  But this PR is still probably "good enough for now" without that and serves as a proof of concept of a string kernel returning var dim arrays.

Some questions:

The general approach here is to allocate the space for the var dim array (using its allocator function) which as far as I can tell gives uninitialized memory, and then I fill it with strings using "placement new".  That's probably the most efficient way (so you don't have to initialize all the resulting strings only to reinitialize them later), but I don't know if there's a better way to spell it -- I find "placement new" isn't always the most well-known feature.

Since this function needs to allocate a var dim array, and getting the allocator from the array metadata is pretty convoluted and tied into kernels etc. I wasn't sure how to also provide the basic function to just do the splitting, as I've done for the other string algorithms.

I couldn't figure out how to write the test to compare the entire var dim array at once, so I'm just testing it element-by-element (this seems to be what the tests in `test_var_dim_type.cpp` do as well, but I don't know if there's a better way now...)