### PR TITLE
Fix compilation on MinGW.

### DIFF
--- a/include/dynd/callables/call_graph.hpp
+++ b/include/dynd/callables/call_graph.hpp
@@ -5,16 +5,16 @@
 
 #pragma once
 
-#include <dynd/storagebuf.hpp>
 #include <dynd/callables/call.hpp>
 #include <dynd/callables/closure_call.hpp>
+#include <dynd/storagebuf.hpp>
 
 namespace dynd {
 namespace nd {
 
   class call_graph : public storagebuf<call_node, call_graph> {
   public:
-    DYND_API void destroy() {}
+    void destroy() {}
 
     ~call_graph() {
       intptr_t offset = 0;


### PR DESCRIPTION
MinGW tends to be slightly less forgiving about inconsistencies in
dllimport/dllexport declarations. In this case it was complaining that,
when compiling the tests, a function was marked dllimport even though it
was still defined in the header. This removes that ambiguity.