### PR TITLE
Use updated declfunc template everywhere

### DIFF
--- a/include/dynd/callable.hpp
+++ b/include/dynd/callable.hpp
@@ -320,33 +320,6 @@ namespace nd {
     template <typename DstType, typename... ArgTypes>
     array operator()(ArgTypes &&... args)
     {
-      return get().operator()<DstType>(std::forward<ArgTypes>(args)...);
-    }
-
-    template <typename... ArgTypes>
-    array operator()(ArgTypes &&... args)
-    {
-      return get()(std::forward<ArgTypes>(args)...);
-    }
-
-    array operator()(const std::initializer_list<array> &args,
-                     const std::initializer_list<std::pair<const char *, array>> &kwds)
-    {
-      return get()(args, kwds);
-    }
-
-    static callable &get()
-    {
-      static callable self = FuncType::make();
-      return self;
-    }
-  };
-
-  template <typename FuncType>
-  struct declfunc2 {
-    template <typename DstType, typename... ArgTypes>
-    array operator()(ArgTypes &&... args)
-    {
       return FuncType::get().template operator()<DstType>(std::forward<ArgTypes>(args)...);
     }
 

--- a/include/dynd/callable.hpp
+++ b/include/dynd/callable.hpp
@@ -363,6 +363,14 @@ namespace nd {
     }
   };
 
+// A macro for defining the get method.
+#define DYND_DEFAULT_DECLFUNC_GET(NAME)                                                                                \
+  DYND_API dynd::nd::callable &NAME::get()                                                                             \
+  {                                                                                                                    \
+    static dynd::nd::callable self = NAME::make();                                                                     \
+    return self;                                                                                                       \
+  }
+
   template <typename FuncType>
   std::ostream &operator<<(std::ostream &o, const declfunc<FuncType> &DYND_UNUSED(rhs))
   {
@@ -473,8 +481,7 @@ namespace nd {
   } // namespace dynd::nd::functional
 
   template <typename CallableType, typename... T, typename>
-  callable::callable(CallableType f, T &&... names)
-      : callable(nd::functional::apply(f, std::forward<T>(names)...))
+  callable::callable(CallableType f, T &&... names) : callable(nd::functional::apply(f, std::forward<T>(names)...))
   {
   }
 

--- a/include/dynd/func/arithmetic.hpp
+++ b/include/dynd/func/arithmetic.hpp
@@ -45,6 +45,7 @@ namespace nd {
       ss << "no viable overload for dynd::nd::" #NAME " with argument type \"" << src0_type << "\"";                   \
       return ss.str();                                                                                                 \
     }                                                                                                                  \
+    static callable &get();                                                                                            \
   } NAME;
 
   DYND_DEF_UNARY_OP_CALLABLE(plus, arithmetic_ids)
@@ -102,16 +103,18 @@ namespace nd {
          << "\"";                                                                                                      \
       return ss.str();                                                                                                 \
     }                                                                                                                  \
+    static nd::callable &get();                                                                                        \
   } NAME;
 
   namespace detail {
 
-    typedef type_id_sequence<uint8_id, uint16_id, uint32_id, uint64_id, int8_id, int16_id,
-                             int32_id, int64_id, float32_id, float64_id, complex_float32_id,
-                             complex_float64_id> binop_ids;
+    typedef type_id_sequence<uint8_id, uint16_id, uint32_id, uint64_id, int8_id, int16_id, int32_id, int64_id,
+                             float32_id, float64_id, complex_float32_id, complex_float64_id>
+        binop_ids;
 
-    typedef type_id_sequence<uint8_id, uint16_id, uint32_id, uint64_id, int8_id, int16_id,
-                             int32_id, int64_id, float32_id, float64_id> binop_real_ids;
+    typedef type_id_sequence<uint8_id, uint16_id, uint32_id, uint64_id, int8_id, int16_id, int32_id, int64_id,
+                             float32_id, float64_id>
+        binop_real_ids;
   }
 
   DYND_DEF_BINARY_OP_CALLABLE(add, detail::binop_ids)
@@ -144,20 +147,21 @@ namespace nd {
       }
 
       return functional::dispatch(ndt::type("(Any) -> Any"),
-                                       [children](const ndt::type &dst_tp, intptr_t DYND_UNUSED(nsrc),
-                                                  const ndt::type *src_tp) mutable -> callable & {
-                                         callable &child = children[{{dst_tp.get_id(), src_tp[0].get_id()}}];
-                                         if (child.is_null()) {
-                                           throw std::runtime_error("no child found");
-                                         }
+                                  [children](const ndt::type &dst_tp, intptr_t DYND_UNUSED(nsrc),
+                                             const ndt::type *src_tp) mutable -> callable & {
+                                    callable &child = children[{{dst_tp.get_id(), src_tp[0].get_id()}}];
+                                    if (child.is_null()) {
+                                      throw std::runtime_error("no child found");
+                                    }
 
-                                         return child;
-                                       });
+                                    return child;
+                                  });
     }
   };
 
 #define DYND_DEF_COMPOUND_OP_CALLABLE(NAME, TYPES)                                                                     \
   extern DYND_API struct DYND_API NAME : compound_arithmetic_operator<NAME, NAME##_kernel_t, TYPES> {                  \
+    static nd::callable &get();                                                                                        \
   } NAME;
 
   DYND_DEF_COMPOUND_OP_CALLABLE(compound_add, detail::binop_ids)

