### PR TITLE
[WIP] Tracking of iteration indices

### DIFF
--- a/include/dynd/callables/elwise_dispatch_callable.hpp
+++ b/include/dynd/callables/elwise_dispatch_callable.hpp
@@ -8,10 +8,44 @@
 #include <dynd/callables/base_callable.hpp>
 #include <dynd/callables/elwise_callable.hpp>
 #include <dynd/types/dim_fragment_type.hpp>
+#include <dynd/types/ellipsis_dim_type.hpp>
+#include <dynd/types/iteration_type.hpp>
+#include <dynd/kernels/tracking_elwise_kernel.hpp>
 
 namespace dynd {
 namespace nd {
   namespace functional {
+
+    template <size_t N>
+    class elwise_iteration_callable : public base_callable {
+      callable m_child;
+
+    public:
+      elwise_iteration_callable(const ndt::type &tp, const callable &child) : base_callable(tp), m_child(child) {}
+
+      ndt::type resolve(base_callable *DYND_UNUSED(caller), char *DYND_UNUSED(data), call_graph &cg,
+                        const ndt::type &dst_tp, size_t DYND_UNUSED(nsrc), const ndt::type *src_tp, size_t nkwd,
+                        const array *kwds, const std::map<std::string, ndt::type> &tp_vars) {
+        std::cout << "elwise_iteration_callable<" << N << ">::resolve" << std::endl;
+
+        cg.emplace_back([](kernel_builder &kb, kernel_request_t kernreq, const char *dst_arrmeta,
+                           size_t DYND_UNUSED(nsrc), const char *const *src_arrmeta) {
+          std::cout << "elwise_iteration_callable<" << N << ">::instantiate" << std::endl;
+
+          kb.emplace_back<elwise_iteration_kernel<N>>(kernreq);
+
+          kb(kernreq | kernel_request_data_only, dst_arrmeta, N + 1, src_arrmeta);
+        });
+
+        ndt::type child_src_tp[N + 1];
+        for (size_t i = 0; i < N; ++i) {
+          child_src_tp[i] = src_tp[i];
+        }
+        child_src_tp[N] = ndt::make_type<ndt::iteration_type>();
+
+        return m_child->resolve(this, nullptr, cg, dst_tp, N + 1, child_src_tp, nkwd, kwds, tp_vars);
+      }
+    };
 
     /**
      * This defines the type and keyword argument resolution for
@@ -22,11 +56,15 @@ namespace nd {
     public:
       struct data_type {
         base_callable *child;
+        bool tracking;
+        size_t ndim;
       };
 
       callable m_child;
+      bool m_tracking;
 
-      elwise_dispatch_callable(const ndt::type &tp, const callable &child) : base_callable(tp), m_child(child) {}
+      elwise_dispatch_callable(const ndt::type &tp, const callable &child, bool tracking = false)
+          : base_callable(tp), m_child(child), m_tracking(tracking) {}
 
       ndt::type resolve(base_callable *caller, char *data, call_graph &cg, const ndt::type &dst_tp, size_t nsrc,
                         const ndt::type *src_tp, size_t nkwd, const array *kwds,
@@ -38,7 +76,13 @@ namespace nd {
           } else {
             child_data.child = m_child.get();
           }
+          child_data.tracking = m_tracking;
+          child_data.ndim = 0;
           data = reinterpret_cast<char *>(&child_data);
+
+          if (m_tracking) {
+          }
+        } else {
         }
 
         const ndt::callable_type *child_tp =
@@ -61,6 +105,8 @@ namespace nd {
               this, nullptr, cg,
               dst_tp.is_symbolic() ? reinterpret_cast<data_type *>(data)->child->get_return_type() : dst_tp, nsrc,
               src_tp, nkwd, kwds, tp_vars);
+        } else {
+          reinterpret_cast<data_type *>(data)->ndim += 1;
         }
 
         // Do a pass through the src types to classify them
@@ -116,4 +162,28 @@ namespace nd {
 
   } // namespace dynd::nd::functional
 } // namespace dynd::nd
+
+namespace ndt {
+
+  template <size_t N>
+  struct traits<nd::functional::elwise_dispatch_callable<N>> {
+    static type equivalent(const type &child_tp) {
+      const std::vector<ndt::type> &param_types = child_tp.extended<ndt::callable_type>()->get_pos_types();
+      std::vector<ndt::type> out_param_types;
+      std::string dimsname("Dims");
+
+      for (const ndt::type &t : param_types) {
+        out_param_types.push_back(ndt::make_ellipsis_dim(dimsname, t));
+      }
+
+      ndt::type kwd_tp = child_tp.extended<ndt::callable_type>()->get_kwd_struct();
+      ndt::type ret_tp = child_tp.extended<ndt::callable_type>()->get_return_type();
+      ret_tp = ndt::make_ellipsis_dim(dimsname, ret_tp);
+
+      return ndt::callable_type::make(
+          ret_tp, ndt::make_type<ndt::tuple_type>(out_param_types.size(), out_param_types.data()), kwd_tp);
+    }
+  };
+
+} // namespace dynd::ndt
 } // namespace dynd

--- a/include/dynd/config.hpp
+++ b/include/dynd/config.hpp
@@ -119,8 +119,7 @@ public:
 #ifdef DYND_CLING
 // Don't use the memcpy function (it has inline assembly).
 
-inline void DYND_MEMCPY(char *dst, const char *src, intptr_t count)
-{
+inline void DYND_MEMCPY(char *dst, const char *src, intptr_t count) {
   char *cdst = (char *)dst;
   const char *csrc = (const char *)src;
   while (count--) {
@@ -139,8 +138,7 @@ namespace dynd {
 
 template <typename T, typename U, typename V>
 struct is_common_type_of : std::conditional<std::is_same<T, typename std::common_type<U, V>::type>::value,
-                                            std::true_type, std::false_type>::type {
-};
+                                            std::true_type, std::false_type>::type {};
 
 template <bool Value, template <typename...> class T, template <typename...> class U, typename... As>
 struct conditional_make;
@@ -162,12 +160,10 @@ struct is_function_pointer {
 };
 
 template <typename T>
-struct is_vector : std::false_type {
-};
+struct is_vector : std::false_type {};
 
 template <typename T>
-struct is_vector<std::vector<T>> : std::true_type {
-};
+struct is_vector<std::vector<T>> : std::true_type {};
 
 template <typename T>
 long intrusive_ptr_use_count(T *ptr);
@@ -191,16 +187,14 @@ public:
   intrusive_ptr() : m_ptr(0) {}
 
   /** Constructor from a raw pointer */
-  explicit intrusive_ptr(T *ptr, bool add_ref = true) : m_ptr(ptr)
-  {
+  explicit intrusive_ptr(T *ptr, bool add_ref = true) : m_ptr(ptr) {
     if (m_ptr != 0 && add_ref) {
       intrusive_ptr_retain(m_ptr);
     }
   }
 
   /** Copy constructor */
-  intrusive_ptr(const intrusive_ptr &other) : m_ptr(other.m_ptr)
-  {
+  intrusive_ptr(const intrusive_ptr &other) : m_ptr(other.m_ptr) {
     if (m_ptr != 0) {
       intrusive_ptr_retain(m_ptr);
     }
@@ -210,8 +204,7 @@ public:
   intrusive_ptr(intrusive_ptr &&other) : m_ptr(other.m_ptr) { other.m_ptr = 0; }
 
   /** Destructor */
-  ~intrusive_ptr()
-  {
+  ~intrusive_ptr() {
     if (m_ptr != 0) {
       intrusive_ptr_release(m_ptr);
     }
@@ -224,24 +217,21 @@ public:
   T *operator->() const { return m_ptr; }
 
   /** Assignment */
-  intrusive_ptr &operator=(const intrusive_ptr &rhs)
-  {
+  intrusive_ptr &operator=(const intrusive_ptr &rhs) {
     if (m_ptr != 0) {
       intrusive_ptr_release(m_ptr);
     }
     if (rhs.m_ptr != 0) {
       m_ptr = rhs.m_ptr;
       intrusive_ptr_retain(m_ptr);
-    }
-    else {
+    } else {
       m_ptr = 0;
     }
     return *this;
   }
 
   /** Move assignment */
-  intrusive_ptr &operator=(intrusive_ptr &&rhs)
-  {
+  intrusive_ptr &operator=(intrusive_ptr &&rhs) {
     if (m_ptr != 0) {
       intrusive_ptr_release(m_ptr);
     }
@@ -251,8 +241,7 @@ public:
   }
 
   /** Assignment from raw memory_block pointer */
-  intrusive_ptr &operator=(T *rhs)
-  {
+  intrusive_ptr &operator=(T *rhs) {
     if (m_ptr != nullptr) {
       intrusive_ptr_release(m_ptr);
     }
@@ -272,15 +261,13 @@ public:
   T *get() const { return m_ptr; }
 
   /** Gives away ownership of the reference count */
-  T *release()
-  {
+  T *release() {
     T *result = m_ptr;
     m_ptr = 0;
     return result;
   }
 
-  void swap(intrusive_ptr &rhs)
-  {
+  void swap(intrusive_ptr &rhs) {
     T *tmp = m_ptr;
     m_ptr = rhs.m_ptr;
     rhs.m_ptr = tmp;
@@ -288,14 +275,12 @@ public:
 };
 
 template <typename T>
-bool operator==(const intrusive_ptr<T> &lhs, const intrusive_ptr<T> &rhs)
-{
+bool operator==(const intrusive_ptr<T> &lhs, const intrusive_ptr<T> &rhs) {
   return lhs.get() == rhs.get();
 }
 
 template <typename T>
-bool operator!=(const intrusive_ptr<T> &lhs, const intrusive_ptr<T> &rhs)
-{
+bool operator!=(const intrusive_ptr<T> &lhs, const intrusive_ptr<T> &rhs) {
   return lhs.get() == rhs.get();
 }
 
@@ -310,8 +295,7 @@ struct is_instance<T, T<A...>> {
 };
 
 template <typename T, typename U>
-T alias_cast(U value)
-{
+T alias_cast(U value) {
   union {
     U tmp;
     T res;
@@ -372,6 +356,9 @@ template <typename T>
 struct remove_reference_then_cv {
   typedef typename std::remove_cv<typename std::remove_reference<T>::type>::type type;
 };
+
+template <typename T>
+using remove_reference_then_cv_t = typename remove_reference_then_cv<T>::type;
 
 template <typename T>
 struct remove_all_pointers<T *> {
@@ -570,20 +557,17 @@ struct arg_at {
 
 #define DYND_GET(NAME, TYPE, DEFAULT_VALUE)                                                                            \
   template <typename T, bool ReturnDefaultValue>                                                                       \
-  typename std::enable_if<ReturnDefaultValue, TYPE>::type get_##NAME()                                                 \
-  {                                                                                                                    \
+  typename std::enable_if<ReturnDefaultValue, TYPE>::type get_##NAME() {                                               \
     return DEFAULT_VALUE;                                                                                              \
   }                                                                                                                    \
                                                                                                                        \
   template <typename T, bool ReturnDefaultValue>                                                                       \
-  typename std::enable_if<!ReturnDefaultValue, TYPE>::type get_##NAME()                                                \
-  {                                                                                                                    \
+  typename std::enable_if<!ReturnDefaultValue, TYPE>::type get_##NAME() {                                              \
     return T::NAME;                                                                                                    \
   }                                                                                                                    \
                                                                                                                        \
   template <typename T>                                                                                                \
-  TYPE get_##NAME()                                                                                                    \
-  {                                                                                                                    \
+  TYPE get_##NAME() {                                                                                                  \
     return get_##NAME<T, !has_##NAME<T>::value>();                                                                     \
   }
 
@@ -650,32 +634,25 @@ struct is_boolean<bool1> {
 };
 
 template <typename T>
-struct is_integral : std::is_integral<T> {
-};
+struct is_integral : std::is_integral<T> {};
 
 template <typename T>
-struct is_floating_point : std::is_floating_point<T> {
-};
+struct is_floating_point : std::is_floating_point<T> {};
 
 template <typename T>
-struct is_complex : std::false_type {
-};
+struct is_complex : std::false_type {};
 
 template <typename T>
-struct is_arithmetic : std::integral_constant<bool, is_integral<T>::value || is_floating_point<T>::value> {
-};
+struct is_arithmetic : std::integral_constant<bool, is_integral<T>::value || is_floating_point<T>::value> {};
 
 template <typename T>
-struct is_numeric : std::integral_constant<bool, is_arithmetic<T>::value || is_complex<T>::value> {
-};
+struct is_numeric : std::integral_constant<bool, is_arithmetic<T>::value || is_complex<T>::value> {};
 
 template <typename T, typename U>
-struct is_mixed_arithmetic : std::integral_constant<bool, is_arithmetic<T>::value && is_arithmetic<U>::value> {
-};
+struct is_mixed_arithmetic : std::integral_constant<bool, is_arithmetic<T>::value && is_arithmetic<U>::value> {};
 
 template <typename T>
-struct is_mixed_arithmetic<T, T> : std::false_type {
-};
+struct is_mixed_arithmetic<T, T> : std::false_type {};
 
 template <typename... Ts>
 using true_t = std::true_type;
@@ -689,14 +666,12 @@ using not_t = std::integral_constant<bool, !T::value>;
 // Checks whether T is not the common type of T and U
 template <typename T, typename U>
 struct is_lcast_arithmetic : not_t<typename conditional_make<is_arithmetic<T>::value && is_arithmetic<U>::value,
-                                                             is_common_type_of, true_t, T, T, U>::type> {
-};
+                                                             is_common_type_of, true_t, T, T, U>::type> {};
 
 // Checks whether U is not the common type of T and U
 template <typename T, typename U>
 struct is_rcast_arithmetic : not_t<typename conditional_make<is_arithmetic<T>::value && is_arithmetic<U>::value,
-                                                             is_common_type_of, true_t, U, T, U>::type> {
-};
+                                                             is_common_type_of, true_t, U, T, U>::type> {};
 
 template <typename T>
 struct is_signed {
@@ -712,20 +687,17 @@ template <typename T>
 T strto(const char *begin, char **end);
 
 template <>
-inline float strto(const char *begin, char **end)
-{
+inline float strto(const char *begin, char **end) {
   return std::strtof(begin, end);
 }
 
 template <>
-inline double strto(const char *begin, char **end)
-{
+inline double strto(const char *begin, char **end) {
   return std::strtod(begin, end);
 }
 
 template <typename T>
-T floor(T value)
-{
+T floor(T value) {
   return std::floor(value);
 }
 
@@ -746,11 +718,9 @@ enum assign_error_mode {
   assign_error_default
 };
 
-struct overflow_check_t {
-};
+struct overflow_check_t {};
 
-inline std::ostream &operator<<(std::ostream &o, assign_error_mode errmode)
-{
+inline std::ostream &operator<<(std::ostream &o, assign_error_mode errmode) {
   switch (errmode) {
   case assign_error_nocheck:
     o << "nocheck";
@@ -779,18 +749,15 @@ namespace detail {
   // Use these declarations before includeing bool1, int128, uint128, etc. so they are usable there.
   // Helper to use for determining if a type is in a given list of unique types.
   template <typename T, typename... Types>
-  struct TypeSetCheckInternal : std::is_same<T, Types>... {
-  };
+  struct TypeSetCheckInternal : std::is_same<T, Types>... {};
 
   // Determine if a type is in a given list of unique types.
   template <typename T, typename... Types>
-  struct TypeSetCheck : std::is_base_of<std::true_type, TypeSetCheckInternal<T, Types...>>::type {
-  };
+  struct TypeSetCheck : std::is_base_of<std::true_type, TypeSetCheckInternal<T, Types...>>::type {};
 
   // Enable a given template only for a given list of unique types.
   template <typename T, typename... Types>
-  struct enable_for : std::enable_if<TypeSetCheck<T, Types...>::value, int> {
-  };
+  struct enable_for : std::enable_if<TypeSetCheck<T, Types...>::value, int> {};
 } // namespace dynd::detail
 
 } // namespace dynd
@@ -815,15 +782,13 @@ template <typename T, typename U>
 struct operator_if_only_lcast_arithmetic
     : std::enable_if<!std::is_same<T, U>::value && !(std::is_arithmetic<T>::value && std::is_arithmetic<U>::value) &&
                          is_lcast_arithmetic<T, U>::value && !is_rcast_arithmetic<T, U>::value,
-                     U> {
-};
+                     U> {};
 
 template <typename T, typename U>
 struct operator_if_only_rcast_arithmetic
     : std::enable_if<!std::is_same<T, U>::value && !(std::is_arithmetic<T>::value && std::is_arithmetic<U>::value) &&
                          !is_lcast_arithmetic<T, U>::value && is_rcast_arithmetic<T, U>::value,
-                     T> {
-};
+                     T> {};
 
 template <typename... T>
 struct make_void {
@@ -835,43 +800,36 @@ struct operator_if_lrcast_arithmetic
     : std::enable_if<!std::is_same<T, U>::value && !(std::is_arithmetic<T>::value && std::is_arithmetic<U>::value) &&
                          is_lcast_arithmetic<T, U>::value && is_rcast_arithmetic<T, U>::value,
                      typename conditional_make<is_arithmetic<T>::value && is_arithmetic<U>::value, std::common_type,
-                                               make_void, T, U>::type::type> {
-};
+                                               make_void, T, U>::type::type> {};
 
 template <typename T, typename U>
-typename operator_if_only_rcast_arithmetic<T, U>::type operator+(T lhs, U rhs)
-{
+typename operator_if_only_rcast_arithmetic<T, U>::type operator+(T lhs, U rhs) {
   return lhs + static_cast<T>(rhs);
 }
 
 template <typename T, typename U>
-typename operator_if_only_lcast_arithmetic<T, U>::type operator+(T lhs, U rhs)
-{
+typename operator_if_only_lcast_arithmetic<T, U>::type operator+(T lhs, U rhs) {
   return static_cast<U>(lhs) + rhs;
 }
 
 template <typename T, typename U>
-typename operator_if_lrcast_arithmetic<T, U>::type operator+(T lhs, U rhs)
-{
+typename operator_if_lrcast_arithmetic<T, U>::type operator+(T lhs, U rhs) {
   return static_cast<typename std::common_type<T, U>::type>(lhs) +
          static_cast<typename std::common_type<T, U>::type>(rhs);
 }
 
 template <typename T, typename U>
-typename operator_if_only_rcast_arithmetic<T, U>::type operator/(T lhs, U rhs)
-{
+typename operator_if_only_rcast_arithmetic<T, U>::type operator/(T lhs, U rhs) {
   return lhs / static_cast<T>(rhs);
 }
 
 template <typename T, typename U>
-typename operator_if_only_lcast_arithmetic<T, U>::type operator/(T lhs, U rhs)
-{
+typename operator_if_only_lcast_arithmetic<T, U>::type operator/(T lhs, U rhs) {
   return static_cast<U>(lhs) / rhs;
 }
 
 template <typename T, typename U>
-typename operator_if_lrcast_arithmetic<T, U>::type operator/(T lhs, U rhs)
-{
+typename operator_if_lrcast_arithmetic<T, U>::type operator/(T lhs, U rhs) {
   return static_cast<typename std::common_type<T, U>::type>(lhs) /
          static_cast<typename std::common_type<T, U>::type>(rhs);
 }
@@ -879,8 +837,7 @@ typename operator_if_lrcast_arithmetic<T, U>::type operator/(T lhs, U rhs)
 template <typename T, typename U>
 
 typename std::enable_if<is_mixed_arithmetic<T, U>::value, complex<typename std::common_type<T, U>::type>>::type
-operator/(complex<T> lhs, U rhs)
-{
+operator/(complex<T> lhs, U rhs) {
   return static_cast<complex<typename std::common_type<T, U>::type>>(lhs) /
          static_cast<typename std::common_type<T, U>::type>(rhs);
 }
@@ -888,15 +845,14 @@ operator/(complex<T> lhs, U rhs)
 template <typename T, typename U>
 
 typename std::enable_if<is_mixed_arithmetic<T, U>::value, complex<typename std::common_type<T, U>::type>>::type
-operator/(T lhs, complex<U> rhs)
-{
+operator/(T lhs, complex<U> rhs) {
   return static_cast<typename std::common_type<T, U>::type>(lhs) /
          static_cast<complex<typename std::common_type<T, U>::type>>(rhs);
 }
 
 template <typename T, typename U>
-typename std::enable_if<std::is_floating_point<T>::value && is_integral<U>::value, T &>::type operator/=(T &lhs, U rhs)
-{
+typename std::enable_if<std::is_floating_point<T>::value && is_integral<U>::value, T &>::type operator/=(T &lhs,
+                                                                                                         U rhs) {
   return lhs /= static_cast<T>(rhs);
 }
 

--- a/include/dynd/functional.hpp
+++ b/include/dynd/functional.hpp
@@ -106,7 +106,8 @@ namespace nd {
 
     DYND_API callable elwise(const ndt::type &tp);
 
-    DYND_API callable elwise(const ndt::type &self_tp, const callable &child);
+    DYND_API callable elwise(const ndt::type &self_tp, const callable &child,
+                             std::initializer_list<size_t> variadic_args = {});
 
     DYND_API ndt::type elwise_make_type(const ndt::callable_type *child_tp);
 

--- a/include/dynd/kernels/apply.hpp
+++ b/include/dynd/kernels/apply.hpp
@@ -7,6 +7,7 @@
 
 #include <dynd/kernels/cuda_launch.hpp>
 #include <dynd/kernels/base_kernel.hpp>
+#include <dynd/types/iteration_type.hpp>
 
 namespace dynd {
 namespace nd {
@@ -19,6 +20,20 @@ namespace nd {
       apply_arg(const char *DYND_UNUSED(arrmeta), const nd::array *DYND_UNUSED(kwds)) {}
 
       D &get(char *data) { return *reinterpret_cast<D *>(data); }
+
+      char *next(char *data) { return data; }
+    };
+
+    template <size_t I>
+    struct apply_arg<iteration_t, I> {
+      apply_arg(const char *DYND_UNUSED(metadata), const array *DYND_UNUSED(kwds)) {}
+
+      iteration_t &get(char *arg) { return *reinterpret_cast<iteration_t *>(arg); }
+
+      char *next(char *arg) {
+//        ++reinterpret_cast<iteration_t *>(arg)->index[0];
+        return arg;
+      }
     };
 
     template <typename ElementType, size_t I>
@@ -27,11 +42,12 @@ namespace nd {
 
       apply_arg(const char *arrmeta, const nd::array *DYND_UNUSED(kwds)) : value(arrmeta, NULL) {}
 
-      fixed_dim<ElementType> &get(char *data)
-      {
+      fixed_dim<ElementType> &get(char *data) {
         value.set_data(data);
         return value;
       }
+
+      char *next(char *data) { return data; }
     };
 
     template <typename func_type, int N = args_of<typename funcproto_of<func_type>::type>::type::size>
@@ -43,9 +59,7 @@ namespace nd {
     template <typename... A, size_t... I>
     struct apply_args<type_sequence<A...>, index_sequence<I...>> : apply_arg<A, I>... {
       apply_args(const char *const *DYND_IGNORE_UNUSED(src_arrmeta), const nd::array *DYND_IGNORE_UNUSED(kwds))
-          : apply_arg<A, I>(src_arrmeta[I], kwds)...
-      {
-      }
+          : apply_arg<A, I>(src_arrmeta[I], kwds)... {}
     };
 
     template <typename T, size_t I>

--- a/include/dynd/kernels/apply_callable_kernel.hpp
+++ b/include/dynd/kernels/apply_callable_kernel.hpp
@@ -16,6 +16,20 @@ namespace nd {
       template <typename func_type, typename R, typename A, typename I, typename K, typename J>
       struct apply_callable_kernel;
 
+      inline size_t select() { return 0; }
+
+      template <typename... ArgTypes>
+      size_t &select(iteration_t &arg0, ArgTypes &&... DYND_UNUSED(args)) {
+        std::cout << "found iteration_t" << std::endl;
+//        arg0.index[arg0.ndim - 1] = 0;
+        return arg0.index[arg0.ndim - 1];
+      }
+
+      template <typename Arg0Type, typename... ArgTypes>
+      decltype(auto) select(Arg0Type &&DYND_UNUSED(arg0), ArgTypes &&... args) {
+        return select(std::forward<ArgTypes>(args)...);
+      }
+
       template <typename func_type, typename R, typename... A, size_t... I, typename... K, size_t... J>
       struct apply_callable_kernel<func_type, R, type_sequence<A...>, index_sequence<I...>, type_sequence<K...>,
                                    index_sequence<J...>>
@@ -30,13 +44,16 @@ namespace nd {
         func_type func;
 
         apply_callable_kernel(func_type func, args_type args, kwds_type kwds)
-            : args_type(args), kwds_type(kwds), func(func)
-        {
+            : args_type(args), kwds_type(kwds), func(func) {}
+
+        void single(char *dst, char *const *DYND_IGNORE_UNUSED(src)) {
+          std::cout << "apply_callable_kernel::single" << std::endl;
+          *reinterpret_cast<R *>(dst) = func(apply_arg<A, I>::get(src[I])..., apply_kwd<K, J>::get()...);
         }
 
-        void single(char *dst, char *const *DYND_IGNORE_UNUSED(src))
-        {
-          *reinterpret_cast<R *>(dst) = func(apply_arg<A, I>::get(src[I])..., apply_kwd<K, J>::get()...);
+        decltype(auto) begin(char *const *src) {
+          std::cout << "apply_callable::begin" << std::endl;
+          return select(apply_arg<A, I>::get(src[I])...);
         }
       };
 
@@ -54,12 +71,9 @@ namespace nd {
         func_type func;
 
         apply_callable_kernel(func_type func, args_type args, kwds_type kwds)
-            : args_type(args), kwds_type(kwds), func(func)
-        {
-        }
+            : args_type(args), kwds_type(kwds), func(func) {}
 
-        void single(char *DYND_UNUSED(dst), char *const *DYND_IGNORE_UNUSED(src))
-        {
+        void single(char *DYND_UNUSED(dst), char *const *DYND_IGNORE_UNUSED(src)) {
           func(apply_arg<A, I>::get(src[I])..., apply_kwd<K, J>::get()...);
         }
       };
@@ -78,12 +92,9 @@ namespace nd {
         func_type *func;
 
         apply_callable_kernel(func_type *func, args_type args, kwds_type kwds)
-            : args_type(args), kwds_type(kwds), func(func)
-        {
-        }
+            : args_type(args), kwds_type(kwds), func(func) {}
 
-        void single(char *dst, char *const *DYND_IGNORE_UNUSED(src))
-        {
+        void single(char *dst, char *const *DYND_IGNORE_UNUSED(src)) {
           *reinterpret_cast<R *>(dst) = (*func)(apply_arg<A, I>::get(src[I])..., apply_kwd<K, J>::get()...);
         }
       };
@@ -102,12 +113,9 @@ namespace nd {
         func_type *func;
 
         apply_callable_kernel(func_type *func, args_type args, kwds_type kwds)
-            : args_type(args), kwds_type(kwds), func(func)
-        {
-        }
+            : args_type(args), kwds_type(kwds), func(func) {}
 
-        void single(char *DYND_UNUSED(dst), char *const *DYND_IGNORE_UNUSED(src))
-        {
+        void single(char *DYND_UNUSED(dst), char *const *DYND_IGNORE_UNUSED(src)) {
           (*func)(apply_arg<A, I>::get(src[I])..., apply_kwd<K, J>::get()...);
         }
       };

--- a/include/dynd/kernels/tracking_elwise_kernel.hpp
+++ b/include/dynd/kernels/tracking_elwise_kernel.hpp
@@ -1,0 +1,124 @@
+//
+// Copyright (C) 2011-16 DyND Developers
+// BSD 2-Clause License, see LICENSE.txt
+//
+
+#pragma once
+
+#include <dynd/kernels/elwise_kernel.hpp>
+
+namespace dynd {
+namespace nd {
+  namespace functional {
+
+    template <size_t N>
+    struct tracking_kernel : base_strided_kernel<tracking_kernel<N>, N> {
+      //    size_t ndim;
+
+      //      tracking_kernel(size_t ndim = 2) : ndim(ndim) {}
+
+      ~tracking_kernel() { this->get_child()->destroy(); }
+
+      void single(char *dst, char *const *src) {
+        std::cout << "tracking_kernel<" << N << ">::single" << std::endl;
+
+        char *child_src[N + 1];
+        for (size_t i = 0; i < N; ++i) {
+          child_src[i] = src[i];
+        }
+
+        iteration_t it;
+        it.ndim = 2;
+        it.index = new size_t[10];
+        it.index[0] = 0;
+        child_src[N] = reinterpret_cast<char *>(&it);
+
+        this->get_child()->single(dst, child_src);
+      }
+    };
+
+    struct X_prefix {
+      size_t index_offset;
+    };
+
+    template <type_id_t RetID, type_id_t ArgID, size_t N>
+    struct tracking_elwise_kernel;
+
+    template <size_t N>
+    struct tracking_elwise_kernel<fixed_dim_id, fixed_dim_id, N>
+        : base_elwise_kernel<tracking_elwise_kernel<fixed_dim_id, fixed_dim_id, N>, N>, X_prefix {
+      size_t index_offset;
+
+      tracking_elwise_kernel(size_t size, intptr_t dst_stride, const intptr_t *src_stride)
+          : base_elwise_kernel<tracking_elwise_kernel<fixed_dim_id, fixed_dim_id, N>, N>(size, dst_stride, src_stride) {
+      }
+
+      void single(char *dst, char *const *src) {
+        std::cout << "tracking_elwise_kernel::single" << std::endl;
+
+        reinterpret_cast<iteration_t *>(src[2])->index[1] = 0;
+        base_elwise_kernel<tracking_elwise_kernel<fixed_dim_id, fixed_dim_id, N>, N>::single(dst, src);
+      }
+
+      size_t &begin(char *const *src) {
+        std::cout << "tracking_elwise_kernel::begin" << std::endl;
+        return reinterpret_cast<iteration_t *>(src[2])->index[0];
+      }
+    };
+
+    template <type_id_t RetID, type_id_t ArgID, size_t N>
+    struct inner_tracking_elwise_kernel;
+
+    template <size_t N>
+    struct inner_tracking_elwise_kernel<fixed_dim_id, fixed_dim_id, N>
+        : base_elwise_kernel<inner_tracking_elwise_kernel<fixed_dim_id, fixed_dim_id, N>, N + 1> {
+      size_t ndim;
+
+      inner_tracking_elwise_kernel(size_t size, intptr_t dst_stride, const intptr_t *src_stride, size_t ndim)
+          : base_elwise_kernel<inner_tracking_elwise_kernel<fixed_dim_id, fixed_dim_id, N>, N + 1>(size, dst_stride,
+                                                                                                   src_stride),
+            ndim(ndim) {
+        this->m_src_stride[N] = 0;
+        std::cout << "inner_tracking_elwise_kernel::constructor" << std::endl;
+        std::cout << "ndim = " << ndim << std::endl;
+      }
+
+      kernel_prefix *get_child() {
+        return kernel_prefix::get_child(
+            kernel_builder::aligned_size(sizeof(inner_tracking_elwise_kernel) + ndim * sizeof(size_t)));
+      }
+
+      void call(array *dst, const array *src) {
+        char *src_data[N];
+        for (size_t i = 0; i < N; ++i) {
+          src_data[i] = const_cast<char *>(src[i].cdata());
+        }
+        single(const_cast<char *>(dst->cdata()), src_data);
+      }
+
+      void single(char *dst, char *const *src) {
+        iteration_t it{ndim,
+                       reinterpret_cast<size_t *>(reinterpret_cast<char *>(this) +
+                                                  kernel_builder::aligned_size(sizeof(inner_tracking_elwise_kernel)))};
+        it.index[0] = 0;
+        std::cout << "inner_tracking_elwise_kernel::single" << std::endl;
+
+        char *child_src[N + 1];
+        for (size_t i = 0; i < N; ++i) {
+          child_src[i] = src[i];
+        }
+        child_src[N] = reinterpret_cast<char *>(&it);
+
+        it.index[1] = 0;
+        base_elwise_kernel<inner_tracking_elwise_kernel<fixed_dim_id, fixed_dim_id, N>, N + 1>::single(dst, child_src);
+      }
+
+      size_t &begin(char *const *src) {
+        std::cout << "inner_tracking_elwise_kernel::begin" << std::endl;
+        return reinterpret_cast<iteration_t *>(src[N + 1])->index[0];
+      }
+    };
+
+  } // namespace dynd::nd::functional
+} // namespace dynd::nd
+} // namespace dynd

--- a/include/dynd/types/iteration_type.hpp
+++ b/include/dynd/types/iteration_type.hpp
@@ -9,7 +9,10 @@
 
 namespace dynd {
 
-struct iteration_t {};
+struct iteration_t {
+  size_t ndim;
+  size_t *index;
+};
 
 namespace ndt {
 

--- a/src/dynd/callables/base_callable.cpp
+++ b/src/dynd/callables/base_callable.cpp
@@ -33,6 +33,8 @@ nd::array nd::base_callable::call(ndt::type &dst_tp, size_t nsrc, const ndt::typ
 nd::array nd::base_callable::call(ndt::type &dst_tp, size_t nsrc, const ndt::type *src_tp,
                                   const char *const *src_arrmeta, const array *src_data, size_t nkwd, const array *kwds,
                                   const std::map<std::string, ndt::type> &tp_vars) {
+  std::cout << "calling" << std::endl;
+
   call_graph cg;
   dst_tp = resolve(nullptr, nullptr, cg, dst_tp, nsrc, src_tp, nkwd, kwds, tp_vars);
 
@@ -40,9 +42,11 @@ nd::array nd::base_callable::call(ndt::type &dst_tp, size_t nsrc, const ndt::typ
   array dst = empty(dst_tp);
 
   // Generate and evaluate the kernel
+  std::cout << "building" << std::endl;
   kernel_builder kb(cg.get());
   kb(kernel_request_call, dst->metadata(), nsrc, src_arrmeta);
 
+  std::cout << "evaling" << std::endl;
   kernel_call_t fn = kb.get()->get_function<kernel_call_t>();
   fn(kb.get(), &dst, src_data);
 

--- a/src/dynd/functional.cpp
+++ b/src/dynd/functional.cpp
@@ -75,36 +75,14 @@ ndt::type nd::functional::elwise_make_type(const ndt::callable_type *child_tp) {
   std::vector<ndt::type> out_param_types;
   std::string dimsname("Dims");
 
-  for (const ndt::type &t : param_types) {
-    out_param_types.push_back(ndt::make_ellipsis_dim(dimsname, t));
+  for (size_t i = 0; i < child_tp->get_npos(); ++i) {
+    if (param_types[i].get_id() == iteration_id) {
+    } else {
+      out_param_types.push_back(ndt::make_ellipsis_dim(dimsname, param_types[i]));
+    }
   }
 
   ndt::type kwd_tp = child_tp->get_kwd_struct();
-  /*
-    if (true) {
-      intptr_t old_field_count =
-          kwd_tp.extended<base_struct_type>()->get_field_count();
-      nd::array names =
-          nd::empty(ndt::make_fixed_dim(old_field_count + 2,
-    ndt::make_string()));
-      nd::array fields =
-          nd::empty(ndt::make_fixed_dim(old_field_count + 2, ndt::make_type()));
-      for (intptr_t i = 0; i < old_field_count; ++i) {
-        names(i)
-            .val_assign(kwd_tp.extended<base_struct_type>()->get_field_name(i));
-        fields(i)
-            .val_assign(kwd_tp.extended<base_struct_type>()->get_field_type(i));
-      }
-      names(old_field_count).val_assign("threads");
-      fields(old_field_count)
-          .val_assign(ndt::make_option(ndt::make_type<int>()));
-      names(old_field_count + 1).val_assign("blocks");
-      fields(old_field_count + 1)
-          .val_assign(ndt::make_option(ndt::make_type<int>()));
-      kwd_tp = ndt::struct_type::make(names, fields);
-    }
-  */
-
   ndt::type ret_tp = child_tp->get_return_type();
   ret_tp = ndt::make_ellipsis_dim(dimsname, ret_tp);
 
@@ -112,24 +90,34 @@ ndt::type nd::functional::elwise_make_type(const ndt::callable_type *child_tp) {
       ret_tp, ndt::make_type<ndt::tuple_type>(out_param_types.size(), out_param_types.data()), kwd_tp);
 }
 
-nd::callable nd::functional::elwise(const ndt::type &self_tp, const callable &child) {
+nd::callable nd::functional::elwise(const ndt::type &self_tp, const callable &child, std::initializer_list<size_t>) {
+  const std::vector<ndt::type> &arg_tp = child.get_arg_types();
+
+  bool has_iteration = false;
+  for (const ndt::type &tp : arg_tp) {
+    if (tp.get_id() == iteration_id) {
+      has_iteration = true;
+      break;
+    }
+  }
+
   switch (self_tp.extended<ndt::callable_type>()->get_npos()) {
   case 0:
-    return make_callable<elwise_dispatch_callable<0>>(self_tp, child);
+    return make_callable<elwise_dispatch_callable<0>>(self_tp, child, has_iteration);
   case 1:
-    return make_callable<elwise_dispatch_callable<1>>(self_tp, child);
+    return make_callable<elwise_dispatch_callable<1>>(self_tp, child, has_iteration);
   case 2:
-    return make_callable<elwise_dispatch_callable<2>>(self_tp, child);
+    return make_callable<elwise_dispatch_callable<2>>(self_tp, child, has_iteration);
   case 3:
-    return make_callable<elwise_dispatch_callable<3>>(self_tp, child);
+    return make_callable<elwise_dispatch_callable<3>>(self_tp, child, has_iteration);
   case 4:
-    return make_callable<elwise_dispatch_callable<4>>(self_tp, child);
+    return make_callable<elwise_dispatch_callable<4>>(self_tp, child, has_iteration);
   case 5:
-    return make_callable<elwise_dispatch_callable<5>>(self_tp, child);
+    return make_callable<elwise_dispatch_callable<5>>(self_tp, child, has_iteration);
   case 6:
-    return make_callable<elwise_dispatch_callable<6>>(self_tp, child);
+    return make_callable<elwise_dispatch_callable<6>>(self_tp, child, has_iteration);
   case 7:
-    return make_callable<elwise_dispatch_callable<7>>(self_tp, child);
+    return make_callable<elwise_dispatch_callable<7>>(self_tp, child, has_iteration);
   default:
     throw std::runtime_error("callable with nsrc > 7 not implemented yet");
   }

--- a/tests/func/test_elwise.cpp
+++ b/tests/func/test_elwise.cpp
@@ -100,6 +100,27 @@ TEST(Elwise, BinaryResolve) {
   EXPECT_EQ(ndt::make_type<double[3]>(), tp);
 }
 
+TEST(Elwise, Iteration) {
+  nd::callable f = nd::functional::elwise([](double x, double y, iteration_t it) {
+    std::cout << "x, y = " << x << ", " << y << std::endl;
+    std::cout << "it.ndim = " << it.ndim << std::endl;
+    for (size_t i = 0; i < it.ndim; ++i) {
+      std::cout << "it.index[" << i << "] = " << it.index[i] << std::endl;
+    }
+
+    return 0;
+  });
+
+  std::cout << f << std::endl;
+  std::cout << "--" << std::endl;
+  f(nd::array{0.0, 1.0, 2.0}, nd::array{0.0, 1.0, 2.0});
+  std::cout << "--" << std::endl;
+  //f(nd::array{{0.0, 1.0}, {2.0, 3.0}}, 5.0);
+
+  //  f(nd::array{{0.0, 1.0}, {2.0, 3.0}}, 0.0);
+  std::exit(-1);
+}
+
 TEST(Elwise, UnaryFixedDim) {
   nd::callable f = nd::functional::elwise(nd::functional::apply([](dynd::string s) { return s.size(); }));
   EXPECT_ARRAY_EQ((nd::array{static_cast<size_t>(5), static_cast<size_t>(2), static_cast<size_t>(6)}),


### PR DESCRIPTION
This PR enables tracking of iteration indices for functionals. It adds an interface to base_kernel, where a derived kernel can provide a begin() function that returns a reference to an index embedded in the kernel itself. For the functionals, like elwse, support for this needs to be built in. For the innermost operations, the kernel itself has to provide it if it wants so support iteration tracking. An example of that is apply, where this is enabled simply by using an `iteration_t` type as an argument to the apply function.

The `iteration_t` has the number of iterated dimensions (ndim) and a pointer to the index that is embedded in the kernel.

If there is no tracking, the kernels reduce to exactly what they where before.