### PR TITLE
Remove type functions.

### DIFF
--- a/include/dynd/type.hpp
+++ b/include/dynd/type.hpp
@@ -629,8 +629,6 @@ namespace ndt {
     }
 
     std::map<std::string, nd::callable> get_properties() const;
-    std::map<std::string, nd::callable> get_functions() const;
-    std::map<std::string, nd::callable> get_array_functions() const;
 
     /**
      * Returns a const pointer to the base_type object which

--- a/include/dynd/types/base_type.hpp
+++ b/include/dynd/types/base_type.hpp
@@ -485,11 +485,6 @@ namespace ndt {
     virtual std::map<std::string, nd::callable> get_dynamic_type_properties() const;
 
     /**
-     * Additional dynamic functions exposed by the type as gfunc::callable.
-     */
-    virtual std::map<std::string, nd::callable> get_dynamic_type_functions() const;
-
-    /**
      * Produces forward and reverse callables for adapting the operand
      * type to the current type, according to the information stored in
      * ``op``.

--- a/src/dynd/type.cpp
+++ b/src/dynd/type.cpp
@@ -338,16 +338,6 @@ std::map<std::string, nd::callable> ndt::type::get_properties() const
   return properties;
 }
 
-std::map<std::string, nd::callable> ndt::type::get_functions() const
-{
-  std::map<std::string, nd::callable> functions;
-  if (!is_builtin()) {
-    return m_ptr->get_dynamic_type_functions();
-  }
-
-  return functions;
-}
-
 bool ndt::type::get_as_strided(const char *arrmeta, intptr_t ndim, const size_stride_t **out_size_stride,
                                ndt::type *out_el_tp, const char **out_el_arrmeta) const
 {

--- a/src/dynd/types/base_type.cpp
+++ b/src/dynd/types/base_type.cpp
@@ -241,11 +241,6 @@ std::map<std::string, nd::callable> ndt::base_type::get_dynamic_type_properties(
   return std::map<std::string, nd::callable>();
 }
 
-std::map<std::string, nd::callable> ndt::base_type::get_dynamic_type_functions() const
-{
-  return std::map<std::string, nd::callable>();
-}
-
 bool ndt::base_type::adapt_type(const type &DYND_UNUSED(operand_tp), const std::string &DYND_UNUSED(op),
                                 nd::callable &DYND_UNUSED(out_forward), nd::callable &DYND_UNUSED(out_reverse)) const
 {


### PR DESCRIPTION

I think the type functions were entirely unused. This just removes them all.