### PR TITLE
Change encoding properties to return strings. Remove latin1 encoding.

### DIFF
--- a/include/dynd/string_encodings.hpp
+++ b/include/dynd/string_encodings.hpp
@@ -24,7 +24,6 @@ enum string_encoding_t : uint32_t {
   string_encoding_utf_16,
   string_encoding_utf_32,
 
-  string_encoding_latin1,
   // TODO: more codepages here
 
   string_encoding_invalid
@@ -45,31 +44,27 @@ inline bool is_variable_length_string_encoding(string_encoding_t encoding)
   return encoding == string_encoding_utf_8 || encoding == string_encoding_utf_16;
 }
 
-inline std::ostream &operator<<(std::ostream &o, string_encoding_t encoding)
+inline const char *encoding_as_string(string_encoding_t encoding)
 {
   switch (encoding) {
   case string_encoding_ascii:
-    o << "ascii";
-    break;
+    return "ascii";
   case string_encoding_ucs_2:
-    o << "ucs2";
-    break;
+    return "ucs2";
   case string_encoding_utf_8:
-    o << "utf8";
-    break;
+    return "utf8";
   case string_encoding_utf_16:
-    o << "utf16";
-    break;
+    return "utf16";
   case string_encoding_utf_32:
-    o << "utf32";
-    break;
-  case string_encoding_latin1:
-    o << "latin1";
-    break;
+    return "utf32";
   default:
-    o << "unknown string encoding";
-    break;
+    return "unknown string encoding";
   }
+}
+
+inline std::ostream &operator<<(std::ostream &o, string_encoding_t encoding)
+{
+  o << encoding_as_string(encoding);
 
   return o;
 }
@@ -98,16 +93,16 @@ typedef uint32_t (*next_unicode_codepoint_t)(const char *&it, const char *end);
  */
 typedef void (*append_unicode_codepoint_t)(uint32_t cp, char *&it, char *end);
 
