### PR TITLE
Add reverse find string kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,6 +309,7 @@ set(libdynd_SRC
     include/dynd/kernels/string_concat_kernel.hpp
     include/dynd/kernels/string_count_kernel.hpp
     include/dynd/kernels/string_find_kernel.hpp
+    include/dynd/kernels/string_rfind_kernel.hpp
     include/dynd/kernels/string_replace_kernel.hpp
     include/dynd/kernels/struct_assignment_kernels.hpp
     include/dynd/kernels/take_kernel.hpp

--- a/include/dynd/kernels/string_rfind_kernel.hpp
+++ b/include/dynd/kernels/string_rfind_kernel.hpp
@@ -27,7 +27,7 @@ namespace nd {
 namespace ndt {
 
   template <>
-  struct traits<dynd::nd::string_rfind_kernel> {
+  struct traits<nd::string_rfind_kernel> {
     static type equivalent()
     {
       return callable_type::make(ndt::make_type<intptr_t>(), {type(string_id), type(string_id)});

--- a/include/dynd/kernels/string_rfind_kernel.hpp
+++ b/include/dynd/kernels/string_rfind_kernel.hpp
@@ -1,0 +1,39 @@
+//
+// Copyright (C) 2011-15 DyND Developers
+// BSD 2-Clause License, see LICENSE.txt
+//
+
+// String rfind kernel
+
+#pragma once
+
+#include <dynd/string.hpp>
+
+namespace dynd {
+namespace nd {
+
+  struct string_rfind_kernel : base_kernel<string_rfind_kernel, 2> {
+    void single(char *dst, char *const *src)
+    {
+      intptr_t *d = reinterpret_cast<intptr_t *>(dst);
+      const string *const *s = reinterpret_cast<const string *const *>(src);
+
+      *d = dynd::string_rfind(*(s[0]), *(s[1]));
+    }
+  };
+
+} // namespace nd
+
+namespace ndt {
+
+  template <>
+  struct traits<dynd::nd::string_rfind_kernel> {
+    static type equivalent()
+    {
+      return callable_type::make(ndt::make_type<intptr_t>(), {type(string_id), type(string_id)});
+    }
+  };
+
+} // namespace ndt
+
+} // namespace dynd

--- a/include/dynd/kernels/string_rfind_kernel.hpp
+++ b/include/dynd/kernels/string_rfind_kernel.hpp
@@ -12,7 +12,7 @@
 namespace dynd {
 namespace nd {
 
-  struct string_rfind_kernel : base_kernel<string_rfind_kernel, 2> {
+  struct string_rfind_kernel : base_strided_kernel<string_rfind_kernel, 2> {
     void single(char *dst, char *const *src)
     {
       intptr_t *d = reinterpret_cast<intptr_t *>(dst);

--- a/include/dynd/kernels/string_split_kernel.hpp
+++ b/include/dynd/kernels/string_split_kernel.hpp
@@ -53,8 +53,7 @@ namespace nd {
       string *dst_str = reinterpret_cast<string *>(dst_v->begin);
 
       dynd::detail::string_splitter<string> f(dst_str, haystack, needle);
-
-      f(haystack, needle);
+      dynd::detail::string_search(haystack, needle, f);
       f.finish();
     }
   };

--- a/include/dynd/string.hpp
+++ b/include/dynd/string.hpp
@@ -141,6 +141,7 @@ namespace nd {
 
   extern DYND_API struct DYND_API string_rfind : declfunc<string_rfind> {
     static callable make();
+    static callable &get();
   } string_rfind;
 
   extern DYND_API struct DYND_API string_replace : declfunc<string_replace> {

--- a/include/dynd/string.hpp
+++ b/include/dynd/string.hpp
@@ -40,9 +40,9 @@ void string_concat(size_t nop, StringType &d, const StringType *const *s)
 template <class StringType>
 intptr_t string_count(const StringType &haystack, const StringType &needle)
 {
-  detail::string_counter<StringType> f;
+  detail::string_counter f;
 
-  f(haystack, needle);
+  detail::string_search(haystack, needle, f);
 
   return f.finish();
 }
@@ -54,9 +54,23 @@ intptr_t string_count(const StringType &haystack, const StringType &needle)
 template <class StringType>
 intptr_t string_find(const StringType &haystack, const StringType &needle)
 {
-  detail::string_finder<StringType> f;
+  detail::string_finder f;
 
-  f(haystack, needle);
+  detail::string_search(haystack, needle, f);
+
+  return f.finish();
+}
+
+/*
+  Returns byte index of the last occurrence of needle in haystack.
+  Returns -1 if not found.
+*/
+template <class StringType>
+intptr_t string_rfind(const StringType &haystack, const StringType &needle)
+{
+  detail::string_finder f;
+
+  detail::string_search_reverse(haystack, needle, f);
 
   return f.finish();
 }
@@ -90,7 +104,7 @@ void string_replace(StringType &dst, const StringType &src, const StringType &ol
     }
     else {
       detail::string_inplace_replacer<StringType> replacer(dst, new_str);
-      replacer(src, old_str);
+      detail::string_search(src, old_str, replacer);
     }
   }
   else {
@@ -103,7 +117,7 @@ void string_replace(StringType &dst, const StringType &src, const StringType &ol
     dst.resize((intptr_t)src.size() + delta);
 
     detail::string_copy_replacer<StringType> replacer(dst, src, old_str, new_str);
-    replacer(src, old_str);
+    detail::string_search(src, old_str, replacer);
     replacer.finish();
   }
 }
@@ -124,6 +138,10 @@ namespace nd {
     static callable make();
     static callable &get();
   } string_find;
+
+  extern DYND_API struct DYND_API string_rfind : declfunc<string_rfind> {
+    static callable make();
+  } string_rfind;
 
   extern DYND_API struct DYND_API string_replace : declfunc<string_replace> {
     static callable make();

--- a/include/dynd/string_search.hpp
+++ b/include/dynd/string_search.hpp
@@ -11,155 +11,242 @@
 namespace dynd {
 namespace detail {
 
-  template <class SelfType, class StringType>
-  struct string_search_base {
-    void bloom_add(uint64_t &mask, const char ch) { mask |= static_cast<uint64_t>(1) << ((ch) & (64 - 1)); }
+  class bloom_filter_t {
+    uint64_t m_mask;
 
-    uint64_t bloom(const uint64_t &mask, const char ch)
-    {
-      return mask & (static_cast<uint64_t>(1) << ((ch) & (64 - 1)));
+  public:
+    bloom_filter_t() : m_mask(0) {}
+
+    void add(const char ch) { m_mask |= static_cast<uint64_t>(1) << ((ch) & (64 - 1)); }
+
+    bool has_char(const char ch) { return m_mask & (static_cast<uint64_t>(1) << ((ch) & (64 - 1))); }
+  };
+
+  /* Special case path where the needle is only a single character.
+     According to effbot's numbers, for haystacks < 10 characters, a
+     naive loop is fastest.  Larger than that, using POSIX `memchr` is
+     faster. */
+  template <class match_handler>
+  void string_search_1char(const char *haystack, size_t n, char needle, match_handler &handle_match)
+  {
+    if (n <= 10) {
+      for (size_t i = 0; i < n; ++i) {
+        if (haystack[i] == needle) {
+          if (handle_match(i)) {
+            return;
+          }
+        }
+      }
+    }
+    else {
+      const char *s = haystack;
+      while (s < haystack + n) {
+        void *candidate = memchr((void *)s, needle, n);
+        if (candidate == NULL) {
+          return;
+        }
+        s = (const char *)candidate;
+        if (handle_match(s - haystack)) {
+          return;
+        }
+        s++;
+      }
+    }
+  }
+
+  template <class match_handler>
+  void string_search_1char_reverse(const char *haystack, size_t n, char needle, match_handler &handle_match)
+  {
+    for (size_t i = n - 1; i <= 0; --i) {
+      if (haystack[i] == needle) {
+        if (handle_match(i)) {
+          return;
+        }
+      }
+    }
+  }
+
+  template <class StringType, class match_handler>
+  void string_search(const StringType &haystack, const StringType &needle, match_handler &handle_match)
+  {
+    /*
+      This is a mostly direct copy of the algorithm by Fredrik Lundh in
+      CPython, as found here:
+
+      http://hg.python.org/cpython/file/3.5/Objects/stringlib/fastsearch.h
+
+      and described here:
+
+      http://effbot.org/zone/stringlib.htm
+
+      The main differences are a result of handling UTF-8 only, and not
+      three different char widths as in Python.
+
+      There are probably further optimizations possible here, given that
+      this is UTF-8. For example, we could skip over multi-byte
+      sequences when a match fails, but this doesn't currently do that.
+    */
+    const char *s = haystack.begin();
+    const char *p = needle.begin();
+    size_t n = haystack.size();
+    size_t m = needle.size();
+
+    intptr_t w = n - m;
+    if (w < 0) {
+      return;
     }
 
-    /* Special case path where the needle is only a single character.
-       According to effbot's numbers, for haystacks < 10 characters, a
-       naive loop is fastest.  Larger than that, using POSIX `memchr` is
-       faster. */
-    void find_1char(const char *haystack, size_t n, char needle)
-    {
-      SelfType *self = (SelfType *)this;
+    /* look for special cases */
+    if (m <= 1) {
+      if (m == 0) {
+        return;
+      }
 
-      if (n <= 10) {
-        for (size_t i = 0; i < n; ++i) {
-          if (haystack[i] == needle) {
-            if (self->handle_match(i)) {
-              return;
-            }
+      string_search_1char(haystack.begin(), n, needle.begin()[0], handle_match);
+      return;
+    }
+
+    intptr_t mlast = m - 1;
+    intptr_t skip = mlast - 1;
+
+    const char *ss = s + m - 1;
+    const char *pp = p + m - 1;
+
+    intptr_t i;
+    intptr_t j;
+
+    bloom_filter_t bloom;
+
+    /* create compressed boyer-moore delta 1 table */
+
+    /* process pattern[:-1] */
+    for (i = 0; i < mlast; i++) {
+      bloom.add(p[i]);
+      if (p[i] == p[mlast]) {
+        skip = mlast - i - 1;
+      }
+    }
+
+    /* process pattern[-1] outside the loop */
+    bloom.add(p[mlast]);
+
+    for (i = 0; i <= w; i++) {
+      /* note: using mlast in the skip path slows things down on x86 */
+      if (ss[i] == pp[0]) {
+        /* candidate match */
+        for (j = 0; j < mlast; j++) {
+          if (s[i + j] != p[j]) {
+            break;
           }
+        }
+        if (j == mlast) {
+          /* got a match! */
+          if (handle_match(i)) {
+            return;
+          }
+          i = i + mlast;
+        }
+        /* miss: check if next character is part of pattern */
+        if (i < w && !bloom.has_char(ss[i + 1])) {
+          i = i + m;
+        }
+        else {
+          i = i + skip;
         }
       }
       else {
-        const char *s = haystack;
-        while (s < haystack + n) {
-          void *candidate = memchr((void *)s, needle, n);
-          if (candidate == NULL) {
-            return;
-          }
-          s = (const char *)candidate;
-          if (self->handle_match(s - haystack)) {
-            return;
-          }
-          s++;
+        /* skip: check if next character is part of pattern */
+        if (i < w && !bloom.has_char(ss[i + 1])) {
+          i = i + m;
         }
       }
     }
 
-    void operator()(const StringType &haystack, const StringType &needle)
-    {
-      /*
-        This is a mostly direct copy of the algorithm by Fredrik Lundh in
-        CPython, as found here:
+    return;
+  }
 
-        http://hg.python.org/cpython/file/3.5/Objects/stringlib/fastsearch.h
+  template <class StringType, class match_handler>
+  void string_search_reverse(const StringType &haystack, const StringType &needle, match_handler &handle_match)
+  {
+    const char *s = haystack.begin();
+    const char *p = needle.begin();
+    size_t n = haystack.size();
+    size_t m = needle.size();
 
-        and described here:
-
-        http://effbot.org/zone/stringlib.htm
-
-        The main differences are a result of handling UTF-8 only, and not
-        three different char widths as in Python.
-
-        There are probably further optimizations possible here, given that
-        this is UTF-8. For example, we could skip over multi-byte
-        sequences when a match fails, but this doesn't currently do that.
-      */
-      SelfType *self = (SelfType *)this;
-
-      const char *s = haystack.begin();
-      const char *p = needle.begin();
-      size_t n = haystack.size();
-      size_t m = needle.size();
-
-      intptr_t w = n - m;
-      if (w < 0) {
-        return;
-      }
-
-      /* look for special cases */
-      if (m <= 1) {
-        if (m == 0) {
-          return;
-        }
-
-        find_1char(haystack.begin(), n, needle.begin()[0]);
-        return;
-      }
-
-      intptr_t mlast = m - 1;
-      intptr_t skip = mlast - 1;
-      uint64_t mask = 0;
-
-      const char *ss = s + m - 1;
-      const char *pp = p + m - 1;
-
-      intptr_t i;
-      intptr_t j;
-
-      /* create compressed boyer-moore delta 1 table */
-
-      /* process pattern[:-1] */
-      for (i = 0; i < mlast; i++) {
-        bloom_add(mask, p[i]);
-        if (p[i] == p[mlast]) {
-          skip = mlast - i - 1;
-        }
-      }
-
-      /* process pattern[-1] outside the loop */
-      bloom_add(mask, p[mlast]);
-
-      for (i = 0; i <= w; i++) {
-        /* note: using mlast in the skip path slows things down on x86 */
-        if (ss[i] == pp[0]) {
-          /* candidate match */
-          for (j = 0; j < mlast; j++) {
-            if (s[i + j] != p[j]) {
-              break;
-            }
-          }
-          if (j == mlast) {
-            /* got a match! */
-            if (self->handle_match(i)) {
-              return;
-            }
-            i = i + mlast;
-          }
-          /* miss: check if next character is part of pattern */
-          if (i < w && !bloom(mask, ss[i + 1])) {
-            i = i + m;
-          }
-          else {
-            i = i + skip;
-          }
-        }
-        else {
-          /* skip: check if next character is part of pattern */
-          if (i < w && !bloom(mask, ss[i + 1])) {
-            i = i + m;
-          }
-        }
-      }
-
+    intptr_t w = n - m;
+    if (w < 0) {
       return;
     }
-  };
 
-  template <class StringType>
-  struct string_finder : public string_search_base<string_finder<StringType>, StringType> {
+    /* look for special cases */
+    if (m <= 1) {
+      if (m == 0) {
+        return;
+      }
+
+      string_search_1char_reverse(haystack.begin(), n, needle.begin()[0], handle_match);
+      return;
+    }
+
+    intptr_t mlast = m - 1;
+    intptr_t skip = mlast - 1;
+
+    intptr_t i;
+    intptr_t j;
+
+    bloom_filter_t bloom;
+
+    /* create compressed boyer-moore delta 1 table */
+
+    bloom.add(p[0]);
+    /* process pattern[:-1] */
+    for (i = mlast; i > 0; i--) {
+      bloom.add(p[i]);
+      if (p[i] == p[0]) {
+        skip = i - 1;
+      }
+    }
+
+    for (i = w; i >= 0; i--) {
+      /* note: using mlast in the skip path slows things down on x86 */
+      if (s[i] == p[0]) {
+        /* candidate match */
+        for (j = mlast; j > 0; j--) {
+          if (s[i + j] != p[j]) {
+            break;
+          }
+        }
+        if (j == 0) {
+          /* got a match! */
+          if (handle_match(i)) {
+            return;
+          }
+        }
+        /* miss: check if next character is part of pattern */
+        if (i > 0 && !bloom.has_char(s[i - 1])) {
+          i = i - m;
+        }
+        else {
+          i = i - skip;
+        }
+      }
+      else {
+        /* skip: check if next character is part of pattern */
+        if (i > 0 && !bloom.has_char(s[i - 1])) {
+          i = i - m;
+        }
+      }
+    }
+
+    return;
+  }
+
+  struct string_finder {
     intptr_t m_result;
 
     string_finder() : m_result(-1) {}
 
-    bool handle_match(const size_t match)
+    bool operator()(const size_t match)
     {
       m_result = (intptr_t)match;
       return true;
@@ -168,13 +255,12 @@ namespace detail {
     intptr_t finish() { return m_result; }
   };
 
-  template <class StringType>
-  struct string_counter : public string_search_base<string_counter<StringType>, StringType> {
+  struct string_counter {
     size_t m_count;
 
     string_counter() : m_count(0) {}
 
-    bool handle_match(const size_t DYND_UNUSED(match))
+    bool operator()(const size_t DYND_UNUSED(match))
     {
       m_count++;
       return false;
@@ -184,13 +270,13 @@ namespace detail {
   };
 
   template <class StringType>
-  struct string_inplace_replacer : public string_search_base<string_inplace_replacer<StringType>, StringType> {
+  struct string_inplace_replacer {
     StringType &m_dst;
     const StringType &m_new_str;
 
     string_inplace_replacer(StringType &dst, const StringType &new_str) : m_dst(dst), m_new_str(new_str) {}
 
-    bool handle_match(const size_t match)
+    bool operator()(const size_t match)
     {
       DYND_MEMCPY(m_dst.begin() + match, m_new_str.begin(), m_new_str.size());
       return false;
@@ -198,7 +284,7 @@ namespace detail {
   };
 
   template <class StringType>
-  struct string_copy_replacer : public string_search_base<string_copy_replacer<StringType>, StringType> {
+  struct string_copy_replacer {
     char *m_dst;
     const char *m_src;
     size_t m_src_size;
@@ -213,7 +299,7 @@ namespace detail {
     {
     }
 
-    bool handle_match(const size_t match)
+    bool operator()(const size_t match)
     {
       size_t src_chunk_size = match - m_last_src_start;
 

--- a/include/dynd/string_search.hpp
+++ b/include/dynd/string_search.hpp
@@ -318,7 +318,7 @@ namespace detail {
   };
 
   template <class StringType>
-  struct string_splitter : public string_search_base<string_splitter<StringType>, StringType> {
+  struct string_splitter {
     StringType *m_dst;
     const char *m_src;
     size_t m_src_size;
@@ -332,7 +332,7 @@ namespace detail {
     {
     }
 
-    bool handle_match(const size_t match)
+    bool operator()(const size_t match)
     {
       size_t new_size = match - m_last_src_start;
 

--- a/include/dynd/string_search.hpp
+++ b/include/dynd/string_search.hpp
@@ -19,7 +19,9 @@ namespace detail {
 
     void add(const char ch) { m_mask |= static_cast<uint64_t>(1) << ((ch) & (64 - 1)); }
 
-    bool has_char(const char ch) { return m_mask & (static_cast<uint64_t>(1) << ((ch) & (64 - 1))); }
+    bool has_char(const char ch) {
+      return (m_mask & (static_cast<uint64_t>(1) << ((ch) & (64 - 1)))) != 0;
+    }
   };
 
   /* Special case path where the needle is only a single character.

--- a/src/dynd/string.cpp
+++ b/src/dynd/string.cpp
@@ -44,6 +44,8 @@ namespace nd {
 
   DYND_API callable string_rfind::make() { return functional::elwise(callable::make<string_rfind_kernel>()); }
 
+  DYND_DEFAULT_DECLFUNC_GET(string_rfind)
+
   DYND_API struct string_rfind string_rfind;
 
   DYND_API callable string_replace::make() { return functional::elwise(callable::make<string_replace_kernel>()); }

--- a/src/dynd/string.cpp
+++ b/src/dynd/string.cpp
@@ -7,6 +7,7 @@
 #include <dynd/kernels/string_concat_kernel.hpp>
 #include <dynd/kernels/string_count_kernel.hpp>
 #include <dynd/kernels/string_find_kernel.hpp>
+#include <dynd/kernels/string_rfind_kernel.hpp>
 #include <dynd/kernels/string_replace_kernel.hpp>
 #include <dynd/kernels/string_split_kernel.hpp>
 #include <dynd/string.hpp>
@@ -40,6 +41,10 @@ namespace nd {
   DYND_DEFAULT_DECLFUNC_GET(string_find)
 
   DYND_API struct string_find string_find;
+
+  DYND_API callable string_rfind::make() { return functional::elwise(callable::make<string_rfind_kernel>()); }
+
+  DYND_API struct string_rfind string_rfind;
 
   DYND_API callable string_replace::make() { return functional::elwise(callable::make<string_replace_kernel>()); }
 

--- a/tests/types/test_string_type.cpp
+++ b/tests/types/test_string_type.cpp
@@ -461,8 +461,18 @@ TEST(StringType, Find3)
   EXPECT_ARRAY_EQ(nd::array(c), nd::string_find(a, b));
 }
 
-TEST(StringType, Count1)
-{
+TEST(StringType, RFind1) {
+  nd::array a, b;
+
+  a = {"abc", "ababc", "abcdabc", "abd"};
+  b = "abc";
+  intptr_t c[] = {0, 2, 4, -1};
+
+  EXPECT_ARRAY_EQ(nd::array(c),
+                  nd::string_rfind(a, b));
+}
+
+TEST(StringType, Count1) {
   nd::array a, b;
 
   a = {"abc", "xxxabcxxxabcxxx", "ababab", "abd"};

--- a/tests/types/test_string_type.cpp
+++ b/tests/types/test_string_type.cpp
@@ -434,7 +434,7 @@ TEST(StringType, Find1)
   b = "abc";
   intptr_t c[] = {0, 2, -1, -1};
 
-  EXPECT_ARRAY_EQ(nd::array(c), nd::string_find(a, b));
+  EXPECT_ARRAY_EQ(c, nd::string_find(a, b));
 }
 
 TEST(StringType, Find2)
@@ -445,7 +445,7 @@ TEST(StringType, Find2)
   b = {"a", "b", "c", "bc", "d", "cd"};
   intptr_t c[] = {0, 1, 2, 1, -1, -1};
 
-  EXPECT_ARRAY_EQ(nd::array(c), nd::string_find(a, b));
+  EXPECT_ARRAY_EQ(c, nd::string_find(a, b));
 }
 
 TEST(StringType, Find3)
@@ -458,7 +458,7 @@ TEST(StringType, Find3)
   b = "a";
   intptr_t c[] = {0, -1, 4, -1, 10};
 
-  EXPECT_ARRAY_EQ(nd::array(c), nd::string_find(a, b));
+  EXPECT_ARRAY_EQ(c, nd::string_find(a, b));
 }
 
 TEST(StringType, RFind1) {
@@ -468,8 +468,7 @@ TEST(StringType, RFind1) {
   b = "abc";
   intptr_t c[] = {0, 2, 4, -1};
 
-  EXPECT_ARRAY_EQ(nd::array(c),
-                  nd::string_rfind(a, b));
+  EXPECT_ARRAY_EQ(c, nd::string_rfind(a, b));
 }
 
 TEST(StringType, Count1) {
@@ -479,7 +478,7 @@ TEST(StringType, Count1) {
   b = "abc";
   intptr_t c[] = {1, 2, 0, 0};
 
-  EXPECT_ARRAY_EQ(nd::array(c), nd::string_count(a, b));
+  EXPECT_ARRAY_EQ(c, nd::string_count(a, b));
 }
 
 TEST(StringType, Count2)
@@ -490,7 +489,7 @@ TEST(StringType, Count2)
   b = {"a", "b", "c", "bc", "d", "cd"};
   intptr_t c[] = {1, 1, 1, 1, 0, 0};
 
-  EXPECT_ARRAY_EQ(nd::array(c), nd::string_count(a, b));
+  EXPECT_ARRAY_EQ(c, nd::string_count(a, b));
 }
 
 TEST(StringType, Count3)
@@ -503,7 +502,7 @@ TEST(StringType, Count3)
   b = "a";
   intptr_t c[] = {1, 2, 0, 3};
 
-  EXPECT_ARRAY_EQ(nd::array(c), nd::string_count(a, b));
+  EXPECT_ARRAY_EQ(c, nd::string_count(a, b));
 }
 
 TEST(StringType, Replace)


### PR DESCRIPTION
This adds the `rfind` string kernel.

This includes a bit of a refactor of the string search-related algorithms so that the bloom filter search and the operators on that search are combined using function composition and not inheritance.

I probably  could have done "reverse search" with the same code as "forward search" using some iterator tricks, but that got hairier and harder to understand than just reimplementing "reverse search" as a separate function.

This is based on #952, which should be merged first.