### PR TITLE
Check for assumptions about float sizes in config.hpp.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 cmake_minimum_required(VERSION 2.8.11)
 project(libdynd)
+include(CheckTypeSize)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
@@ -14,6 +15,16 @@ set(LIB_SUFFIX "" CACHE STRING
 if(NOT WIN32)
   set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
   set(CMAKE_C_FLAGS_DEBUG "-O0 -g")
+endif()
+
+CHECK_TYPE_SIZE("float" SIZEOF_FLOAT)
+if(NOT (SIZEOF_FLOAT EQUAL 4))
+  message(FATAL_ERROR "libdynd requires sizeof(float) == 4")
+endif()
+
+CHECK_TYPE_SIZE("double" SIZEOF_DOUBLE)
+if(NOT (SIZEOF_DOUBLE EQUAL 8))
+  message(FATAL_ERROR "libdynd requires sizeof(double) == 8")
 endif()
 
 # Only add these options if this is the top level CMakeLists.txt

--- a/src/dynd/types/datashape_parser.cpp
+++ b/src/dynd/types/datashape_parser.cpp
@@ -85,8 +85,8 @@ static const map<std::string, ndt::type> &builtin_types()
     bit["float64"] = ndt::make_type<float64>();
     bit["real"] = ndt::make_type<double>();
     bit["float128"] = ndt::make_type<float128>();
-    bit["complex64"] = ndt::make_type<dynd::complex<float>>();
-    bit["complex128"] = ndt::make_type<dynd::complex<double>>();
+    bit["complex64"] = ndt::make_type<dynd::complex<float32>>();
+    bit["complex128"] = ndt::make_type<dynd::complex<float64>>();
     bit["complex"] = ndt::make_type<dynd::complex<double>>();
     bit["bytes"] = ndt::bytes_type::make(1);
     bit["type"] = ndt::make_type<ndt::type_type>();


### PR DESCRIPTION

config.hpp assumes sizeof(float)==4 and sizeof(double)==8.  The patch checks this in the ```cmake``` stage.

I think the assumption holds for most systems, so it should be fine.  If this goes in, the ```real``` type is effectively locked down to ```float64``` and ```complex``` to ```complex128```.

Perhaps we should also make that explicit.
