### PR TITLE
Add initial sqrt and cbrt callables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,7 @@ set(libdynd_SRC
     src/dynd/right_shift.cpp
     src/dynd/search.cpp
     src/dynd/sort.cpp
+    src/dynd/sqrt.cpp
     src/dynd/statistics.cpp
     src/dynd/string.cpp
     src/dynd/subtract.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,6 +328,7 @@ set(libdynd_SRC
     src/dynd/bitwise_or.cpp
     src/dynd/bitwise_xor.cpp
     src/dynd/callable.cpp
+    src/dynd/cbrt.cpp
     src/dynd/comparison.cpp
     src/dynd/compound_add.cpp
     src/dynd/compound_div.cpp

--- a/include/dynd/arithmetic.hpp
+++ b/include/dynd/arithmetic.hpp
@@ -17,6 +17,7 @@ namespace nd {
   extern DYND_API callable bitwise_and;
   extern DYND_API callable bitwise_or;
   extern DYND_API callable bitwise_xor;
+  extern DYND_API callable cbrt;
   extern DYND_API callable divide;
   extern DYND_API callable left_shift;
   extern DYND_API callable logical_and;

--- a/include/dynd/arithmetic.hpp
+++ b/include/dynd/arithmetic.hpp
@@ -26,6 +26,7 @@ namespace nd {
   extern DYND_API callable multiply;
   extern DYND_API callable pow;
   extern DYND_API callable right_shift;
+  extern DYND_API callable sqrt;
   extern DYND_API callable subtract;
 
   extern DYND_API callable compound_add;

--- a/include/dynd/callables/cbrt_callable.hpp
+++ b/include/dynd/callables/cbrt_callable.hpp
@@ -1,0 +1,19 @@
+//
+// Copyright (C) 2011-16 DyND Developers
+// BSD 2-Clause License, see LICENSE.txt
+//
+
+#pragma once
+
+#include <dynd/callables/apply_function_callable.hpp>
+#include <dynd/kernels/arithmetic.hpp>
+
+namespace dynd {
+namespace nd {
+
+  template <type_id_t Src0TypeID>
+  using cbrt_callable = functional::apply_function_callable<decltype(&dynd::detail::inline_cbrt<Src0TypeID>::f),
+                                                            &dynd::detail::inline_cbrt<Src0TypeID>::f>;
+
+} // namespace dynd::nd
+} // namespace dynd

--- a/include/dynd/callables/sqrt_callable.hpp
+++ b/include/dynd/callables/sqrt_callable.hpp
@@ -1,0 +1,19 @@
+//
+// Copyright (C) 2011-16 DyND Developers
+// BSD 2-Clause License, see LICENSE.txt
+//
+
+#pragma once
+
+#include <dynd/callables/apply_function_callable.hpp>
+#include <dynd/kernels/arithmetic.hpp>
+
+namespace dynd {
+namespace nd {
+
+  template <type_id_t Src0TypeID>
+  using sqrt_callable = functional::apply_function_callable<decltype(&dynd::detail::inline_sqrt<Src0TypeID>::f),
+                                                            &dynd::detail::inline_sqrt<Src0TypeID>::f>;
+
+} // namespace dynd::nd
+} // namespace dynd

--- a/include/dynd/kernels/arithmetic.hpp
+++ b/include/dynd/kernels/arithmetic.hpp
@@ -155,6 +155,11 @@ namespace detail {
     static auto f(typename type_of<Src0TypeID>::type a) { return std::sqrt(a); }
   };
 
+  template <type_id_t Src0TypeID>
+  struct inline_cbrt {
+    static auto f(typename type_of<Src0TypeID>::type a) { return std::cbrt(a); }
+  };
+
   // Arithmetic operators that need zero checking.
   template <type_id_t Src0TypeID, type_id_t Src1TypeID>
   constexpr bool needs_zero_check() {

--- a/include/dynd/kernels/arithmetic.hpp
+++ b/include/dynd/kernels/arithmetic.hpp
@@ -150,6 +150,11 @@ namespace detail {
     DYND_END_ALLOW_INT_FLOAT_CAST
   };
 
+  template <type_id_t Src0TypeID>
+  struct inline_sqrt {
+    static auto f(typename type_of<Src0TypeID>::type a) { return std::sqrt(a); }
+  };
+
   // Arithmetic operators that need zero checking.
   template <type_id_t Src0TypeID, type_id_t Src1TypeID>
   constexpr bool needs_zero_check() {

--- a/include/dynd/math.hpp
+++ b/include/dynd/math.hpp
@@ -52,86 +52,72 @@ template <typename T>
 T _nan(const char *arg); // nan
 
 template <>
-inline float _e<float>()
-{
+inline float _e<float>() {
   return 2.718281828459045235360287471352662498f;
 }
 
 template <>
-inline float _log2_e<float>()
-{
+inline float _log2_e<float>() {
   return 1.442695040888963407359924681001892137f;
 }
 
 template <>
-inline float _log10_e<float>()
-{
+inline float _log10_e<float>() {
   return 0.434294481903251827651128918916605082f;
 }
 
 template <>
-inline float _log_2<float>()
-{
+inline float _log_2<float>() {
   return 0.693147180559945309417232121458176568f;
 }
 
 template <>
-inline float _log_10<float>()
-{
+inline float _log_10<float>() {
   return 2.302585092994045684017991454684364208f;
 }
 
 template <>
-inline float _pi<float>()
-{
+inline float _pi<float>() {
   return 3.141592653589793238462643383279502884f;
 }
 
 template <>
-inline float _2_pi<float>()
-{
+inline float _2_pi<float>() {
   return 6.283185307179586231995926937088370323f;
 }
 
 template <>
-inline float _pi_by_2<float>()
-{
+inline float _pi_by_2<float>() {
   return 1.570796326794896619231321691639751442f;
 }
 
 template <>
-inline float _pi_by_4<float>()
-{
+inline float _pi_by_4<float>() {
   return 0.785398163397448309615660845819875721f;
 }
 
 template <>
-inline float _1_by_pi<float>()
-{
+inline float _1_by_pi<float>() {
   return 0.318309886183790671537767526745028724f;
 }
 
 template <>
-inline float _2_by_pi<float>()
-{
+inline float _2_by_pi<float>() {
   return 0.636619772367581343075535053490057448f;
 }
 
 template <>
-inline float _sqrt_2<float>()
-{
+inline float _sqrt_2<float>() {
   return 1.414213562373095048801688724209698079f;
 }
 
 template <>
-inline float _1_by_sqrt_2<float>()
-{
+inline float _1_by_sqrt_2<float>() {
   return 0.707106781186547524400844362104849039f;
 }
 
 template <>
-inline float _nan(const char *arg)
-{
+inline float _nan(const char *arg) {
 #ifdef __CUDACC__
   return ::nanf(arg);
 #else
@@ -140,86 +126,72 @@ inline float _nan(const char *arg)
 }
 
 template <>
-inline double _e<double>()
-{
+inline double _e<double>() {
   return 2.718281828459045235360287471352662498;
 }
 
 template <>
-inline double _log2_e<double>()
-{
+inline double _log2_e<double>() {
   return 1.442695040888963407359924681001892137;
 }
 
 template <>
-inline double _log10_e<double>()
-{
+inline double _log10_e<double>() {
   return 0.434294481903251827651128918916605082;
 }
 
 template <>
-inline double _log_2<double>()
-{
+inline double _log_2<double>() {
   return 0.693147180559945309417232121458176568;
 }
 
 template <>
-inline double _log_10<double>()
-{
+inline double _log_10<double>() {
   return 2.302585092994045684017991454684364208;
 }
 
 template <>
-inline double _pi<double>()
-{
+inline double _pi<double>() {
   return 3.141592653589793238462643383279502884;
 }
 
 template <>
-inline double _2_pi<double>()
-{
+inline double _2_pi<double>() {
   return 6.283185307179586231995926937088370323;
 }
 
 template <>
-inline double _pi_by_2<double>()
-{
+inline double _pi_by_2<double>() {
   return 1.570796326794896619231321691639751442;
 }
 
 template <>
-inline double _pi_by_4<double>()
-{
+inline double _pi_by_4<double>() {
   return 0.785398163397448309615660845819875721;
 }
 
 template <>
-inline double _1_by_pi<double>()
-{
+inline double _1_by_pi<double>() {
   return 0.318309886183790671537767526745028724;
 }
 
 template <>
-inline double _2_by_pi<double>()
-{
+inline double _2_by_pi<double>() {
   return 0.636619772367581343075535053490057448;
 }
 
 template <>
-inline double _sqrt_2<double>()
-{
+inline double _sqrt_2<double>() {
   return 1.414213562373095048801688724209698079;
 }
 
 template <>
-inline double _1_by_sqrt_2<double>()
-{
+inline double _1_by_sqrt_2<double>() {
   return 0.707106781186547524400844362104849039;
 }
 
 template <>
-inline double _nan(const char *arg)
-{
+inline double _nan(const char *arg) {
 #ifdef __CUDACC__
   return ::nan(arg);
 #else
@@ -228,20 +200,17 @@ inline double _nan(const char *arg)
 }
 
 template <typename T>
-T abs(complex<T> z)
-{
+T abs(complex<T> z) {
   return static_cast<T>(hypot(z.real(), z.imag()));
 }
 
 template <typename T>
-T arg(complex<T> z)
-{
+T arg(complex<T> z) {
   return atan2(z.imag(), z.real());
 }
 
 template <typename T>
-complex<T> exp(complex<T> z)
-{
+complex<T> exp(complex<T> z) {
   T x, c, s;
   T r = z.real(), i = z.imag();
   complex<T> ret;
@@ -254,46 +223,38 @@ complex<T> exp(complex<T> z)
 
     if (isfinite(i)) {
       ret = complex<T>(x * c, x * s);
-    }
-    else {
+    } else {
       ret = complex<T>(_nan<T>(NULL), copysign(_nan<T>(NULL), i));
     }
-  }
-  else if (isnan(r)) {
+  } else if (isnan(r)) {
     // r is nan
     if (i == 0) {
       ret = complex<T>(r, 0);
-    }
-    else {
+    } else {
       ret = complex<T>(r, copysign(_nan<T>(NULL), i));
     }
-  }
-  else {
+  } else {
     // r is +- inf
     if (r > 0) {
       if (i == 0) {
         ret = complex<T>(r, i);
-      }
-      else if (isfinite(i)) {
+      } else if (isfinite(i)) {
         c = cos(i);
         s = sin(i);
 
         ret = complex<T>(r * c, r * s);
-      }
-      else {
+      } else {
         // x = +inf, y = +-inf | nan
         ret = complex<T>(r, _nan<T>(NULL));
       }
-    }
-    else {
+    } else {
       if (isfinite(i)) {
         x = exp(r);
         c = cos(i);
         s = sin(i);
 
         ret = complex<T>(x * c, x * s);
-      }
-      else {
+      } else {
         // x = -inf, y = nan | +i inf
         ret = complex<T>(0, 0);
       }
@@ -304,14 +265,12 @@ complex<T> exp(complex<T> z)
 }
 
 template <typename T>
-complex<T> log(complex<T> z)
-{
+complex<T> log(complex<T> z) {
   return complex<T>(log(abs(z)), arg(z));
 }
 
 template <typename T>
-inline complex<T> sqrt(complex<T> z)
-{
+inline complex<T> sqrt(complex<T> z) {
   using namespace std;
   // We risk spurious overflow for components >= DBL_MAX / (1 + sqrt(2))
   const T thresh = (std::numeric_limits<T>::max)() / (1 + ::sqrt(static_cast<T>(2)));
@@ -339,8 +298,7 @@ inline complex<T> sqrt(complex<T> z)
     // csqrt(-inf + y i) = 0 + inf i
     if (signbit(a)) {
       return complex<T>(std::fabs(b - b), copysign(a, b));
-    }
-    else {
+    } else {
       return complex<T>(a, copysign(b - b, b));
     }
   }
@@ -351,8 +309,7 @@ inline complex<T> sqrt(complex<T> z)
     a *= 0.25;
     b *= 0.25;
     scale = true;
-  }
-  else {
+  } else {
     scale = false;
   }
 
@@ -360,8 +317,7 @@ inline complex<T> sqrt(complex<T> z)
   if (a >= 0) {
     t = std::sqrt((a + hypot(a, b)) * 0.5);
     result = complex<T>(t, b / (2 * t));
-  }
-  else {
+  } else {
     t = std::sqrt((-a + hypot(a, b)) * 0.5);
     result = complex<T>(std::fabs(b) / (2 * t), copysign(t, b));
   }
@@ -369,15 +325,13 @@ inline complex<T> sqrt(complex<T> z)
   // Rescale
   if (scale) {
     return complex<T>(result.real() * 2, result.imag());
-  }
-  else {
+  } else {
     return result;
   }
 }
 
 template <typename T>
-complex<T> pow(complex<T> x, complex<T> y)
-{
+complex<T> pow(complex<T> x, complex<T> y) {
   T yr = y.real(), yi = y.imag();
 
   complex<T> b = log(x);
@@ -387,8 +341,7 @@ complex<T> pow(complex<T> x, complex<T> y)
 }
 
 template <typename T>
-complex<T> pow(complex<T> x, T y)
-{
+complex<T> pow(complex<T> x, T y) {
   complex<T> b = log(x);
   T br = b.real(), bi = b.imag();
 
@@ -396,15 +349,13 @@ complex<T> pow(complex<T> x, T y)
 }
 
 template <typename T>
-complex<T> cos(complex<T> z)
-{
+complex<T> cos(complex<T> z) {
   T x = z.real(), y = z.imag();
   return complex<T>(cos(x) * cosh(y), -(sin(x) * sinh(y)));
 }
 
 template <typename T>
-complex<T> sin(complex<T> z)
-{
+complex<T> sin(complex<T> z) {
   T x = z.real(), y = z.imag();
   return complex<T>(sin(x) * cosh(y), cos(x) * sinh(y));
 }

--- a/src/dynd/callable.cpp
+++ b/src/dynd/callable.cpp
@@ -49,6 +49,7 @@ std::map<std::string, nd::callable> &nd::detail::get_regfunctions() {
                                              {"bitwise_not", bitwise_not},
                                              {"bitwise_or", bitwise_or},
                                              {"bitwise_xor", bitwise_xor},
+                                             {"cbrt", cbrt},
                                              {"compound_add", compound_add},
                                              {"compound_div", compound_div},
                                              {"conj", conj},

--- a/src/dynd/callable.cpp
+++ b/src/dynd/callable.cpp
@@ -81,6 +81,7 @@ std::map<std::string, nd::callable> &nd::detail::get_regfunctions() {
                                              {"right_shift", right_shift},
                                              {"serialize", serialize},
                                              {"sin", sin},
+                                             {"sqrt", sqrt},
                                              {"subtract", subtract},
                                              {"sum", sum},
                                              {"take", take},

--- a/src/dynd/cbrt.cpp
+++ b/src/dynd/cbrt.cpp
@@ -1,0 +1,13 @@
+//
+// Copyright (C) 2011-16 DyND Developers
+// BSD 2-Clause License, see LICENSE.txt
+//
+
+#include <dynd/callables/cbrt_callable.hpp>
+#include <dynd/unary_arithmetic.hpp>
+
+template <type_id_t>
+using isdef_cbrt = std::true_type;
+
+DYND_API nd::callable nd::cbrt =
+    make_unary_arithmetic<nd::cbrt_callable, isdef_cbrt, type_id_sequence<float32_id, float64_id>>();

--- a/src/dynd/math.cpp
+++ b/src/dynd/math.cpp
@@ -3,14 +3,14 @@
 // BSD 2-Clause License, see LICENSE.txt
 //
 
-#include <dynd/math.hpp>
-#include <dynd/functional.hpp>
-#include <dynd/callables/conj_dispatch_callable.hpp>
-#include <dynd/callables/real_dispatch_callable.hpp>
-#include <dynd/callables/imag_dispatch_callable.hpp>
-#include <dynd/callables/imag_callable.hpp>
-#include <dynd/callables/real_callable.hpp>
 #include <dynd/callables/conj_callable.hpp>
+#include <dynd/callables/conj_dispatch_callable.hpp>
+#include <dynd/callables/imag_callable.hpp>
+#include <dynd/callables/imag_dispatch_callable.hpp>
+#include <dynd/callables/real_callable.hpp>
+#include <dynd/callables/real_dispatch_callable.hpp>
+#include <dynd/functional.hpp>
+#include <dynd/math.hpp>
 
 using namespace std;
 using namespace dynd;

--- a/src/dynd/sqrt.cpp
+++ b/src/dynd/sqrt.cpp
@@ -1,0 +1,13 @@
+//
+// Copyright (C) 2011-16 DyND Developers
+// BSD 2-Clause License, see LICENSE.txt
+//
+
+#include <dynd/callables/sqrt_callable.hpp>
+#include <dynd/unary_arithmetic.hpp>
+
+template <type_id_t>
+using isdef_sqrt = std::true_type;
+
+DYND_API nd::callable nd::sqrt =
+    make_unary_arithmetic<nd::sqrt_callable, isdef_sqrt, type_id_sequence<float32_id, float64_id>>();


### PR DESCRIPTION
For the time being, only provide overloads for float and double.