### PR TITLE
Add docs directory as a source in Doxyfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ cache:
 matrix:
   include:
   - compiler: gcc
+    sudo: required
     env: VALGRIND DYND_FFTW=ON
     addons:
       apt:

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -766,6 +766,7 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = include/dynd/
+INPUT                  += docs/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
Markdown support was added in Doxygen 1.8, so I'll have to fiddle with this for a bit to see if I can get Travis CI to install a sufficiently recent version of Doxygen.