### PR TITLE
Add deprecated versions of the old elwise and reduction headers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,6 +334,8 @@ set(libdynd_SRC
     include/dynd/diagnostics.hpp
     include/dynd/ensure_immutable_contig.hpp
     include/dynd/fft.hpp
+    include/dynd/func/elwise.hpp
+    include/dynd/func/reduction.hpp
     include/dynd/functional.hpp
     include/dynd/io.hpp
     include/dynd/iterator.hpp

--- a/include/dynd/func/elwise.hpp
+++ b/include/dynd/func/elwise.hpp
@@ -1,11 +1,11 @@
-#include <dynd/functional.hpp>
+#include <dynd/callable.hpp>
 
 namespace dynd {
 namespace nd {
   namespace functional {
-    [[deprecated(
-        "Using elwise from the header <dynd/func/elwise.hpp> is deprecated. Please stop using that header. Elwise "
-        "is now provided in <dynd/functional.hpp>.")]] DYND_API callable
+    [[deprecated("Using elwise from the header <dynd/func/elwise.hpp> is deprecated. Please stop using that header. "
+                 "dynd::nd::functional::elwise "
+                 "is now provided in <dynd/functional.hpp>.")]] DYND_API callable
     elwise(const callable &child);
   } // namespace dynd::nd::functional
 } // namespace dynd::nd

--- a/include/dynd/func/elwise.hpp
+++ b/include/dynd/func/elwise.hpp
@@ -1,0 +1,12 @@
+#include <dynd/functional.hpp>
+
+namespace dynd {
+namespace nd {
+  namespace functional {
+    [[deprecated(
+        "Using elwise from the header <dynd/func/elwise.hpp> is deprecated. Please stop using that header. Elwise "
+        "is now provided in <dynd/functional.hpp>.")]] DYND_API callable
+    elwise(const callable &child);
+  } // namespace dynd::nd::functional
+} // namespace dynd::nd
+} // namespace dynd

--- a/include/dynd/func/reduction.hpp
+++ b/include/dynd/func/reduction.hpp
@@ -1,0 +1,12 @@
+#include <dynd/functional.hpp>
+
+namespace dynd {
+namespace nd {
+  namespace functional {
+    [[deprecated("Using reduction from the header <dynd/func/reduction.hpp> is deprecated. Please stop using that "
+                 "header. Elwise "
+                 "is now provided in <dynd/functional.hpp>.")]] DYND_API callable
+    reduction(const callable &child);
+  } // namespace dynd::nd::functional
+} // namespace dynd::nd
+} // namespace dynd

--- a/include/dynd/func/reduction.hpp
+++ b/include/dynd/func/reduction.hpp
@@ -1,10 +1,10 @@
-#include <dynd/functional.hpp>
+#include <dynd/callable.hpp>
 
 namespace dynd {
 namespace nd {
   namespace functional {
     [[deprecated("Using reduction from the header <dynd/func/reduction.hpp> is deprecated. Please stop using that "
-                 "header. Elwise "
+                 "header. dynd::nd::functional::reduction "
                  "is now provided in <dynd/functional.hpp>.")]] DYND_API callable
     reduction(const callable &child);
   } // namespace dynd::nd::functional


### PR DESCRIPTION
Given that this is one of the better known parts of our API, I figured it would be good to do an actual deprecation cycle for the old `<dynd/func/elwise.hpp>` and `<dynd/func/reduction.hpp>` headers before removing them in favor of `<dynd/functional.hpp>`. This uses the C++14 deprecated syntax on the most commonly used versions of `dynd::nd::functional::elwise` and `dynd::nd::functional::reduction`. The deprecations are only picked up if the additional headers containing these forward declarations are included.