--- a/include/dynd/func/assignment.hpp
+++ b/include/dynd/func/assignment.hpp
@@ -11,7 +11,7 @@
 namespace dynd {
 namespace nd {
 
-  extern DYND_API struct DYND_API assign : declfunc2<assign> {
+  extern DYND_API struct DYND_API assign : declfunc<assign> {
     static callable make();
     static callable &get();
   } assign;

--- a/include/dynd/func/comparison.hpp
+++ b/include/dynd/func/comparison.hpp
@@ -16,7 +16,8 @@ namespace nd {
     static decltype(auto) make_children()
     {
       typedef type_id_sequence<bool_id, int8_id, int16_id, int32_id, int64_id, uint8_id, uint16_id, uint32_id,
-                               uint64_id, float32_id, float64_id> numeric_ids;
+                               uint64_id, float32_id, float64_id>
+          numeric_ids;
 
       auto children = callable::make_all<KernelType, numeric_ids, numeric_ids>();
 
@@ -70,9 +71,11 @@ namespace nd {
   };
 
   extern DYND_API struct DYND_API less : comparison_operator<less, less_kernel> {
+    static callable &get();
   } less;
 
   extern DYND_API struct DYND_API less_equal : comparison_operator<less_equal, less_equal_kernel> {
+    static callable &get();
   } less_equal;
 
   extern DYND_API struct DYND_API equal : comparison_operator<equal, equal_kernel> {
@@ -90,6 +93,7 @@ namespace nd {
 
       return children;
     }
+    static callable &get();
   } equal;
 
   extern DYND_API struct DYND_API not_equal : comparison_operator<not_equal, not_equal_kernel> {
@@ -107,16 +111,20 @@ namespace nd {
 
       return children;
     }
+    static callable &get();
   } not_equal;
 
   extern DYND_API struct DYND_API greater_equal : comparison_operator<greater_equal, greater_equal_kernel> {
+    static callable &get();
   } greater_equal;
 
   extern DYND_API struct DYND_API greater : comparison_operator<greater, greater_kernel> {
+    static callable &get();
   } greater;
 
   extern DYND_API struct DYND_API total_order : declfunc<total_order> {
     static callable make();
+    static callable &get();
   } total_order;
 
 } // namespace dynd::nd

--- a/include/dynd/func/complex.hpp
+++ b/include/dynd/func/complex.hpp
@@ -12,14 +12,17 @@ namespace nd {
 
   extern DYND_API struct DYND_API real : declfunc<real> {
     static callable make();
+    static callable &get();
   } real;
 
   extern DYND_API struct DYND_API imag : declfunc<imag> {
     static callable make();
+    static callable &get();
   } imag;
 
   extern DYND_API struct DYND_API conj : declfunc<conj> {
     static callable make();
+    static callable &get();
   } conj;
 
 } // namespace dynd::nd

--- a/include/dynd/func/copy.hpp
+++ b/include/dynd/func/copy.hpp
@@ -16,6 +16,7 @@ namespace nd {
    */
   DYND_API extern struct DYND_API copy : declfunc<copy> {
     static callable make();
+    static callable &get();
   } copy;
 
 } // namespace dynd::nd

--- a/include/dynd/func/fft.hpp
+++ b/include/dynd/func/fft.hpp
@@ -5,8 +5,8 @@
 
 #pragma once
 
-#include <dynd/kernels/fft_kernel.hpp>
 #include <dynd/callable.hpp>
+#include <dynd/kernels/fft_kernel.hpp>
 
 namespace dynd {
 namespace nd {
@@ -84,18 +84,22 @@ namespace nd {
 
   extern DYND_API struct DYND_API fft : declfunc<fft> {
     static callable make();
+    static callable &get();
   } fft;
 
   extern DYND_API struct DYND_API ifft : declfunc<ifft> {
     static callable make();
+    static callable &get();
   } ifft;
 
   extern DYND_API struct DYND_API rfft : declfunc<rfft> {
     static callable make();
+    static callable &get();
   } rfft;
 
   extern DYND_API struct DYND_API irfft : declfunc<irfft> {
     static callable make();
+    static callable &get();
   } irfft;
 
   /**

--- a/include/dynd/func/math.hpp
+++ b/include/dynd/func/math.hpp
@@ -12,18 +12,22 @@ namespace nd {
 
   extern DYND_API struct DYND_API cos : declfunc<cos> {
     static callable make();
+    static callable &get();
   } cos;
 
   extern DYND_API struct DYND_API sin : declfunc<sin> {
     static callable make();
+    static callable &get();
   } sin;
 
   extern DYND_API struct DYND_API tan : declfunc<tan> {
     static callable make();
+    static callable &get();
   } tan;
 
   extern DYND_API struct DYND_API exp : declfunc<exp> {
     static callable make();
+    static callable &get();
   } exp;
 
 } // namespace dynd::nd

--- a/include/dynd/func/max.hpp
+++ b/include/dynd/func/max.hpp
@@ -12,6 +12,7 @@ namespace nd {
 
   extern DYND_API struct DYND_API max : declfunc<max> {
     static callable make();
+    static callable &get();
   } max;
 
 } // namespace dynd::nd

--- a/include/dynd/func/mean.hpp
+++ b/include/dynd/func/mean.hpp
@@ -12,6 +12,7 @@ namespace nd {
 
   extern DYND_API struct DYND_API mean : declfunc<mean> {
     static callable make();
+    static callable &get();
   } mean;
 
 } // namespace dynd::nd

--- a/include/dynd/func/min.hpp
+++ b/include/dynd/func/min.hpp
@@ -12,6 +12,7 @@ namespace nd {
 
   extern DYND_API struct DYND_API min : declfunc<min> {
     static callable make();
+    static callable &get();
   } min;
 
 } // namespace dynd::nd

--- a/include/dynd/func/pointer.hpp
+++ b/include/dynd/func/pointer.hpp
@@ -12,6 +12,7 @@ namespace nd {
 
   extern DYND_API struct DYND_API dereference : declfunc<dereference> {
     static callable make();
+    static callable &get();
   } dereference;
 
 } // namespace dynd::nd

--- a/include/dynd/func/random.hpp
+++ b/include/dynd/func/random.hpp
@@ -12,6 +12,7 @@ namespace nd {
 
     extern DYND_API struct DYND_API uniform : declfunc<uniform> {
       static callable make();
+      static callable &get();
     } uniform;
 
   } // namespace dynd::nd::random

--- a/include/dynd/func/sum.hpp
+++ b/include/dynd/func/sum.hpp
@@ -12,6 +12,7 @@ namespace nd {
 
   extern DYND_API struct DYND_API sum : declfunc<sum> {
     static callable make();
+    static callable &get();
   } sum;
 
 } // namespace dynd::nd

--- a/include/dynd/func/take.hpp
+++ b/include/dynd/func/take.hpp
@@ -16,6 +16,7 @@ namespace nd {
    */
   extern DYND_API struct DYND_API take : declfunc<take> {
     static callable make();
+    static callable &get();
   } take;
 
 } // namespace dynd::nd

--- a/include/dynd/func/take_by_pointer.hpp
+++ b/include/dynd/func/take_by_pointer.hpp
@@ -5,8 +5,8 @@
 
 #pragma once
 
-#include <dynd/shape_tools.hpp>
 #include <dynd/callable.hpp>
+#include <dynd/shape_tools.hpp>
 #include <dynd/types/pointer_type.hpp>
 
 namespace dynd {
@@ -19,6 +19,7 @@ namespace nd {
    */
   extern DYND_API struct DYND_API take_by_pointer : declfunc<take_by_pointer> {
     static callable make();
+    static callable &get();
   } take_by_pointer;
 
 } // namespace dynd::nd

--- a/include/dynd/func/view.hpp
+++ b/include/dynd/func/view.hpp
@@ -12,6 +12,7 @@ namespace nd {
 
   extern DYND_API struct DYND_API view : declfunc<view> {
     static callable make();
+    static callable &get();
   } view;
 
 } // namespace dynd::nd

--- a/include/dynd/index.hpp
+++ b/include/dynd/index.hpp
@@ -12,6 +12,7 @@ namespace nd {
 
   extern DYND_API struct DYND_API index : declfunc<index> {
     static callable make();
+    static callable &get();
   } index;
 
 } // namespace dynd::nd

--- a/include/dynd/io.hpp
+++ b/include/dynd/io.hpp
@@ -12,6 +12,7 @@ namespace nd {
 
   extern DYND_API struct DYND_API serialize : declfunc<serialize> {
     static callable make();
+    static callable &get();
   } serialize;
 
 } // namespace dynd::nd

--- a/include/dynd/kernels/byteswap_kernels.hpp
+++ b/include/dynd/kernels/byteswap_kernels.hpp
@@ -5,8 +5,8 @@
 
 #pragma once
 
-#include <dynd/diagnostics.hpp>
 #include <dynd/callable.hpp>
+#include <dynd/diagnostics.hpp>
 
 namespace dynd {
 
@@ -109,10 +109,12 @@ namespace nd {
 
   extern DYND_API struct DYND_API byteswap : declfunc<byteswap> {
     static callable make();
+    static callable &get();
   } byteswap;
 
   extern DYND_API struct DYND_API pairwise_byteswap : declfunc<pairwise_byteswap> {
     static callable make();
+    static callable &get();
   } pairwise_byteswap;
 
 } // namespace dynd::nd

--- a/include/dynd/kernels/parse_kernel.hpp
+++ b/include/dynd/kernels/parse_kernel.hpp
@@ -5,8 +5,9 @@
 
 #pragma once
 
-#include <dynd/option.hpp>
 #include <dynd/kernels/base_kernel.hpp>
+#include <dynd/option.hpp>
+#include <dynd/parse.hpp>
 
 namespace dynd {
 namespace nd {

--- a/include/dynd/logic.hpp
+++ b/include/dynd/logic.hpp
@@ -12,6 +12,7 @@ namespace nd {
 
   extern DYND_API struct DYND_API all : declfunc<all> {
     static callable make();
+    static callable &get();
   } all;
 
 } // namespace dynd::nd

--- a/include/dynd/option.hpp
+++ b/include/dynd/option.hpp
@@ -12,10 +12,12 @@ namespace nd {
 
   extern DYND_API struct DYND_API assign_na : declfunc<assign_na> {
     static callable make();
+    static callable &get();
   } assign_na;
 
   extern DYND_API struct DYND_API is_na : declfunc<is_na> {
     static callable make();
+    static callable &get();
   } is_na;
 
 } // namespace dynd::nd

--- a/include/dynd/parse.hpp
+++ b/include/dynd/parse.hpp
@@ -5,14 +5,14 @@
 
 #pragma once
 
-#include <string>
 #include <stdexcept>
+#include <string>
 
+#include <dynd/callable.hpp>
 #include <dynd/config.hpp>
+#include <dynd/string_encodings.hpp>
 #include <dynd/type.hpp>
 #include <dynd/types/string_type.hpp>
-#include <dynd/string_encodings.hpp>
-#include <dynd/callable.hpp>
 
 #define DYND_BOOL_NA (2)
 #define DYND_INT8_NA (std::numeric_limits<int8_t>::min())
@@ -324,7 +324,7 @@ inline bool skip_required_whitespace(const char *&rbegin, const char *end)
  *     }
  */
 template <int N>
-inline bool parse_token(const char *&rbegin, const char *end, const char(&token)[N])
+inline bool parse_token(const char *&rbegin, const char *end, const char (&token)[N])
 {
   const char *begin = rbegin;
   skip_whitespace(begin, end);
@@ -363,7 +363,7 @@ inline bool parse_token(const char *&rbegin, const char *end, char token)
 }
 
 template <int N>
-inline bool parse_token(char *const *src, const char(&token)[N])
+inline bool parse_token(char *const *src, const char (&token)[N])
 {
   return parse_token(*reinterpret_cast<const char **>(src[0]), *reinterpret_cast<const char **>(src[1]), token);
 }
@@ -383,7 +383,7 @@ inline bool parse_token(char *const *src, const char(&token)[N])
  *     }
  */
 template <int N>
-inline bool parse_token_no_ws(const char *&rbegin, const char *end, const char(&token)[N])
+inline bool parse_token_no_ws(const char *&rbegin, const char *end, const char (&token)[N])
 {
   const char *begin = rbegin;
   if (N - 1 <= end - begin && memcmp(begin, token, N - 1) == 0) {
@@ -507,7 +507,7 @@ namespace nd {
  * Does an exact comparison of a byte range to a string literal.
  */
 template <int N>
-inline bool compare_range_to_literal(const char *begin, const char *end, const char(&token)[N])
+inline bool compare_range_to_literal(const char *begin, const char *end, const char (&token)[N])
 {
   return (end - begin) == N - 1 && !memcmp(begin, token, N - 1);
 }
@@ -1139,7 +1139,7 @@ struct DYND_API named_value {
  *     }
  */
 template <int N>
-inline bool parse_ci_alpha_str_named_value_no_ws(const char *&rbegin, const char *end, named_value(&nvt)[N],
+inline bool parse_ci_alpha_str_named_value_no_ws(const char *&rbegin, const char *end, named_value (&nvt)[N],
                                                  int &out_value)
 {
   using namespace std;
@@ -1475,6 +1475,7 @@ namespace nd {
       }
 
       static callable make();
+      static callable &get();
     } parse;
 
   } // namespace dynd::nd::json

--- a/include/dynd/search.hpp
+++ b/include/dynd/search.hpp
@@ -18,6 +18,7 @@ namespace nd {
    */
   extern DYND_API struct DYND_API binary_search : declfunc<binary_search> {
     static callable make();
+    static callable &get();
   } binary_search;
 
 } // namespace dynd::nd

--- a/include/dynd/sort.hpp
+++ b/include/dynd/sort.hpp
@@ -12,10 +12,12 @@ namespace nd {
 
   extern DYND_API struct DYND_API sort : declfunc<sort> {
     static callable make();
+    static callable &get();
   } sort;
 
   extern DYND_API struct DYND_API unique : declfunc<unique> {
     static callable make();
+    static callable &get();
   } unique;
 
 } // namespace dynd::nd

--- a/include/dynd/string.hpp
+++ b/include/dynd/string.hpp
@@ -112,22 +112,27 @@ namespace nd {
 
   extern DYND_API struct DYND_API string_concatenation : declfunc<string_concatenation> {
     static callable make();
+    static callable &get();
   } string_concatenation;
 
   extern DYND_API struct DYND_API string_count : declfunc<string_count> {
     static callable make();
+    static callable &get();
   } string_count;
 
   extern DYND_API struct DYND_API string_find : declfunc<string_find> {
     static callable make();
+    static callable &get();
   } string_find;
 
   extern DYND_API struct DYND_API string_replace : declfunc<string_replace> {
     static callable make();
+    static callable &get();
   } string_replace;
 
   extern DYND_API struct DYND_API string_split : declfunc<string_split> {
     static callable make();
+    static callable &get();
   } string_split;
 
 } // namespace dynd::nd

--- a/include/dynd/struct.hpp
+++ b/include/dynd/struct.hpp
@@ -12,6 +12,7 @@ namespace nd {
 
   extern DYND_API struct DYND_API field_access : declfunc<field_access> {
     static callable make();
+    static callable &get();
   } field_access;
 
   extern DYND_API nd::callable make_field_access_kernel(const ndt::type &dt, const std::string &name);

--- a/src/dynd/func/arithmetic.cpp
+++ b/src/dynd/func/arithmetic.cpp
@@ -9,6 +9,7 @@ using namespace std;
 using namespace dynd;
 
 #define DYND_DEF_UNARY_OP_AND_CALLABLE(OP, NAME)                                                                       \
+  DYND_DEFAULT_DECLFUNC_GET(nd::NAME)                                                                                  \
   DYND_API struct nd::NAME nd::NAME;                                                                                   \
   nd::array nd::operator OP(const array &a0) { return nd::NAME(a0); }
 
@@ -20,6 +21,7 @@ DYND_DEF_UNARY_OP_AND_CALLABLE(~, bitwise_not)
 #undef DYND_DEF_UNARY_OP_AND_CALLABLE
 
 #define DYND_DEF_BINARY_OP_WITH_CALLABLE(OP, NAME)                                                                     \
+  DYND_DEFAULT_DECLFUNC_GET(nd::NAME)                                                                                  \
   DYND_API struct nd::NAME nd::NAME;                                                                                   \
   nd::array nd::operator OP(const array &a0, const array &a1) { return nd::NAME(a0, a1); }
 
@@ -33,6 +35,7 @@ DYND_DEF_BINARY_OP_WITH_CALLABLE(||, logical_or)
 #undef DYND_DEF_BINARY_OP_WITH_CALLABLE
 
 #define DYND_DEF_COMPOUND_OP_WITH_CALLABLE(OP, NAME)                                                                   \
+  DYND_DEFAULT_DECLFUNC_GET(nd::NAME)                                                                                  \
   DYND_API struct nd::NAME nd::NAME;                                                                                   \
   nd::array &nd::array::operator OP(const array &rhs)                                                                  \
   {                                                                                                                    \

--- a/src/dynd/func/assignment.cpp
+++ b/src/dynd/func/assignment.cpp
@@ -121,11 +121,7 @@ DYND_API nd::callable nd::assign::make()
   });
 }
 
-DYND_API nd::callable &nd::assign::get()
-{
-  static nd::callable self = nd::assign::make();
-  return self;
-}
+DYND_DEFAULT_DECLFUNC_GET(nd::assign)
 
 DYND_API struct nd::assign nd::assign;
 

--- a/src/dynd/func/comparison.cpp
+++ b/src/dynd/func/comparison.cpp
@@ -8,25 +8,37 @@
 using namespace std;
 using namespace dynd;
 
+DYND_DEFAULT_DECLFUNC_GET(nd::less)
+
 DYND_API struct nd::less nd::less;
 
 nd::array nd::operator<(const array &a0, const array &a1) { return less(a0, a1); }
+
+DYND_DEFAULT_DECLFUNC_GET(nd::less_equal)
 
 DYND_API struct nd::less_equal nd::less_equal;
 
 nd::array nd::operator<=(const array &a0, const array &a1) { return less_equal(a0, a1); }
 
+DYND_DEFAULT_DECLFUNC_GET(nd::equal)
+
 DYND_API struct nd::equal nd::equal;
 
 nd::array nd::operator==(const array &a0, const array &a1) { return equal(a0, a1); }
+
+DYND_DEFAULT_DECLFUNC_GET(nd::not_equal)
 
 DYND_API struct nd::not_equal nd::not_equal;
 
 nd::array nd::operator!=(const array &a0, const array &a1) { return not_equal(a0, a1); }
 
+DYND_DEFAULT_DECLFUNC_GET(nd::greater_equal)
+
 DYND_API struct nd::greater_equal nd::greater_equal;
 
 nd::array nd::operator>=(const array &a0, const array &a1) { return greater_equal(a0, a1); }
+
+DYND_DEFAULT_DECLFUNC_GET(nd::greater)
 
 DYND_API struct nd::greater nd::greater;
 
@@ -52,5 +64,7 @@ nd::callable nd::total_order::make()
                                 return child;
                               });
 }
+
+DYND_DEFAULT_DECLFUNC_GET(nd::total_order)
 
 DYND_API struct nd::total_order nd::total_order;

--- a/src/dynd/func/complex.cpp
+++ b/src/dynd/func/complex.cpp
@@ -5,9 +5,9 @@
 
 #include <dynd/func/complex.hpp>
 #include <dynd/functional.hpp>
-#include <dynd/kernels/real_kernel.hpp>
-#include <dynd/kernels/imag_kernel.hpp>
 #include <dynd/kernels/conj_kernel.hpp>
+#include <dynd/kernels/imag_kernel.hpp>
+#include <dynd/kernels/real_kernel.hpp>
 
 using namespace std;
 using namespace dynd;
@@ -19,9 +19,11 @@ DYND_API nd::callable nd::real::make()
 
   return functional::elwise(functional::dispatch(
       ndt::type("(Scalar) -> Scalar"),
-      [children](const ndt::type &DYND_UNUSED(dst_tp), intptr_t DYND_UNUSED(nsrc), const ndt::type *src_tp) mutable
-      -> callable &{ return children[src_tp[0].get_id()]; }));
+      [children](const ndt::type &DYND_UNUSED(dst_tp), intptr_t DYND_UNUSED(nsrc),
+                 const ndt::type *src_tp) mutable -> callable & { return children[src_tp[0].get_id()]; }));
 }
+
+DYND_DEFAULT_DECLFUNC_GET(nd::real)
 
 DYND_API struct nd::real nd::real;
 
@@ -32,9 +34,11 @@ DYND_API nd::callable nd::imag::make()
 
   return functional::elwise(functional::dispatch(
       ndt::type("(Scalar) -> Scalar"),
-      [children](const ndt::type &DYND_UNUSED(dst_tp), intptr_t DYND_UNUSED(nsrc), const ndt::type *src_tp) mutable
-      -> callable &{ return children[src_tp[0].get_id()]; }));
+      [children](const ndt::type &DYND_UNUSED(dst_tp), intptr_t DYND_UNUSED(nsrc),
+                 const ndt::type *src_tp) mutable -> callable & { return children[src_tp[0].get_id()]; }));
 }
+
+DYND_DEFAULT_DECLFUNC_GET(nd::imag)
 
 DYND_API struct nd::imag nd::imag;
 
@@ -45,8 +49,10 @@ DYND_API nd::callable nd::conj::make()
 
   return functional::elwise(functional::dispatch(
       ndt::type("(Scalar) -> Scalar"),
-      [children](const ndt::type &DYND_UNUSED(dst_tp), intptr_t DYND_UNUSED(nsrc), const ndt::type *src_tp) mutable
-      -> callable &{ return children[src_tp[0].get_id()]; }));
+      [children](const ndt::type &DYND_UNUSED(dst_tp), intptr_t DYND_UNUSED(nsrc),
+                 const ndt::type *src_tp) mutable -> callable & { return children[src_tp[0].get_id()]; }));
 }
