### PR TITLE
Workaround compiler bug in MSVC 2015 involving initializer lists

### DIFF
--- a/include/dynd/callables/forward_na_callable.hpp
+++ b/include/dynd/callables/forward_na_callable.hpp
@@ -30,7 +30,7 @@ namespace nd {
 
         kb(kernel_request_single, dst_arrmeta, nsrc, src_arrmeta);
 
-        for (intptr_t i : {I...}) {
+        for (intptr_t i : std::array<index_t, sizeof...(I)>({I...})) {
           size_t is_na_offset = kb.size() - self_offset;
           kb(kernel_request_single, nullptr, 1, src_arrmeta + i);
           kb.get_at<forward_na_kernel<I...>>(self_offset)->is_na_offset[i] = is_na_offset;
@@ -45,7 +45,7 @@ namespace nd {
       for (intptr_t i = 0; i < 2; ++i) {
         src_value_tp[i] = src_tp[i];
       }
-      for (intptr_t i : {I...}) {
+      for (intptr_t i : std::array<index_t, sizeof...(I)>({I...})) {
         src_value_tp[i] = src_value_tp[i].extended<ndt::option_type>()->get_value_type();
       }
 
@@ -60,7 +60,7 @@ namespace nd {
           child->resolve(this, nullptr, cg, dst_tp.is_symbolic() ? child->get_return_type() : dst_tp, 2, src_value_tp,
                          nkwd, kwds, tp_vars);
 
-      for (index_t i : {I...}) {
+      for (index_t i : std::array<index_t, sizeof...(I)>({I...})) {
         is_na->resolve(this, nullptr, cg, ndt::make_type<bool>(), 1, src_tp + i, 0, nullptr, tp_vars);
       }
 

--- a/include/dynd/kernels/forward_na_kernel.hpp
+++ b/include/dynd/kernels/forward_na_kernel.hpp
@@ -16,7 +16,7 @@ namespace nd {
     size_t assign_na_offset;
 
     void single(char *res, char *const *args) {
-      for (intptr_t i : {I...}) {
+      for (intptr_t i : std::array<intptr_t, sizeof...(I)>({I...})) {
         bool1 is_na;
         this->get_child(is_na_offset[i])->single(reinterpret_cast<char *>(&is_na), args + i);
 


### PR DESCRIPTION
For some reason it's not always letting initializer lists be used with range based for loops. Still no minimal reproducible example. This workaround works, but the problem is pretty clearly a compiler bug.