-DYNDT_API next_unicode_codepoint_t get_next_unicode_codepoint_function(string_encoding_t encoding,
-                                                                      assign_error_mode errmode);
-DYNDT_API append_unicode_codepoint_t get_append_unicode_codepoint_function(string_encoding_t encoding,
-                                                                          assign_error_mode errmode);
+DYNDT_API next_unicode_codepoint_t
+get_next_unicode_codepoint_function(string_encoding_t encoding, assign_error_mode errmode);
+DYNDT_API append_unicode_codepoint_t
+get_append_unicode_codepoint_function(string_encoding_t encoding, assign_error_mode errmode);
 
 /**
  * Converts a string buffer provided as a range of bytes into a std::string as UTF8.
  */
 DYNDT_API std::string string_range_as_utf8_string(string_encoding_t encoding, const char *begin, const char *end,
-                                                 assign_error_mode errmode);
+                                                  assign_error_mode errmode);
 
 /**
  * Prints the given code point to the output stream, escaping it as necessary.
@@ -118,7 +113,7 @@ DYNDT_API void print_escaped_unicode_codepoint(std::ostream &o, uint32_t cp, boo
  * Prints the utf8 string, escaping as necessary.
  */
 DYNDT_API void print_escaped_utf8_string(std::ostream &o, const char *str_begin, const char *str_end,
-                                        bool single_quote = false);
+                                         bool single_quote = false);
 
 /**
  * Prints the utf8 string, escaping as necessary.

--- a/include/dynd/types/base_string_type.hpp
+++ b/include/dynd/types/base_string_type.hpp
@@ -18,7 +18,8 @@ namespace ndt {
    */
   class DYNDT_API base_string_type : public base_type {
   private:
-    const string_encoding_t m_encoding = string_encoding_ascii;
+    const string_encoding_t m_encoding{string_encoding_ascii};
+    const std::string m_encoding_repr{encoding_as_string(string_encoding_ascii)};
 
   public:
     base_string_type(type_id_t type_id, size_t data_size, size_t alignment, uint32_t flags, size_t arrmeta_size)

--- a/include/dynd/types/char_type.hpp
+++ b/include/dynd/types/char_type.hpp
@@ -16,7 +16,7 @@ namespace dynd {
 namespace ndt {
 
   class DYNDT_API char_type : public base_type {
-    // This encoding can be ascii, latin1, ucs2, or utf32.
+    // This encoding can be ascii, ucs2, or utf32.
     // Not a variable-sized encoding.
     string_encoding_t m_encoding;
 

--- a/include/dynd/types/fixed_string_type.hpp
+++ b/include/dynd/types/fixed_string_type.hpp
@@ -17,7 +17,8 @@ namespace ndt {
 
   class DYNDT_API fixed_string_type : public base_string_type {
     intptr_t m_stringsize;
-    string_encoding_t m_encoding;
+    const string_encoding_t m_encoding;
+    const std::string m_encoding_repr;
 
   public:
     fixed_string_type(intptr_t stringsize, string_encoding_t encoding);
@@ -49,6 +50,8 @@ namespace ndt {
                              const std::string &DYND_UNUSED(indent)) const
     {
     }
+
+    std::map<std::string, std::pair<ndt::type, const char *>> get_dynamic_type_properties() const;
 
     static type make(intptr_t stringsize, string_encoding_t encoding = string_encoding_utf_8)
     {

--- a/include/dynd/types/string_type.hpp
+++ b/include/dynd/types/string_type.hpp
@@ -59,7 +59,9 @@ namespace ndt {
 
   class DYNDT_API string_type : public base_string_type {
   private:
-    const string_encoding_t m_encoding = string_encoding_utf_8;
+    const string_encoding_t m_encoding{string_encoding_utf_8};
+    const std::string m_encoding_repr{encoding_as_string(string_encoding_utf_8)};
+
   public:
     typedef string data_type;
 

--- a/src/dynd/types/base_string_type.cpp
+++ b/src/dynd/types/base_string_type.cpp
@@ -23,7 +23,7 @@ size_t ndt::base_string_type::get_iterdata_size(intptr_t DYND_UNUSED(ndim)) cons
 std::map<std::string, std::pair<ndt::type, const char *>> ndt::base_string_type::get_dynamic_type_properties() const
 {
   std::map<std::string, std::pair<ndt::type, const char *>> properties;
-  properties["encoding"] = {ndt::type("uint32"), reinterpret_cast<const char *>(&m_encoding)};
+  properties["encoding"] = {ndt::type("string"), reinterpret_cast<const char *>(&m_encoding_repr)};
 
   return properties;
 }

--- a/src/dynd/types/char_type.cpp
+++ b/src/dynd/types/char_type.cpp
@@ -18,7 +18,6 @@ ndt::char_type::char_type(string_encoding_t encoding)
 {
   switch (encoding) {
   case string_encoding_ascii:
-  case string_encoding_latin1:
   case string_encoding_ucs_2:
   case string_encoding_utf_32:
     break;

--- a/src/dynd/types/fixed_string_type.cpp
+++ b/src/dynd/types/fixed_string_type.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 
+#include <dynd/string_encodings.hpp>
 #include <dynd/types/fixed_string_type.hpp>
 #include <dynd/types/string_type.hpp>
 #include <dynd/exceptions.hpp>
@@ -13,7 +14,8 @@ using namespace std;
 using namespace dynd;
 
 ndt::fixed_string_type::fixed_string_type(intptr_t stringsize, string_encoding_t encoding)
-    : base_string_type(fixed_string_id, 0, 1, type_flag_none, 0), m_stringsize(stringsize), m_encoding(encoding)
+    : base_string_type(fixed_string_id, 0, 1, type_flag_none, 0), m_stringsize(stringsize), m_encoding(encoding),
+      m_encoding_repr(encoding_as_string(encoding))
 {
   switch (encoding) {
   case string_encoding_ascii:
@@ -149,4 +151,12 @@ bool ndt::fixed_string_type::operator==(const base_type &rhs) const
     const fixed_string_type *dt = static_cast<const fixed_string_type *>(&rhs);
     return m_encoding == dt->m_encoding && m_stringsize == dt->m_stringsize;
   }
+}
+
+std::map<std::string, std::pair<ndt::type, const char *>> ndt::fixed_string_type::get_dynamic_type_properties() const
+{
+  std::map<std::string, std::pair<ndt::type, const char *>> properties;
+  properties["encoding"] = {ndt::type("string"), reinterpret_cast<const char *>(&m_encoding_repr)};
+
+  return properties;
 }

--- a/src/dynd/types/string_type.cpp
+++ b/src/dynd/types/string_type.cpp
@@ -137,7 +137,7 @@ void ndt::string_type::data_destruct_strided(const char *DYND_UNUSED(arrmeta), c
 std::map<std::string, std::pair<ndt::type, const char *>> ndt::string_type::get_dynamic_type_properties() const
 {
   std::map<std::string, std::pair<ndt::type, const char *>> properties;
-  properties["encoding"] = {ndt::type("uint32"), reinterpret_cast<const char *>(&m_encoding)};
+  properties["encoding"] = {ndt::type("string"), reinterpret_cast<const char *>(&m_encoding_repr)};
 
   return properties;
 }

--- a/tests/types/test_fixed_string_type.cpp
+++ b/tests/types/test_fixed_string_type.cpp
@@ -10,6 +10,7 @@
 #include "../dynd_assertions.hpp"
 
 #include <dynd/array.hpp>
+#include <dynd/string_encodings.hpp>
 #include <dynd/types/fixed_string_type.hpp>
 #include <dynd/types/string_type.hpp>
 
@@ -61,6 +62,25 @@ TEST(FixedstringDType, Create)
   EXPECT_EQ(4u * 129u, d.get_data_size());
   // Roundtripping through a string
   EXPECT_EQ(d, ndt::type(d.str()));
+}
+
+TEST(FixedStringDType, Encoding)
+{
+  ndt::type t;
+
+  t = ndt::fixed_string_type::make(10, string_encoding_ascii);
+  EXPECT_EQ("ascii", t.p<std::string>("encoding"));
+
+  t = ndt::fixed_string_type::make(10, string_encoding_ucs_2);
+  EXPECT_EQ("ucs2", t.p<std::string>("encoding"));
+
+  t = ndt::fixed_string_type::make(10, string_encoding_utf_8);
+  EXPECT_EQ("utf8", t.p<std::string>("encoding"));
+
+  t = ndt::fixed_string_type::make(10, string_encoding_utf_16);
+  EXPECT_EQ("utf16", t.p<std::string>("encoding"));
+
+  EXPECT_THROW(ndt::fixed_string_type::make(10, string_encoding_invalid), std::runtime_error);
 }
 
 TEST(FixedStringDType, Basic)

--- a/tests/types/test_string_type.cpp
+++ b/tests/types/test_string_type.cpp
@@ -223,7 +223,7 @@ TEST(StringType, Properties)
 {
   ndt::type d = ndt::make_type<ndt::string_type>();
 
-  EXPECT_EQ(string_encoding_utf_8, d.p<uint32_t>("encoding"));
+  EXPECT_EQ("utf8", d.p<std::string>("encoding"));
 }
 
 TEST(StringType, EncodingSizes)


### PR DESCRIPTION

This changes the encoding properties from integers to strings, so that the dynd-python representation becomes human-readable.

Additionally, this removes the latin1 encoding since it was unsupported by the parser and is not present in blaze datashape.  The alternative would be to make the parser accept latin1.