+
+DYND_DEFAULT_DECLFUNC_GET(nd::conj)
 
 DYND_API struct nd::conj nd::conj;

--- a/src/dynd/func/copy.cpp
+++ b/src/dynd/func/copy.cpp
@@ -9,9 +9,8 @@
 using namespace std;
 using namespace dynd;
 
-DYND_API nd::callable nd::copy::make()
-{
-  return callable::make<copy_ck>(ndt::type("(A... * S) -> B... * T"), 0);
-}
+DYND_API nd::callable nd::copy::make() { return callable::make<copy_ck>(ndt::type("(A... * S) -> B... * T"), 0); }
+
+DYND_DEFAULT_DECLFUNC_GET(nd::copy)
 
 DYND_API struct nd::copy nd::copy;

--- a/src/dynd/func/fft.cpp
+++ b/src/dynd/func/fft.cpp
@@ -4,8 +4,8 @@
 //
 
 #include <dynd/func/fft.hpp>
-#include <dynd/functional.hpp>
 #include <dynd/func/take.hpp>
+#include <dynd/functional.hpp>
 
 using namespace std;
 using namespace dynd;
@@ -20,8 +20,7 @@ DYND_API nd::callable nd::fft::make()
 #endif
 
 #ifdef DYND_CUDA
-  children.push_back(nd::callable::make<
-      cufft_ck<cufftDoubleComplex, cufftDoubleComplex, CUFFT_FORWARD>>(0));
+  children.push_back(nd::callable::make<cufft_ck<cufftDoubleComplex, cufftDoubleComplex, CUFFT_FORWARD>>(0));
 #endif
 
   if (children.empty()) {
@@ -29,13 +28,13 @@ DYND_API nd::callable nd::fft::make()
   }
 
   return children[0];
