### PR TITLE
Braces

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,7 +2,7 @@ BasedOnStyle: LLVM
 Standard: Cpp11
 UseTab: Never
 IndentWidth: 2
-BreakBeforeBraces: Stroustrup
+BreakBeforeBraces: Attach
 Cpp11BracedListStyle: true
 NamespaceIndentation: Inner
 AlwaysBreakTemplateDeclarations: true

--- a/include/dynd/callables/conj_callable.hpp
+++ b/include/dynd/callables/conj_callable.hpp
@@ -7,6 +7,7 @@
 
 #include <dynd/callables/base_instantiable_callable.hpp>
 #include <dynd/kernels/conj_kernel.hpp>
+#include <dynd/types/callable_type.hpp>
 
 namespace dynd {
 namespace nd {

--- a/include/dynd/callables/index_callable.hpp
+++ b/include/dynd/callables/index_callable.hpp
@@ -6,7 +6,10 @@
 #pragma once
 
 #include <dynd/callables/base_instantiable_callable.hpp>
+#include <dynd/index.hpp>
 #include <dynd/kernels/index_kernel.hpp>
+#include <dynd/type.hpp>
+#include <dynd/types/fixed_dim_type.hpp>
 
 namespace dynd {
 namespace nd {

--- a/include/dynd/callables/outer_callable.hpp
+++ b/include/dynd/callables/outer_callable.hpp
@@ -7,6 +7,7 @@
 
 #include <dynd/arrmeta_holder.hpp>
 #include <dynd/callables/base_callable.hpp>
+#include <dynd/functional.hpp>
 
 namespace dynd {
 namespace nd {

--- a/include/dynd/callables/serialize_callable.hpp
+++ b/include/dynd/callables/serialize_callable.hpp
@@ -7,6 +7,7 @@
 
 #include <dynd/callables/base_instantiable_callable.hpp>
 #include <dynd/kernels/serialize_kernel.hpp>
+#include <dynd/types/callable_type.hpp>
 
 namespace dynd {
 namespace nd {

--- a/include/dynd/callables/uniform_callable.hpp
+++ b/include/dynd/callables/uniform_callable.hpp
@@ -7,6 +7,8 @@
 
 #include <dynd/callables/base_callable.hpp>
 #include <dynd/kernels/uniform_kernel.hpp>
+#include <dynd/types/callable_type.hpp>
+#include <dynd/types/option_type.hpp>
 
 namespace dynd {
 namespace nd {

--- a/include/dynd/kernels/conj_kernel.hpp
+++ b/include/dynd/kernels/conj_kernel.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <dynd/kernels/base_kernel.hpp>
+#include <dynd/kernels/base_strided_kernel.hpp>
 
 namespace dynd {
 namespace nd {

--- a/include/dynd/kernels/kernel_builder.hpp
+++ b/include/dynd/kernels/kernel_builder.hpp
@@ -6,8 +6,11 @@
 #pragma once
 
 #include <new>
+#include <cstring>
 #include <algorithm>
 #include <map>
+
+#include <dynd/visibility.hpp>
 
 namespace dynd {
 namespace nd {

--- a/include/dynd/kernels/max_kernel.hpp
+++ b/include/dynd/kernels/max_kernel.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <dynd/kernels/base_kernel.hpp>
+#include <dynd/kernels/base_strided_kernel.hpp>
 #include <dynd/types/callable_type.hpp>
 
 namespace dynd {

--- a/include/dynd/kernels/serialize_kernel.hpp
+++ b/include/dynd/kernels/serialize_kernel.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <dynd/kernels/base_kernel.hpp>
+#include <dynd/kernels/base_strided_kernel.hpp>
 
 namespace dynd {
 namespace nd {

--- a/include/dynd/kernels/uniform_kernel.hpp
+++ b/include/dynd/kernels/uniform_kernel.hpp
@@ -5,7 +5,11 @@
 
 #pragma once
 
+#include <memory>
+#include <random>
+
 #include <dynd/kernels/base_kernel.hpp>
+#include <dynd/kernels/base_strided_kernel.hpp>
 
 namespace dynd {
 


### PR DESCRIPTION
This implements my old suggestion of changing the clang-format configuration to attach braces for functions, catch statements, and else statements. The relevant change is one line and is the only thing in the first commit. The second commit applies clang-format to our whole source tree. The third commit  adds various missing includes that clang-format's reordering of include directives exposed.

This is really just a suggestion, take it or leave it. Input is welcome.