### PR TITLE
Stop requiring bash to run libdynd-config.

### DIFF
--- a/libdynd-config.in
+++ b/libdynd-config.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 if [ "$1" == "-lflag" ]; then
     echo @DYND_LINK_FLAG@


### PR DESCRIPTION
The script is generic enough to be run by any shell implementation, so stop requiring bash.