-/*
-  return functional::multidispatch(
-      ndt::type("(M[Fixed**N * complex[float64]], shape: ?N * int64, axes: "
-                "?Fixed * int64, "
-                "flags: ?int32) -> M[Fixed**N * complex[float64]]"),
-      children, {"N"});
-*/
+  /*
+    return functional::multidispatch(
+        ndt::type("(M[Fixed**N * complex[float64]], shape: ?N * int64, axes: "
+                  "?Fixed * int64, "
+                  "flags: ?int32) -> M[Fixed**N * complex[float64]]"),
+        children, {"N"});
+  */
 }
 
 DYND_API nd::callable nd::ifft::make()
@@ -43,13 +42,11 @@ DYND_API nd::callable nd::ifft::make()
   std::vector<nd::callable> children;
 
 #ifdef DYND_FFTW
-  children.push_back(
-      nd::callable::make<fftw_ck<fftw_complex, fftw_complex, FFTW_BACKWARD>>());
+  children.push_back(nd::callable::make<fftw_ck<fftw_complex, fftw_complex, FFTW_BACKWARD>>());
 #endif
 
 #ifdef DYND_CUDA
-  children.push_back(nd::callable::make<
-      cufft_ck<cufftDoubleComplex, cufftDoubleComplex, CUFFT_INVERSE>>());
+  children.push_back(nd::callable::make<cufft_ck<cufftDoubleComplex, cufftDoubleComplex, CUFFT_INVERSE>>());
 #endif
 
   if (children.empty()) {
@@ -57,13 +54,13 @@ DYND_API nd::callable nd::ifft::make()
   }
 
   return children[0];
