### PR TITLE
Code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -147,7 +147,7 @@ matrix:
     - make -j3 || exit 1
     - make coverage
     after_script:
-    - coveralls-lcov coverage.info
+    - coveralls-lcov coverage.info.cleaned
 
 
 language: cpp

--- a/.travis.yml
+++ b/.travis.yml
@@ -135,8 +135,8 @@ matrix:
     - export CC="gcc-5"
     - export CXX="g++-5"
     - gem install coveralls-lcov
-    - wget http://downloads.sourceforge.net/project/ltp/Coverage%20Analysis/LCOV-1.12/lcov-1.12.tar.gz
-    - tar zvxf lcov-1.12.tar.gz
+    - wget https://github.com/linux-test-project/lcov/archive/v1.12.zip
+    - unzip v1.12.zip
     - export PATH=${PWD}/lcov-1.12/bin:$PATH
     - cp /usr/bin/gcov-5 ${PWD}/lcov-1.12/bin/gcov
     before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -147,8 +147,8 @@ matrix:
     - make -j3 || exit 1
     - make coverage
     after_script:
-    # Edit the absolute filesystem paths to be project-local so
-    # coveralls can find them
+    # Must upload coverage results from the root of the project so
+    # paths are translated correctly.
     - popd
     - coveralls-lcov build/coverage.info.cleaned
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -147,7 +147,9 @@ matrix:
     - make -j3 || exit 1
     - make coverage
     after_script:
-    - sed 's/SF:\/home\/travis\/build\/libdynd\/libdynd\///' coverage.info.cleaned > coverage.coveralls.info
+    # Edit the absolute filesystem paths to be project-local so
+    # coveralls can find them
+    - sed 's/SF:\/home\/travis\/build\/libdynd\/libdynd\//SF:/' coverage.info.cleaned > coverage.coveralls.info
     - coveralls-lcov coverage.coveralls.info
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -115,7 +115,41 @@ matrix:
     - python -c "import dynd; dynd.test(verbosity=2, exit=True)"
     after_script:
     - cd .
- 
+
+  - compiler: gcc
+    env: DYND_FFTW=ON DYND_COVERAGE=ON
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        - kalakris-cmake
+        packages:
+        - gcc-5
+        - g++-5
+        - cmake
+        # Install lcov for its Perl dependencies, even though we'll
+        # be locally installing a newer version below
+        - lcov
+        - libfftw3-dev
+    before_install:
+    - export CC="gcc-5"
+    - export CXX="g++-5"
+    - gem install coveralls-lcov
+    - wget http://downloads.sourceforge.net/project/ltp/Coverage%20Analysis/LCOV-1.12/lcov-1.12.tar.gz
+    - tar zvxf lcov-1.12.tar.gz
+    - export PATH=${PWD}/lcov-1.12/bin:$PATH
+    - cp /usr/bin/gcov-5 ${PWD}/lcov-1.12/bin/gcov
+    before_script:
+    - mkdir build
+    - pushd build
+    - cmake -DDYND_FFTW=${DYND_FFTW} -DDYND_COVERAGE=${DYND_COVERAGE} ..
+    script:
+    - make -j3 || exit 1
+    - make coverage
+    after_script:
+    - coveralls-lcov coverage.info
+
+
 language: cpp
 before_install:
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -149,8 +149,8 @@ matrix:
     after_script:
     # Edit the absolute filesystem paths to be project-local so
     # coveralls can find them
-    - sed 's/SF:\/home\/travis\/build\/libdynd\/libdynd\//SF:/' coverage.info.cleaned > coverage.coveralls.info
-    - coveralls-lcov coverage.coveralls.info
+    - popd
+    - coveralls-lcov build/coverage.info.cleaned
 
 
 language: cpp

--- a/.travis.yml
+++ b/.travis.yml
@@ -147,7 +147,8 @@ matrix:
     - make -j3 || exit 1
     - make coverage
     after_script:
-    - coveralls-lcov coverage.info.cleaned
+    - sed 's/SF:\/home\/travis\/build\/libdynd\/libdynd\///' coverage.info.cleaned > coverage.coveralls.info
+    - coveralls-lcov coverage.coveralls.info
 
 
 language: cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,8 +53,20 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
     option(DYND_BUILD_DOCS
            "Use Doxygen to generate the documentation."
            OFF)
+# -DDYND_COVERAGE=ON/OFF, whether to generate test coverage information
+    option(DYND_COVERAGE
+           "Generate code coverage reports from the unit test suite."
+           OFF)
 #
 ################################################
