### PR TITLE
Fix cmake "liblib" problem on Linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,15 +438,26 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 if (DYND_SHARED_LIB)
     # xcode doesn't like when all cpp files are contained in an OBJECT library
     add_library(libdyndt SHARED ${libdyndt_SRC})
+    set_target_properties(libdyndt
+        PROPERTIES
+        OUTPUT_NAME "dyndt"
+        PREFIX "${CMAKE_SHARED_LIBRARY_PREFIX}"
+        )
     add_library(libdynd SHARED ${libdynd_SRC})
-    add_dependencies(libdynd libdyndt)
     set_target_properties(libdynd
         PROPERTIES
         OUTPUT_NAME "dynd"
         PREFIX "${CMAKE_SHARED_LIBRARY_PREFIX}"
         )
+    add_dependencies(libdynd libdyndt)
 else()
     add_library(libdyndt STATIC ${libdyndt_SRC})
+    set_target_properties(libdyndt
+        PROPERTIES
+        OUTPUT_NAME "dyndt"
+        PREFIX "${CMAKE_STATIC_LIBRARY_PREFIX}"
+        )
+
     add_library(libdynd STATIC ${libdynd_SRC})
     set_target_properties(libdynd
         PROPERTIES


### PR DESCRIPTION

libdyndt.so is currently installed as liblibdyndt.so on Linux.