-/*
-  return functional::multidispatch(
-      ndt::type("(M[Fixed**N * complex[float64]], shape: ?N * int64, "
-                "axes: ?Fixed * int64, "
-                "flags: ?int32) -> M[Fixed**N * complex[float64]]"),
-      children, {"N"});
-*/
+  /*
+    return functional::multidispatch(
+        ndt::type("(M[Fixed**N * complex[float64]], shape: ?N * int64, "
+                  "axes: ?Fixed * int64, "
+                  "flags: ?int32) -> M[Fixed**N * complex[float64]]"),
+        children, {"N"});
+  */
 }
 
 DYND_API nd::callable nd::rfft::make()
@@ -84,9 +81,13 @@ DYND_API nd::callable nd::irfft::make()
 #endif
 }
 
+DYND_DEFAULT_DECLFUNC_GET(nd::fft)
+DYND_DEFAULT_DECLFUNC_GET(nd::rfft)
+DYND_DEFAULT_DECLFUNC_GET(nd::ifft)
+DYND_DEFAULT_DECLFUNC_GET(nd::irfft)
+
 DYND_API struct nd::fft nd::fft;
 DYND_API struct nd::rfft nd::rfft;
-
 DYND_API struct nd::ifft nd::ifft;
 DYND_API struct nd::irfft nd::irfft;
 
@@ -117,7 +118,5 @@ nd::array nd::ifftshift(const nd::array &x)
 nd::array nd::fftspace(intptr_t count, double step)
 {
   // Todo: When casting is fixed, change the ranges below to integer versions
-  return nd::concatenate(nd::range((count - 1) / 2 + 1.0),
-                         nd::range(-count / 2 + 0.0, 0.0)) /
-         (count * step);
+  return nd::concatenate(nd::range((count - 1) / 2 + 1.0), nd::range(-count / 2 + 0.0, 0.0)) / (count * step);
 }

--- a/src/dynd/func/math.cpp
+++ b/src/dynd/func/math.cpp
@@ -4,8 +4,8 @@
 //
 
 #include <dynd/callable.hpp>
-#include <dynd/functional.hpp>
 #include <dynd/func/math.hpp>
+#include <dynd/functional.hpp>
 
 using namespace std;
 using namespace dynd;
@@ -59,8 +59,7 @@ DYND_API nd::callable nd::cos::make()
   #endif
   */
 
-  return functional::elwise(
-      functional::multidispatch(pattern_tp, children.begin(), children.end()));
+  return functional::elwise(functional::multidispatch(pattern_tp, children.begin(), children.end()));
 }
 
 DYND_API nd::callable nd::sin::make()
@@ -86,8 +85,7 @@ DYND_API nd::callable nd::sin::make()
   #endif
   */
 
-  return functional::elwise(
-      functional::multidispatch(pattern_tp, children.begin(), children.end()));
+  return functional::elwise(functional::multidispatch(pattern_tp, children.begin(), children.end()));
 }
 
 DYND_API nd::callable nd::tan::make()
