### PR TITLE
Avoid harmless decrement of exhausted iterator in topological sort.

### DIFF
--- a/include/dynd/dispatcher.hpp
+++ b/include/dynd/dispatcher.hpp
@@ -76,7 +76,7 @@ namespace detail {
 
   template <typename VertexIterator, typename EdgeIterator, typename MarkerIterator, typename Iterator>
   void topological_sort_visit(size_t i, VertexIterator vertices, EdgeIterator edges, MarkerIterator markers,
-                              Iterator &res)
+                              Iterator &res, Iterator &res_begin)
   {
     if (markers[i].is_temporarily_marked()) {
       throw std::runtime_error("not a dag");
@@ -85,11 +85,13 @@ namespace detail {
     if (!markers[i].is_marked()) {
       markers[i].temporarily_mark();
       for (auto j : edges[i]) {
-        topological_sort_visit(j, vertices, edges, markers, res);
+        topological_sort_visit(j, vertices, edges, markers, res, res_begin);
       }
       markers[i].mark();
       *res = vertices[i];
-      --res;
+      if (res != res_begin) {
+        --res;
+      }
     }
   }
 
@@ -99,12 +101,13 @@ template <typename VertexIterator, typename EdgeIterator, typename Iterator>
 void topological_sort(VertexIterator begin, VertexIterator end, EdgeIterator edges, Iterator res)
 {
   size_t size = end - begin;
+  Iterator res_begin = res;
   res += size - 1;
 
   std::unique_ptr<detail::topological_sort_marker[]> markers =
       std::make_unique<detail::topological_sort_marker[]>(size);
   for (size_t i = 0; i < size; ++i) {
-    detail::topological_sort_visit(i, begin, edges, markers.get(), res);
+    detail::topological_sort_visit(i, begin, edges, markers.get(), res, res_begin);
   }
 }
 
@@ -253,7 +256,6 @@ public:
         return true;
       }
     }
-
     return false;
   }
 


### PR DESCRIPTION
This fixes an assertion error in running our test suite with a Debug build built with MSVC 2015.
As near as I can tell, the assertion error was just complaining that the iterator in question was decremented one too many times, regardless of the fact that it was never actually accessed out of bounds.

It'd be nice if we could revise the control flow at some point to make it so that the extra if statement is no longer necessary here, but this at least gets the build working again.