### PR TITLE
Compilation errors on MinGW

### DIFF
--- a/include/dynd/callables/base_dispatch_callable.hpp
+++ b/include/dynd/callables/base_dispatch_callable.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <dynd/callable.hpp>
 #include <dynd/callables/base_callable.hpp>
 
 namespace dynd {

--- a/include/dynd/dispatcher.hpp
+++ b/include/dynd/dispatcher.hpp
@@ -9,7 +9,7 @@
 
 // #include <sparsehash/dense_hash_map>
 
-#include <dynd/types/type_id.hpp>
+#include <dynd/type_registry.hpp>
 
 namespace dynd {
 
@@ -49,7 +49,7 @@ inline bool ambiguous(const std::vector<type_id_t> &lhs, const std::vector<type_
 }
 
 template <size_t N>
-bool supercedes(const type_id_t(&lhs)[N], const std::vector<type_id_t> &rhs)
+bool supercedes(const type_id_t (&lhs)[N], const std::vector<type_id_t> &rhs)
 {
   if (rhs.size() != N) {
     return false;
@@ -175,8 +175,7 @@ public:
   dispatcher(const dispatcher &other) : m_pairs(other.m_pairs), m_map(other.m_map) {}
 
   template <typename Iterator>
-  dispatcher(Iterator begin, Iterator end, const map_type &map = map_type())
-      : m_map(map)
+  dispatcher(Iterator begin, Iterator end, const map_type &map = map_type()) : m_map(map)
   {
     //    m_map.set_empty_key(uninitialized_id);
 

--- a/include/dynd/type_registry.hpp
+++ b/include/dynd/type_registry.hpp
@@ -30,7 +30,7 @@ struct id_info {
 
 namespace detail {
 
-  DYNDT_API std::vector<id_info> &infos();
+  extern DYNDT_API std::vector<id_info> &infos();
 
 } // namespace dynd::detail
 

--- a/include/dynd/types/type_id.hpp
+++ b/include/dynd/types/type_id.hpp
@@ -5,8 +5,8 @@
 
 #pragma once
 
-#include <iostream>
 #include <complex>
+#include <iostream>
 
 #include <dynd/config.hpp>
 
@@ -809,7 +809,5 @@ template <>
 struct property_type_id_of<std::string> {
   static const type_id_t value = string_id;
 };
-
-DYNDT_API bool is_base_id_of(type_id_t base_id, type_id_t id);
 
 } // namespace dynd

--- a/src/dynd/assignment.cpp
+++ b/src/dynd/assignment.cpp
@@ -4,12 +4,12 @@
 //
 
 #include <dynd/assignment.hpp>
+#include <dynd/callables/assign_callable.hpp>
 #include <dynd/callables/assign_dispatch_callable.hpp>
+#include <dynd/callables/copy_callable.hpp>
 #include <dynd/functional.hpp>
 #include <dynd/kernels/assignment_kernels.hpp>
 #include <dynd/types/any_kind_type.hpp>
-#include <dynd/callables/assign_callable.hpp>
-#include <dynd/callables/copy_callable.hpp>
 
 using namespace std;
 using namespace dynd;
@@ -25,8 +25,8 @@ struct DYND_API _bind {
 nd::callable make_assign()
 {
   typedef type_id_sequence<bool_id, int8_id, int16_id, int32_id, int64_id, int128_id, uint8_id, uint16_id, uint32_id,
-                           uint64_id, uint128_id, float32_id, float64_id, complex_float32_id,
-                           complex_float64_id> numeric_ids;
+                           uint64_id, uint128_id, float32_id, float64_id, complex_float32_id, complex_float64_id>
+      numeric_ids;
 
   ndt::type self_tp = ndt::callable_type::make(ndt::any_kind_type::make(), {ndt::any_kind_type::make()}, {"error_mode"},
                                                {ndt::make_type<ndt::option_type>(ndt::make_type<assign_error_mode>())});


### PR DESCRIPTION
This fixes everything other than the persistent "too many sections" error from too many template instantiations. I'm still looking into what the best way forward is there. Adding `-Wa,-mbig-obj` to the flags seems to be throwing my linker into an infinite loop (or making linking take forever), so it's not clear what the best fix is.