@@ -113,8 +111,7 @@ DYND_API nd::callable nd::tan::make()
   #endif
   */
 
-  return functional::elwise(
-      functional::multidispatch(pattern_tp, children.begin(), children.end()));
+  return functional::elwise(functional::multidispatch(pattern_tp, children.begin(), children.end()));
 }
 
 DYND_API nd::callable nd::exp::make()
@@ -140,9 +137,13 @@ DYND_API nd::callable nd::exp::make()
   #endif
   */
 
-  return functional::elwise(
-      functional::multidispatch(pattern_tp, children.begin(), children.end()));
+  return functional::elwise(functional::multidispatch(pattern_tp, children.begin(), children.end()));
 }
+
+DYND_DEFAULT_DECLFUNC_GET(nd::cos)
+DYND_DEFAULT_DECLFUNC_GET(nd::sin)
+DYND_DEFAULT_DECLFUNC_GET(nd::tan)
+DYND_DEFAULT_DECLFUNC_GET(nd::exp)
 
 DYND_API struct nd::cos nd::cos;
 DYND_API struct nd::sin nd::sin;

--- a/src/dynd/func/max.cpp
+++ b/src/dynd/func/max.cpp
@@ -3,10 +3,10 @@
 // BSD 2-Clause License, see LICENSE.txt
 //
 
-#include <dynd/kernels/max_kernel.hpp>
-#include <dynd/functional.hpp>
-#include <dynd/func/reduction.hpp>
 #include <dynd/func/max.hpp>
+#include <dynd/func/reduction.hpp>
+#include <dynd/functional.hpp>
+#include <dynd/kernels/max_kernel.hpp>
 #include <dynd/types/scalar_kind_type.hpp>
 
 using namespace std;
@@ -18,15 +18,17 @@ DYND_API nd::callable nd::max::make()
 
   return functional::reduction(
       functional::dispatch(ndt::callable_type::make(ndt::scalar_kind_type::make(), ndt::scalar_kind_type::make()),
-                                [children](const ndt::type &DYND_UNUSED(dst_tp), intptr_t DYND_UNUSED(nsrc),
-                                           const ndt::type *src_tp) mutable -> callable & {
-                                  callable &child = children[src_tp[0].get_id()];
-                                  if (child.is_null()) {
-                                    throw runtime_error("no suitable child found for nd::sum");
-                                  }
+                           [children](const ndt::type &DYND_UNUSED(dst_tp), intptr_t DYND_UNUSED(nsrc),
+                                      const ndt::type *src_tp) mutable -> callable & {
+                             callable &child = children[src_tp[0].get_id()];
+                             if (child.is_null()) {
+                               throw runtime_error("no suitable child found for nd::sum");
+                             }
 
-                                  return child;
-                                }));
+                             return child;
+                           }));
 }
+
+DYND_DEFAULT_DECLFUNC_GET(nd::max)
 
 DYND_API struct nd::max nd::max;

--- a/src/dynd/func/mean.cpp
+++ b/src/dynd/func/mean.cpp
@@ -3,17 +3,19 @@
 // BSD 2-Clause License, see LICENSE.txt
 //
 
-#include <dynd/func/mean.hpp>
 #include <dynd/array.hpp>
-#include <dynd/types/fixed_dim_kind_type.hpp>
+#include <dynd/func/mean.hpp>
 #include <dynd/func/reduction.hpp>
 #include <dynd/kernels/base_kernel.hpp>
-#include <dynd/kernels/sum_kernel.hpp>
 #include <dynd/kernels/mean_kernel.hpp>
+#include <dynd/kernels/sum_kernel.hpp>
+#include <dynd/types/fixed_dim_kind_type.hpp>
 
 using namespace std;
 using namespace dynd;
 
 DYND_API nd::callable nd::mean::make() { return callable::make<mean_kernel>(ndt::type(int64_id)); }
+
+DYND_DEFAULT_DECLFUNC_GET(nd::mean)
 
 DYND_API struct nd::mean nd::mean;

--- a/src/dynd/func/min.cpp
+++ b/src/dynd/func/min.cpp
@@ -3,10 +3,10 @@
 // BSD 2-Clause License, see LICENSE.txt
 //
 
-#include <dynd/kernels/min_kernel.hpp>
-#include <dynd/functional.hpp>
-#include <dynd/func/reduction.hpp>
 #include <dynd/func/min.hpp>
+#include <dynd/func/reduction.hpp>
+#include <dynd/functional.hpp>
+#include <dynd/kernels/min_kernel.hpp>
 #include <dynd/types/scalar_kind_type.hpp>
 
 using namespace std;
@@ -28,5 +28,7 @@ DYND_API nd::callable nd::min::make()
                              return child;
                            }));
 }
+
+DYND_DEFAULT_DECLFUNC_GET(nd::min)
 
 DYND_API struct nd::min nd::min;

--- a/src/dynd/func/pointer.cpp
+++ b/src/dynd/func/pointer.cpp
@@ -15,6 +15,6 @@ DYND_API nd::callable nd::dereference::make()
   return nd::callable::make<dereference_kernel>(ndt::type("(self: Any) -> Any"));
 }
 
+DYND_DEFAULT_DECLFUNC_GET(nd::dereference)
+
 DYND_API struct nd::dereference nd::dereference;
-
-

--- a/src/dynd/func/random.cpp
+++ b/src/dynd/func/random.cpp
@@ -15,8 +15,9 @@ struct uniform_kernel_alias {
 
 DYND_API nd::callable nd::random::uniform::make()
 {
-  typedef type_id_sequence<int32_id, int64_id, uint32_id, uint64_id, float32_id,
-                           float64_id, complex_float32_id, complex_float64_id> numeric_ids;
+  typedef type_id_sequence<int32_id, int64_id, uint32_id, uint64_id, float32_id, float64_id, complex_float32_id,
+                           complex_float64_id>
+      numeric_ids;
 
   std::random_device random_device;
 
@@ -31,6 +32,8 @@ DYND_API nd::callable nd::random::uniform::make()
         return child;
       }));
 }
+
+DYND_DEFAULT_DECLFUNC_GET(nd::random::uniform)
 
 DYND_API struct nd::random::uniform nd::random::uniform;
 

--- a/src/dynd/func/sum.cpp
+++ b/src/dynd/func/sum.cpp
@@ -3,10 +3,10 @@
 // BSD 2-Clause License, see LICENSE.txt
 //
 
-#include <dynd/kernels/sum_kernel.hpp>
-#include <dynd/functional.hpp>
 #include <dynd/func/reduction.hpp>
 #include <dynd/func/sum.hpp>
+#include <dynd/functional.hpp>
+#include <dynd/kernels/sum_kernel.hpp>
 #include <dynd/types/scalar_kind_type.hpp>
 
 using namespace std;
