### PR TITLE
This makes it so that libdynd can build with MSVC 2015 Update 2

### DIFF
--- a/include/dynd/bool1.hpp
+++ b/include/dynd/bool1.hpp
@@ -5,13 +5,13 @@
 
 #pragma once
 
-#include <iostream>
 #include <dynd/visibility.hpp>
+#include <iostream>
 
 namespace dynd {
 
 // A boolean class that is just one byte
-class DYND_API bool1 {
+class bool1 {
   char m_value;
 
 public:
@@ -21,8 +21,7 @@ public:
 
   operator bool() const { return m_value != 0; }
 
-  bool1 &operator=(bool rhs)
-  {
+  bool1 &operator=(bool rhs) {
     m_value = rhs;
     return *this;
   }
@@ -39,26 +38,22 @@ public:
 
   bool1 operator||(bool1 &rhs) { return bool1(m_value || rhs.m_value); }
 
-  bool1 &operator+=(bool1 rhs)
-  {
+  bool1 &operator+=(bool1 rhs) {
     m_value += rhs.m_value;
     return *this;
   }
 
-  bool1 &operator-=(bool1 rhs)
-  {
+  bool1 &operator-=(bool1 rhs) {
     m_value -= rhs.m_value;
     return *this;
   }
 
-  bool1 &operator*=(bool1 rhs)
-  {
+  bool1 &operator*=(bool1 rhs) {
     m_value *= rhs.m_value;
     return *this;
   }
 
-  bool1 &operator/=(bool1 rhs)
-  {
+  bool1 &operator/=(bool1 rhs) {
     m_value /= rhs.m_value;
     return *this;
   }
@@ -70,8 +65,7 @@ public:
 };
 
 template <>
-struct is_integral<bool1> : std::true_type {
-};
+struct is_integral<bool1> : std::true_type {};
 
 inline int operator+(bool1 lhs, bool1 rhs) { return lhs.m_value + rhs.m_value; }
 
@@ -86,8 +80,7 @@ inline int operator/(bool1 lhs, bool1 rhs) { return lhs.m_value / rhs.m_value; }
 namespace std {
 
 template <>
-struct common_type<dynd::bool1, bool> : common_type<char, bool> {
-};
+struct common_type<dynd::bool1, bool> : common_type<char, bool> {};
 
 template <>
 struct common_type<dynd::bool1, dynd::bool1> {
@@ -95,60 +88,46 @@ struct common_type<dynd::bool1, dynd::bool1> {
 };
 
 template <>
-struct common_type<dynd::bool1, char> : common_type<char, char> {
-};
+struct common_type<dynd::bool1, char> : common_type<char, char> {};
 
 template <>
-struct common_type<dynd::bool1, signed char> : common_type<char, signed char> {
-};
+struct common_type<dynd::bool1, signed char> : common_type<char, signed char> {};
 
 template <>
-struct common_type<dynd::bool1, unsigned char> : common_type<char, unsigned char> {
-};
+struct common_type<dynd::bool1, unsigned char> : common_type<char, unsigned char> {};
 
 template <>
-struct common_type<dynd::bool1, short> : common_type<char, short> {
-};
+struct common_type<dynd::bool1, short> : common_type<char, short> {};
 
 template <>
-struct common_type<dynd::bool1, unsigned short> : common_type<char, unsigned short> {
-};
+struct common_type<dynd::bool1, unsigned short> : common_type<char, unsigned short> {};
 
 template <>
-struct common_type<dynd::bool1, int> : common_type<char, int> {
-};
+struct common_type<dynd::bool1, int> : common_type<char, int> {};
 
 template <>
-struct common_type<dynd::bool1, unsigned int> : common_type<char, unsigned int> {
-};
+struct common_type<dynd::bool1, unsigned int> : common_type<char, unsigned int> {};
 
 template <>
-struct common_type<dynd::bool1, long> : common_type<char, long> {
-};
+struct common_type<dynd::bool1, long> : common_type<char, long> {};
 
 template <>
-struct common_type<dynd::bool1, unsigned long> : common_type<char, unsigned long> {
-};
+struct common_type<dynd::bool1, unsigned long> : common_type<char, unsigned long> {};
 
 template <>
-struct common_type<dynd::bool1, long long> : common_type<char, long long> {
-};
+struct common_type<dynd::bool1, long long> : common_type<char, long long> {};
 
 template <>
-struct common_type<dynd::bool1, unsigned long long> : common_type<char, unsigned long long> {
-};
+struct common_type<dynd::bool1, unsigned long long> : common_type<char, unsigned long long> {};
 
 template <>
-struct common_type<dynd::bool1, float> : common_type<char, float> {
-};
+struct common_type<dynd::bool1, float> : common_type<char, float> {};
 
 template <>
-struct common_type<dynd::bool1, double> : common_type<char, double> {
-};
+struct common_type<dynd::bool1, double> : common_type<char, double> {};
 
 template <typename T>
-struct common_type<T, dynd::bool1> : common_type<dynd::bool1, T> {
-};
+struct common_type<T, dynd::bool1> : common_type<dynd::bool1, T> {};
 
 } // namespace std
 
@@ -157,84 +136,72 @@ namespace dynd {
 inline bool operator<(bool1 lhs, bool1 rhs) { return static_cast<bool>(lhs) < static_cast<bool>(rhs); }
 
 template <typename T>
-typename std::enable_if<std::is_arithmetic<T>::value, bool>::type operator<(bool1 lhs, T rhs)
-{
+typename std::enable_if<std::is_arithmetic<T>::value, bool>::type operator<(bool1 lhs, T rhs) {
   return static_cast<T>(lhs) < rhs;
 }
 
 template <typename T>
-typename std::enable_if<std::is_arithmetic<T>::value, bool>::type operator<(T lhs, bool1 rhs)
-{
+typename std::enable_if<std::is_arithmetic<T>::value, bool>::type operator<(T lhs, bool1 rhs) {
   return lhs < static_cast<T>(rhs);
 }
 
 inline bool operator<=(bool1 lhs, bool1 rhs) { return static_cast<bool>(lhs) <= static_cast<bool>(rhs); }
 
 template <typename T>
-typename std::enable_if<std::is_arithmetic<T>::value, bool>::type operator<=(bool1 lhs, T rhs)
-{
+typename std::enable_if<std::is_arithmetic<T>::value, bool>::type operator<=(bool1 lhs, T rhs) {
   return static_cast<T>(lhs) <= rhs;
 }
 
 template <typename T>
-typename std::enable_if<std::is_arithmetic<T>::value, bool>::type operator<=(T lhs, bool1 rhs)
-{
+typename std::enable_if<std::is_arithmetic<T>::value, bool>::type operator<=(T lhs, bool1 rhs) {
   return lhs <= static_cast<T>(rhs);
 }
 
 inline bool operator==(bool1 lhs, bool1 rhs) { return static_cast<bool>(lhs) == static_cast<bool>(rhs); }
 
 template <typename T>
-typename std::enable_if<std::is_arithmetic<T>::value, bool>::type operator==(bool1 lhs, T rhs)
-{
+typename std::enable_if<std::is_arithmetic<T>::value, bool>::type operator==(bool1 lhs, T rhs) {
   return static_cast<T>(lhs) == rhs;
 }
 
 template <typename T>
-typename std::enable_if<std::is_arithmetic<T>::value, bool>::type operator==(T lhs, bool1 rhs)
-{
+typename std::enable_if<std::is_arithmetic<T>::value, bool>::type operator==(T lhs, bool1 rhs) {
   return lhs == static_cast<T>(rhs);
 }
 
 inline bool operator!=(bool1 lhs, bool1 rhs) { return static_cast<bool>(lhs) != static_cast<bool>(rhs); }
 
 template <typename T>
-typename std::enable_if<std::is_arithmetic<T>::value, bool>::type operator!=(bool1 lhs, T rhs)
-{
+typename std::enable_if<std::is_arithmetic<T>::value, bool>::type operator!=(bool1 lhs, T rhs) {
   return static_cast<T>(lhs) != rhs;
 }
 
 template <typename T>
-typename std::enable_if<std::is_arithmetic<T>::value, bool>::type operator!=(T lhs, bool1 rhs)
-{
+typename std::enable_if<std::is_arithmetic<T>::value, bool>::type operator!=(T lhs, bool1 rhs) {
   return lhs != static_cast<T>(rhs);
 }
 
 inline bool operator>=(bool1 lhs, bool1 rhs) { return static_cast<bool>(lhs) >= static_cast<bool>(rhs); }
 
 template <typename T>
-typename std::enable_if<std::is_arithmetic<T>::value, bool>::type operator>=(bool1 lhs, T rhs)
-{
+typename std::enable_if<std::is_arithmetic<T>::value, bool>::type operator>=(bool1 lhs, T rhs) {
   return static_cast<T>(lhs) >= rhs;
 }
 
 template <typename T>
-typename std::enable_if<std::is_arithmetic<T>::value, bool>::type operator>=(T lhs, bool1 rhs)
-{
+typename std::enable_if<std::is_arithmetic<T>::value, bool>::type operator>=(T lhs, bool1 rhs) {
   return lhs >= static_cast<T>(rhs);
 }
 
 inline bool operator>(bool1 lhs, bool1 rhs) { return static_cast<bool>(lhs) > static_cast<bool>(rhs); }
 
 template <typename T>
-typename std::enable_if<std::is_arithmetic<T>::value, bool>::type operator>(bool1 lhs, T rhs)
-{
+typename std::enable_if<std::is_arithmetic<T>::value, bool>::type operator>(bool1 lhs, T rhs) {
   return static_cast<T>(lhs) > rhs;
 }
 
 template <typename T>
-typename std::enable_if<std::is_arithmetic<T>::value, bool>::type operator>(T lhs, bool1 rhs)
-{
+typename std::enable_if<std::is_arithmetic<T>::value, bool>::type operator>(T lhs, bool1 rhs) {
   return lhs > static_cast<T>(rhs);
 }
 


### PR DESCRIPTION
The DYND_API specifier isn't needed for bool1 since the class and everything relating to it are defined via inline functions.
There is still an assertion error at load time when running the test suite. I'm looking in to that now.