### PR TITLE
Initial clang-cl build configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ if(${MSVC} OR "${CMAKE_CXX_SIMULATED_ID}" STREQUAL "MSVC")
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
         # If this is the clang-cl compiler have it act like MSVC 2015 and not 2013.
         # Don't enable -WX here yet.
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -EHsc -bigobj -wd4503 -fms-compatibility-version=19.00.23506")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -EHsc -bigobj -wd4503")
     elseif(${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 19)
         message(FATAL_ERROR "Only MSVC 2015 (Version 19.0) and later are supported by LibDyND. Found version ${CMAKE_CXX_COMPILER_VERSION}.")
     else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,14 +82,18 @@ if(WIN32)
     set(DYND_BUILD_BENCHMARKS OFF)
 endif()
 
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+if(${MSVC} OR "${CMAKE_CXX_SIMULATED_ID}" STREQUAL "MSVC")
     # -WX: Treat warnings as errors
     # -bigobj: Allow lots of symbols (assignment_kernels.cpp and assignment_kernels.cu need this flag)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -WX -EHsc -bigobj -wd4503")
-
-    if (${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 19)
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+        # If this is the clang-cl compiler have it act like MSVC 2015 and not 2013.
+        # Don't enable -WX here yet.
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -EHsc -bigobj -wd4503 -fms-compatibility-version=19.00.23506")
+    elseif(${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 19)
         message(FATAL_ERROR "Only MSVC 2015 (Version 19.0) and later are supported by LibDyND. Found version ${CMAKE_CXX_COMPILER_VERSION}.")
-    endif ()
+    else()
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -WX -EHsc -bigobj -wd4503")
+    endif()
 else()
     if(WIN32)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -std=c++14 -fomit-frame-pointer -fstrict-aliasing -Wall -Wextra -Werror -Wno-missing-field-initializers")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,11 +82,17 @@ if(WIN32)
     set(DYND_BUILD_BENCHMARKS OFF)
 endif()
 
-if(${MSVC} OR "${CMAKE_CXX_SIMULATED_ID}" STREQUAL "MSVC")
+if (DEFINED CMAKE_CXX_SIMULATED_ID)
+    set(DYND_SIMULATED_COMPILER ${CMAKE_CXX_SIMULATED_ID})
+else()
+    set(DYND_SIMULATED_COMPILER ${CMAKE_CXX_COMPILER_ID})
+endif()
+
+if("${MSVC}" OR "${DYND_SIMULATED_COMPILER}" STREQUAL "MSVC")
     # -WX: Treat warnings as errors
     # -bigobj: Allow lots of symbols (assignment_kernels.cpp and assignment_kernels.cu need this flag)
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-        # If this is the clang-cl compiler have it act like MSVC 2015 and not 2013.
+        # If this is the clang-cl compiler.
         # Don't enable -WX here yet.
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -EHsc -bigobj -wd4503")
     elseif(${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 19)


### PR DESCRIPTION
This is some old code I was working on some time ago that I'd like to get into the repo before it bitrots too badly. It adds an initial configuration for building with clang-cl.
There are probably several more compiler bugs they'll need to fix on their end before this actually works, but this at least lets CMake configure everything correctly.
The magic CMake incantation that makes this work is `cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_C_FLAGS="-MP" -DCMAKE_CXX_FLAGS="-MP" -G "Visual Studio 14 2015 Win64" -TLLVM-vs2014 ..`. I then run `cmake --build . --config Release` in the MSVC x64 native tools command prompt.