@@ -14,9 +14,9 @@ using namespace dynd;
 
 DYND_API nd::callable nd::sum::make()
 {
-  typedef type_id_sequence<int8_id, int16_id, int32_id, int64_id, uint8_id, uint16_id,
-                           uint32_id, uint64_id, float16_id, float32_id, float64_id,
-                           complex_float32_id, complex_float64_id> arithmetic_ids;
+  typedef type_id_sequence<int8_id, int16_id, int32_id, int64_id, uint8_id, uint16_id, uint32_id, uint64_id, float16_id,
+                           float32_id, float64_id, complex_float32_id, complex_float64_id>
+      arithmetic_ids;
 
   auto children = callable::make_all<sum_kernel, arithmetic_ids>();
   return functional::reduction(
@@ -31,5 +31,7 @@ DYND_API nd::callable nd::sum::make()
                              return child;
                            }));
 }
+
+DYND_DEFAULT_DECLFUNC_GET(nd::sum)
 
 DYND_API struct nd::sum nd::sum;

--- a/src/dynd/func/take.cpp
+++ b/src/dynd/func/take.cpp
@@ -17,4 +17,6 @@ DYND_API nd::callable nd::take::make()
   return callable::make<take_ck>(ndt::type("(Dims... * T, N * Ix) -> R * T"), 0);
 }
 
+DYND_DEFAULT_DECLFUNC_GET(nd::take)
+
 DYND_API struct nd::take nd::take;

--- a/src/dynd/func/take_by_pointer.cpp
+++ b/src/dynd/func/take_by_pointer.cpp
@@ -127,4 +127,6 @@ DYND_API nd::callable nd::take_by_pointer::make()
       ndt::callable_type::make(ndt::type("R * pointer[T]"), {ndt::type("M * T"), ndt::type("N * Ix")}), 0);
 }
 
+DYND_DEFAULT_DECLFUNC_GET(nd::take_by_pointer)
+
 DYND_API struct nd::take_by_pointer nd::take_by_pointer;

--- a/src/dynd/func/view.cpp
+++ b/src/dynd/func/view.cpp
@@ -9,9 +9,8 @@
 using namespace std;
 using namespace dynd;
 
-DYND_API nd::callable nd::view::make()
-{
-  return callable::make<view_kernel>(ndt::type("(Any) -> Any"));
-}
+DYND_API nd::callable nd::view::make() { return callable::make<view_kernel>(ndt::type("(Any) -> Any")); }
+
+DYND_DEFAULT_DECLFUNC_GET(nd::view)
 
 DYND_API struct nd::view nd::view;

--- a/src/dynd/index.cpp
+++ b/src/dynd/index.cpp
@@ -21,4 +21,6 @@ DYND_API nd::callable nd::index::make()
                  const ndt::type *src_tp) mutable -> callable & { return children[src_tp[0].get_id()]; });
 }
 
+DYND_DEFAULT_DECLFUNC_GET(nd::index)
+
 DYND_API struct nd::index nd::index;

--- a/src/dynd/io.cpp
+++ b/src/dynd/io.cpp
@@ -15,4 +15,6 @@ DYND_API nd::callable nd::serialize::make()
   return functional::reduction(callable::make<serialize_kernel<scalar_kind_id>>());
 }
 
+DYND_DEFAULT_DECLFUNC_GET(nd::serialize)
+
 DYND_API struct nd::serialize nd::serialize;

--- a/src/dynd/kernels/byteswap_kernels.cpp
+++ b/src/dynd/kernels/byteswap_kernels.cpp
@@ -10,8 +10,12 @@ using namespace dynd;
 
 nd::callable nd::byteswap::make() { return callable::make<byteswap_ck>(ndt::type("(Any) -> Any")); }
 
+DYND_DEFAULT_DECLFUNC_GET(nd::byteswap)
+
 struct nd::byteswap nd::byteswap;
 
 nd::callable nd::pairwise_byteswap::make() { return callable::make<pairwise_byteswap_ck>(ndt::type("(Any) -> Any")); }
+
+DYND_DEFAULT_DECLFUNC_GET(nd::pairwise_byteswap)
 
 struct nd::pairwise_byteswap nd::pairwise_byteswap;

--- a/src/dynd/logic.cpp
+++ b/src/dynd/logic.cpp
@@ -4,12 +4,14 @@
 //
 
 #include <dynd/func/reduction.hpp>
-#include <dynd/logic.hpp>
 #include <dynd/kernels/all_kernel.hpp>
+#include <dynd/logic.hpp>
 
 using namespace std;
 using namespace dynd;
 
 DYND_API nd::callable nd::all::make() { return functional::reduction(callable::make<all_kernel>()); }
+
+DYND_DEFAULT_DECLFUNC_GET(nd::all)
 
 DYND_API struct nd::all nd::all;

--- a/src/dynd/option.cpp
+++ b/src/dynd/option.cpp
@@ -4,9 +4,9 @@
 //
 
 #include <dynd/functional.hpp>
-#include <dynd/option.hpp>
 #include <dynd/kernels/assign_na_kernel.hpp>
 #include <dynd/kernels/is_na_kernel.hpp>
+#include <dynd/option.hpp>
 
 using namespace std;
 using namespace dynd;
@@ -14,7 +14,8 @@ using namespace dynd;
 DYND_API nd::callable nd::assign_na::make()
 {
   typedef type_id_sequence<bool_id, int8_id, int16_id, int32_id, int64_id, int128_id, float32_id, float64_id,
-                           complex_float32_id, complex_float64_id, void_id, bytes_id, string_id, fixed_dim_id> type_ids;
+                           complex_float32_id, complex_float64_id, void_id, bytes_id, string_id, fixed_dim_id>
+      type_ids;
 
   std::map<type_id_t, callable> children = callable::make_all<assign_na_kernel, type_ids>();
   children[uint32_id] = callable::make<assign_na_kernel<uint32_id>>();
@@ -44,12 +45,15 @@ DYND_API nd::callable nd::assign_na::make()
   });
 }
 
+DYND_DEFAULT_DECLFUNC_GET(nd::assign_na)
+
 DYND_API struct nd::assign_na nd::assign_na;
 
 DYND_API nd::callable nd::is_na::make()
 {
   typedef type_id_sequence<bool_id, int8_id, int16_id, int32_id, int64_id, int128_id, uint32_id, float32_id, float64_id,
-                           complex_float32_id, complex_float64_id, void_id, bytes_id, string_id, fixed_dim_id> type_ids;
+                           complex_float32_id, complex_float64_id, void_id, bytes_id, string_id, fixed_dim_id>
+      type_ids;
 
   std::map<type_id_t, callable> children = callable::make_all<is_na_kernel, type_ids>();
   std::array<callable, 2> dim_children;
@@ -76,5 +80,7 @@ DYND_API nd::callable nd::is_na::make()
                                 return *child;
                               });
 }
