### PR TITLE
Workaround for segfault in Python bindings with clang on Linux

### DIFF
--- a/include/dynd/func/assignment.hpp
+++ b/include/dynd/func/assignment.hpp
@@ -11,8 +11,9 @@
 namespace dynd {
 namespace nd {
 
-  extern DYND_API struct DYND_API assign : declfunc<assign> {
+  extern DYND_API struct DYND_API assign : declfunc2<assign> {
     static callable make();
+    static callable &get();
   } assign;
 
 } // namespace dynd::nd

--- a/src/dynd/func/assignment.cpp
+++ b/src/dynd/func/assignment.cpp
@@ -24,8 +24,8 @@ struct DYND_API _bind {
 DYND_API nd::callable nd::assign::make()
 {
   typedef type_id_sequence<bool_id, int8_id, int16_id, int32_id, int64_id, int128_id, uint8_id, uint16_id, uint32_id,
-                           uint64_id, uint128_id, float32_id, float64_id, complex_float32_id,
-                           complex_float64_id> numeric_ids;
+                           uint64_id, uint128_id, float32_id, float64_id, complex_float32_id, complex_float64_id>
+      numeric_ids;
 
   ndt::type self_tp = ndt::callable_type::make(ndt::any_kind_type::make(), {ndt::any_kind_type::make()}, {"error_mode"},
                                                {ndt::make_type<ndt::option_type>(ndt::make_type<assign_error_mode>())});
@@ -119,6 +119,12 @@ DYND_API nd::callable nd::assign::make()
     }
     return child;
   });
+}
+
+DYND_API nd::callable &nd::assign::get()
+{
+  static nd::callable self = nd::assign::make();
+  return self;
 }
 
 DYND_API struct nd::assign nd::assign;


### PR DESCRIPTION
This introduces new declfunc template to demonstrate a possible workaround for the recurring segfault  with clang on Linux that was caused by symbol duplication between libdynd and client libraries under certain circumstances.

My current best theory is that the static data at https://github.com/libdynd/libdynd/blob/d14ee985052c14c08ffa156c7e70dff0cc3dcfc4/include/dynd/callable.hpp#L340 is getting inadvertently duplicated. Looking at the symbol tables it's already clear that the get method is getting instantiated wherever it's used, so it's not overly surprising that the static data gets dragged along with it. I haven't yet been able to pin down what circumstances make the duplication start happening. It'd be nice to pin that down better so we could submit a bug report upstream.

This PR, at least for now, shows a new idiom that we can use as a replacement for the current declfunc template that avoids these static initialization issues by forcing the get method of the structs created that way to be linked from libdynd. I've only applied it in the relevant place for assignment thus far. Feedback would be appreciated before I apply the replacement everywhere.