+endif()
+
+if(DYND_COVERAGE)
+  INCLUDE(CodeCoverage)
+
+  SET(CMAKE_BUILD_TYPE "Debug")
+  SET(CMAKE_CXX_FLAGS "-fprofile-arcs -ftest-coverage")
+  SET(CMAKE_C_FLAGS "-fprofile-arcs -ftest-coverage")
 endif()
 
 if(DYND_LLVM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,8 +65,8 @@ if(DYND_COVERAGE)
   INCLUDE(CodeCoverage)
 
   SET(CMAKE_BUILD_TYPE "Debug")
-  SET(CMAKE_CXX_FLAGS "-fprofile-arcs -ftest-coverage")
-  SET(CMAKE_C_FLAGS "-fprofile-arcs -ftest-coverage")
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_COVERAGE}")
+  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS_COVERAGE}")
 endif()
 
 if(DYND_LLVM)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The DyND Library
 
 [![Join the chat at https://gitter.im/libdynd/libdynd](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/libdynd/libdynd?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-TravisCI: [![Build Status](https://api.travis-ci.org/libdynd/libdynd.svg?branch=master)](https://travis-ci.org/libdynd/libdynd) AppVeyor: [![Build status](https://ci.appveyor.com/api/projects/status/92o89tiw6wwliuxy/branch/master?svg=true)](https://ci.appveyor.com/project/libdynd/libdynd/branch/master)
+TravisCI: [![Build Status](https://api.travis-ci.org/libdynd/libdynd.svg?branch=master)](https://travis-ci.org/libdynd/libdynd) AppVeyor: [![Build status](https://ci.appveyor.com/api/projects/status/92o89tiw6wwliuxy/branch/master?svg=true)](https://ci.appveyor.com/project/libdynd/libdynd/branch/master) Coveralls: [![Coverage Status](https://coveralls.io/repos/github/libdynd/libdynd/badge.svg?branch=master)](https://coveralls.io/github/libdynd/libdynd?branch=master)
 
 The core DyND developer team consists of
 [Mark Wiebe](https://github.com/mwiebe),

--- a/TESTING.md
+++ b/TESTING.md
@@ -52,3 +52,29 @@ with the option `--gtest_catch_exceptions=0`. This allows your debugger
 to handle it.
 
 To generate Jenkins-compatible XML output, use `test_dynd --gtest_output=xml:test_dynd_results.xml`.
+
+
+GETTING TEST COVERAGE REPORTS
+=============================
+
+Code coverage reports for the unit test suite can be generated.  The
+full library must be recompiled with `gcov` flags turned on, and
+[lcov](http://ltp.sourceforge.net/coverage/lcov.php) must be installed
+to generate the report.
+
+The easiest way to do this is to make a separate CMake build directory
+with the `DYND_COVERAGE` parameter set to on::
+
+  ```
+  ~ $ cd libdynd
+  ~/libdynd $ mkdir build-coverage
+  ~/libdynd $ cd build-coverage
+  ~/libdynd/build $ cmake -DDYND_COVERAGE=ON ..
+  <...>
+  ~/libdynd/build $ make
+  <...>
+  ~/libdynd/build $ make coverage
+  ```
+
+View the resulting `coverage/index.html` in your web browser to see
+the code coverage.

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -147,8 +147,9 @@ FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _outputname)
 		COMMAND ${_testrunner} ${ARGV3}
 
 		# Capturing lcov counters and generating report
-		COMMAND ${LCOV_PATH} --directory . --capture --output-file ${_outputname}.info
-		COMMAND ${GENHTML_PATH} -o ${_outputname} ${_outputname}.info
+		COMMAND ${LCOV_PATH} --directory . --capture --output-file ${_outputname}.info --gcov-tool ${GCOV_PATH}
+                COMMAND ${LCOV_PATH} --remove ${_outputname}.info 'thirdparty/*' '/usr/*' 'libdynd/build/*' --output-file ${_outputname}.info.cleaned
+		COMMAND ${GENHTML_PATH} -o ${_outputname} ${_outputname}.info.cleaned
 
 		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 		COMMENT "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -67,9 +67,9 @@
 #				)
 #
 # 4. Build a Debug build:
-#	 cmake -DCMAKE_BUILD_TYPE=Debug ..
-#	 make
-#	 make my_coverage_target
+#        cmake -DCMAKE_BUILD_TYPE=Debug ..
+#        make
+#        make my_coverage_target
 #
 #
 
@@ -80,16 +80,16 @@ FIND_PROGRAM( GENHTML_PATH genhtml )
 FIND_PROGRAM( GCOVR_PATH gcovr PATHS ${CMAKE_SOURCE_DIR}/tests)
 
 IF(NOT GCOV_PATH)
-	MESSAGE(FATAL_ERROR "gcov not found! Aborting...")
+        MESSAGE(FATAL_ERROR "gcov not found! Aborting...")
 ENDIF() # NOT GCOV_PATH
 
 IF(NOT CMAKE_COMPILER_IS_GNUCXX)
-	# Clang version 3.0.0 and greater now supports gcov as well.
-	MESSAGE(WARNING "Compiler is not GNU gcc! Clang Version 3.0.0 and greater supports gcov as well, but older versions don't.")
+        # Clang version 3.0.0 and greater now supports gcov as well.
+        MESSAGE(WARNING "Compiler is not GNU gcc! Clang Version 3.0.0 and greater supports gcov as well, but older versions don't.")
 
-	IF(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-		MESSAGE(FATAL_ERROR "Compiler is not GNU gcc! Aborting...")
-	ENDIF()
+        IF(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+                MESSAGE(FATAL_ERROR "Compiler is not GNU gcc! Aborting...")
+        ENDIF()
 ENDIF() # NOT CMAKE_COMPILER_IS_GNUCXX
 
 SET(CMAKE_CXX_FLAGS_COVERAGE
@@ -121,24 +121,24 @@ ENDIF() # NOT CMAKE_BUILD_TYPE STREQUAL "Debug"
 
 # Param _targetname     The name of new the custom make target
 # Param _testrunner     The name of the target which runs the tests.
-#						MUST return ZERO always, even on errors.
-#						If not, no coverage report will be created!
+#                                               MUST return ZERO always, even on errors.
+#                                               If not, no coverage report will be created!
 # Param _outputname     lcov output is generated as _outputname.info
 #                       HTML report is generated in _outputname/index.html
 # Optional fourth parameter is passed as arguments to _testrunner
 #   Pass them in list form, e.g.: "-j;2" for -j 2
 FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _outputname)
 
-	IF(NOT LCOV_PATH)
-		MESSAGE(FATAL_ERROR "lcov not found! Aborting...")
-	ENDIF() # NOT LCOV_PATH
+        IF(NOT LCOV_PATH)
+                MESSAGE(FATAL_ERROR "lcov not found! Aborting...")
+        ENDIF() # NOT LCOV_PATH
 
-	IF(NOT GENHTML_PATH)
-		MESSAGE(FATAL_ERROR "genhtml not found! Aborting...")
-	ENDIF() # NOT GENHTML_PATH
+        IF(NOT GENHTML_PATH)
+                MESSAGE(FATAL_ERROR "genhtml not found! Aborting...")
+        ENDIF() # NOT GENHTML_PATH
 
-	# Setup target
-	ADD_CUSTOM_TARGET(${_targetname}
+        # Setup target
+        ADD_CUSTOM_TARGET(${_targetname}
 
 		# Cleanup lcov
 		${LCOV_PATH} --directory . --zerocounters

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -1,0 +1,163 @@
+# This plugin is based on one downloaded from:
+#
+#  https://github.com/bilke/cmake-modules/blob/master/CodeCoverage.cmake
+#
+# and then modified for use with libdynd
+
+
+# Copyright (c) 2012 - 2015, Lars Bilke
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without
+#    specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# 2012-01-31, Lars Bilke
+# - Enable Code Coverage
+#
+# 2013-09-17, Joakim Söderberg
+# - Added support for Clang.
+# - Some additional usage instructions.
+#
+# USAGE:
+
+# 0. (Mac only) If you use Xcode 5.1 make sure to patch geninfo as described here:
+#      http://stackoverflow.com/a/22404544/80480
+#
+# 1. Copy this file into your cmake modules path.
+#
+# 2. Add the following line to your CMakeLists.txt:
+#      INCLUDE(CodeCoverage)
+#
+# 3. Set compiler flags to turn off optimization and enable coverage:
+#    SET(CMAKE_CXX_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
+#	 SET(CMAKE_C_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
+#
+# 3. Use the function SETUP_TARGET_FOR_COVERAGE to create a custom make target
+#    which runs your test executable and produces a lcov code coverage report:
+#    Example:
+#	 SETUP_TARGET_FOR_COVERAGE(
+#				my_coverage_target  # Name for custom target.
+#				test_driver         # Name of the test driver executable that runs the tests.
+#									# NOTE! This should always have a ZERO as exit code
+#									# otherwise the coverage generation will not complete.
+#				coverage            # Name of output directory.
+#				)
+#
+# 4. Build a Debug build:
+#	 cmake -DCMAKE_BUILD_TYPE=Debug ..
+#	 make
+#	 make my_coverage_target
+#
+#
+
+# Check prereqs
+FIND_PROGRAM( GCOV_PATH gcov )
+FIND_PROGRAM( LCOV_PATH lcov )
+FIND_PROGRAM( GENHTML_PATH genhtml )
+FIND_PROGRAM( GCOVR_PATH gcovr PATHS ${CMAKE_SOURCE_DIR}/tests)
+
+IF(NOT GCOV_PATH)
+	MESSAGE(FATAL_ERROR "gcov not found! Aborting...")
+ENDIF() # NOT GCOV_PATH
+
+IF(NOT CMAKE_COMPILER_IS_GNUCXX)
+	# Clang version 3.0.0 and greater now supports gcov as well.
+	MESSAGE(WARNING "Compiler is not GNU gcc! Clang Version 3.0.0 and greater supports gcov as well, but older versions don't.")
+
+	IF(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+		MESSAGE(FATAL_ERROR "Compiler is not GNU gcc! Aborting...")
+	ENDIF()
+ENDIF() # NOT CMAKE_COMPILER_IS_GNUCXX
+
+SET(CMAKE_CXX_FLAGS_COVERAGE
+    "-g -O0 --coverage -fprofile-arcs -ftest-coverage"
+    CACHE STRING "Flags used by the C++ compiler during coverage builds."
+    FORCE )
+SET(CMAKE_C_FLAGS_COVERAGE
+    "-g -O0 --coverage -fprofile-arcs -ftest-coverage"
+    CACHE STRING "Flags used by the C compiler during coverage builds."
+    FORCE )
+SET(CMAKE_EXE_LINKER_FLAGS_COVERAGE
+    ""
+    CACHE STRING "Flags used for linking binaries during coverage builds."
+    FORCE )
+SET(CMAKE_SHARED_LINKER_FLAGS_COVERAGE
+    ""
+    CACHE STRING "Flags used by the shared libraries linker during coverage builds."
+    FORCE )
+MARK_AS_ADVANCED(
+    CMAKE_CXX_FLAGS_COVERAGE
+    CMAKE_C_FLAGS_COVERAGE
+    CMAKE_EXE_LINKER_FLAGS_COVERAGE
+    CMAKE_SHARED_LINKER_FLAGS_COVERAGE )
+
+IF ( NOT (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "Coverage"))
+  MESSAGE( WARNING "Code coverage results with an optimized (non-Debug) build may be misleading" )
+ENDIF() # NOT CMAKE_BUILD_TYPE STREQUAL "Debug"
+
+
+# Param _targetname     The name of new the custom make target
+# Param _testrunner     The name of the target which runs the tests.
+#						MUST return ZERO always, even on errors.
+#						If not, no coverage report will be created!
+# Param _outputname     lcov output is generated as _outputname.info
+#                       HTML report is generated in _outputname/index.html
+# Optional fourth parameter is passed as arguments to _testrunner
+#   Pass them in list form, e.g.: "-j;2" for -j 2
+FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _outputname)
+
+	IF(NOT LCOV_PATH)
+		MESSAGE(FATAL_ERROR "lcov not found! Aborting...")
+	ENDIF() # NOT LCOV_PATH
+
+	IF(NOT GENHTML_PATH)
+		MESSAGE(FATAL_ERROR "genhtml not found! Aborting...")
+	ENDIF() # NOT GENHTML_PATH
+
+	# Setup target
+	ADD_CUSTOM_TARGET(${_targetname}
+
+		# Cleanup lcov
+		${LCOV_PATH} --directory . --zerocounters
+
+		# Run tests
+		COMMAND ${_testrunner} ${ARGV3}
+
+		# Capturing lcov counters and generating report
+		COMMAND ${LCOV_PATH} --directory . --capture --output-file ${_outputname}.info
+		COMMAND ${GENHTML_PATH} -o ${_outputname} ${_outputname}.info
+
+		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+		COMMENT "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
+	)
+
+	# Show info where to find the report
+	ADD_CUSTOM_COMMAND(TARGET ${_targetname} POST_BUILD
+		COMMAND ;
+		COMMENT "Open ./${_outputname}/index.html in your browser to view the coverage report."
+	)
+
+ENDFUNCTION() # SETUP_TARGET_FOR_COVERAGE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -175,3 +175,10 @@ endif()
 
 #test_expected_compile_succeed(builderror_includendarray.cpp)
 #test_expected_compile_error(builderror_badassignment.cpp)
+
+if (DYND_COVERAGE)
+  SETUP_TARGET_FOR_COVERAGE(
+    coverage
+    test_libdynd
+    coverage)
+endif()


### PR DESCRIPTION
This makes it easy to generate code coverage reports with `gcov` and `lcov`.

Theoretically, these reports can be posted from Travis to Coveralls, but I'm pretty sure that part of this PR won't work yet and will require some back and forth.  Even without that, this recipe is handy for generating coverage reports locally.