+
+DYND_DEFAULT_DECLFUNC_GET(nd::is_na)
 
 DYND_API struct nd::is_na nd::is_na;

--- a/src/dynd/parse.cpp
+++ b/src/dynd/parse.cpp
@@ -3,13 +3,13 @@
 // BSD 2-Clause License, see LICENSE.txt
 //
 
-#include <string>
 #include <climits>
+#include <string>
 
 #include <dynd/functional.hpp>
+#include <dynd/kernels/parse_kernel.hpp>
 #include <dynd/parse.hpp>
 #include <dynd/string_encodings.hpp>
-#include <dynd/kernels/parse_kernel.hpp>
 #include <dynd/types/any_kind_type.hpp>
 #include <dynd/types/option_type.hpp>
 
@@ -441,6 +441,8 @@ bool json::parse_bool(const char *&begin, const char *&end)
   throw std::invalid_argument(ss.str());
 }
 
+DYND_DEFAULT_DECLFUNC_GET(nd::json::parse)
+
 DYND_API struct nd::json::parse nd::json::parse;
 
 DYND_API nd::callable nd::json::parse::make()
@@ -463,6 +465,6 @@ DYND_API nd::callable nd::json::parse::make()
 
   return functional::dispatch(
       ndt::callable_type::make(ndt::make_type<ndt::any_kind_type>(), {ndt::make_type<string>()}),
-      [children](const ndt::type &dst_tp, intptr_t DYND_UNUSED(nsrc), const ndt::type *DYND_UNUSED(src_tp)) mutable
-      -> callable & { return children[dst_tp.get_id()]; });
+      [children](const ndt::type &dst_tp, intptr_t DYND_UNUSED(nsrc),
+                 const ndt::type *DYND_UNUSED(src_tp)) mutable -> callable & { return children[dst_tp.get_id()]; });
 }

--- a/src/dynd/search.cpp
+++ b/src/dynd/search.cpp
@@ -3,16 +3,15 @@
 // BSD 2-Clause License, see LICENSE.txt
 //
 
-#include <dynd/search.hpp>
 #include <dynd/kernels/binary_search_kernel.hpp>
+#include <dynd/search.hpp>
 #include <dynd/types/fixed_dim_type.hpp>
 
 using namespace std;
 using namespace dynd;
 
-DYND_API nd::callable nd::binary_search::make()
-{
-  return callable::make<binary_search_kernel>();
-}
+DYND_API nd::callable nd::binary_search::make() { return callable::make<binary_search_kernel>(); }
+
+DYND_DEFAULT_DECLFUNC_GET(nd::binary_search)
 
 DYND_API struct nd::binary_search nd::binary_search;

--- a/src/dynd/sort.cpp
+++ b/src/dynd/sort.cpp
@@ -3,23 +3,21 @@
 // BSD 2-Clause License, see LICENSE.txt
 //
 
-#include <dynd/sort.hpp>
 #include <dynd/kernels/sort_kernel.hpp>
 #include <dynd/kernels/unique_kernel.hpp>
+#include <dynd/sort.hpp>
 
 using namespace std;
 using namespace dynd;
 
-DYND_API nd::callable nd::sort::make()
-{
-  return callable::make<sort_kernel>();
-}
+DYND_API nd::callable nd::sort::make() { return callable::make<sort_kernel>(); }
+
+DYND_DEFAULT_DECLFUNC_GET(nd::sort)
 
 DYND_API struct nd::sort nd::sort;
 
-DYND_API nd::callable nd::unique::make()
-{
-  return callable::make<unique_kernel>();
-}
+DYND_API nd::callable nd::unique::make() { return callable::make<unique_kernel>(); }
+
+DYND_DEFAULT_DECLFUNC_GET(nd::unique)
 
 DYND_API struct nd::unique nd::unique;

--- a/src/dynd/string.cpp
+++ b/src/dynd/string.cpp
@@ -3,13 +3,13 @@
 // BSD 2-Clause License, see LICENSE.txt
 //
 
-#include <dynd/string.hpp>
+#include <dynd/func/elwise.hpp>
 #include <dynd/kernels/string_concat_kernel.hpp>
 #include <dynd/kernels/string_count_kernel.hpp>
 #include <dynd/kernels/string_find_kernel.hpp>
 #include <dynd/kernels/string_replace_kernel.hpp>
 #include <dynd/kernels/string_split_kernel.hpp>
-#include <dynd/func/elwise.hpp>
+#include <dynd/string.hpp>
 
 using namespace std;
 using namespace dynd;
@@ -25,21 +25,31 @@ namespace nd {
     return functional::elwise(callable::make<string_concatenation_kernel>());
   }
 
+  DYND_DEFAULT_DECLFUNC_GET(string_concatenation)
+
   DYND_API struct string_concatenation string_concatenation;
 
   DYND_API callable string_count::make() { return functional::elwise(callable::make<string_count_kernel>()); }
+
+  DYND_DEFAULT_DECLFUNC_GET(string_count)
 
   DYND_API struct string_count string_count;
 
   DYND_API callable string_find::make() { return functional::elwise(callable::make<string_find_kernel>()); }
 
+  DYND_DEFAULT_DECLFUNC_GET(string_find)
+
   DYND_API struct string_find string_find;
 
   DYND_API callable string_replace::make() { return functional::elwise(callable::make<string_replace_kernel>()); }
 
+  DYND_DEFAULT_DECLFUNC_GET(string_replace)
+
   DYND_API struct string_replace string_replace;
 
   DYND_API callable string_split::make() { return functional::elwise(callable::make<string_split_kernel>()); }
+
+  DYND_DEFAULT_DECLFUNC_GET(string_split)
 
   DYND_API struct string_split string_split;
 

--- a/src/dynd/struct.cpp
+++ b/src/dynd/struct.cpp
@@ -3,17 +3,19 @@
 // BSD 2-Clause License, see LICENSE.txt
 //
 
-#include <dynd/functional.hpp>
 #include <dynd/array.hpp>
-#include <dynd/struct.hpp>
 #include <dynd/callable.hpp>
+#include <dynd/functional.hpp>
 #include <dynd/kernels/field_access_kernel.hpp>
+#include <dynd/struct.hpp>
 #include <dynd/types/callable_type.hpp>
 
 using namespace std;
 using namespace dynd;
 
 DYND_API nd::callable nd::field_access::make() { return callable::make<field_access_kernel>(); }
+
+DYND_DEFAULT_DECLFUNC_GET(nd::field_access)
 
 DYND_API struct nd::field_access nd::field_access;
 


### PR DESCRIPTION
There's a little code bloat here since it expands an oft-used idiom, but this does make it so that the static data used to lazy initialize our callables is never duplicated in other shared objects.