### PR TITLE
[WIP] "Requires" for kernel predicates

### DIFF
--- a/include/dynd/callables/uniform_callable.hpp
+++ b/include/dynd/callables/uniform_callable.hpp
@@ -14,11 +14,12 @@ namespace dynd {
 namespace nd {
   namespace random {
 
-    template <typename ReturnType, typename GeneratorType, typename Requires = void>
+    template <typename ReturnType, typename GeneratorType, typename Enable = void>
     class uniform_callable;
 
     template <typename ReturnType, typename GeneratorType>
-    class uniform_callable<ReturnType, GeneratorType, Requires<is_integral<ReturnType>::value>> : public base_callable {
+    class uniform_callable<ReturnType, GeneratorType, std::enable_if_t<is_integral<ReturnType>::value>>
+        : public base_callable {
     public:
       uniform_callable()
           : base_callable(ndt::make_type<ndt::callable_type>(
@@ -57,7 +58,7 @@ namespace nd {
     };
 
     template <typename ReturnType, typename GeneratorType>
-    class uniform_callable<ReturnType, GeneratorType, Requires<is_floating_point<ReturnType>::value>>
+    class uniform_callable<ReturnType, GeneratorType, std::enable_if_t<is_floating_point<ReturnType>::value>>
         : public base_callable {
     public:
       uniform_callable()
@@ -97,7 +98,8 @@ namespace nd {
     };
 
     template <typename ReturnType, typename GeneratorType>
-    class uniform_callable<ReturnType, GeneratorType, Requires<is_complex<ReturnType>::value>> : public base_callable {
+    class uniform_callable<ReturnType, GeneratorType, std::enable_if_t<is_complex<ReturnType>::value>>
+        : public base_callable {
     public:
       uniform_callable()
           : base_callable(ndt::make_type<ndt::callable_type>(

--- a/include/dynd/callables/uniform_callable.hpp
+++ b/include/dynd/callables/uniform_callable.hpp
@@ -50,7 +50,7 @@ namespace nd {
           cg.emplace_back([g, a, b](kernel_builder &kb, kernel_request_t kernreq, char *DYND_UNUSED(data),
                                     const char *DYND_UNUSED(dst_arrmeta), size_t DYND_UNUSED(nsrc),
                                     const char *const *DYND_UNUSED(src_arrmeta)) {
-            kb.emplace_back<uniform_kernel<ReturnType, ndt::int_kind_type, GeneratorType>>(kernreq, g.get(), a, b);
+            kb.emplace_back<uniform_kernel<ReturnType, GeneratorType>>(kernreq, g.get(), a, b);
           });
 
           return dst_tp;
@@ -93,7 +93,7 @@ namespace nd {
           cg.emplace_back([g, a, b](kernel_builder &kb, kernel_request_t kernreq, char *DYND_UNUSED(data),
                                     const char *DYND_UNUSED(dst_arrmeta), size_t DYND_UNUSED(nsrc),
                                     const char *const *DYND_UNUSED(src_arrmeta)) {
-            kb.emplace_back<uniform_kernel<ReturnType, ndt::float_kind_type, GeneratorType>>(kernreq, g.get(), a, b);
+            kb.emplace_back<uniform_kernel<ReturnType, GeneratorType>>(kernreq, g.get(), a, b);
           });
 
           return dst_tp;
@@ -132,7 +132,7 @@ namespace nd {
           cg.emplace_back([g, a, b](kernel_builder &kb, kernel_request_t kernreq, char *DYND_UNUSED(data),
                                     const char *DYND_UNUSED(dst_arrmeta), size_t DYND_UNUSED(nsrc),
                                     const char *const *DYND_UNUSED(src_arrmeta)) {
-            kb.emplace_back<uniform_kernel<ReturnType, ndt::complex_kind_type, GeneratorType>>(kernreq, g.get(), a, b);
+            kb.emplace_back<uniform_kernel<ReturnType, GeneratorType>>(kernreq, g.get(), a, b);
           });
 
           return dst_tp;

--- a/include/dynd/callables/uniform_callable.hpp
+++ b/include/dynd/callables/uniform_callable.hpp
@@ -13,136 +13,127 @@
 namespace dynd {
 namespace nd {
   namespace random {
-    namespace detail {
 
-      template <typename ReturnType, typename ReturnBaseType, typename GeneratorType>
-      class uniform_callable;
-
-      template <typename ReturnType, typename GeneratorType>
-      class uniform_callable<ReturnType, ndt::int_kind_type, GeneratorType> : public base_callable {
-      public:
-        uniform_callable()
-            : base_callable(ndt::make_type<ndt::callable_type>(
-                  ndt::make_type<ReturnType>(), {},
-                  {{ndt::make_type<ndt::option_type>(ndt::make_type<ReturnType>()), "a"},
-                   {ndt::make_type<ndt::option_type>(ndt::make_type<ReturnType>()), "b"}})) {}
-
-        ndt::type resolve(base_callable *DYND_UNUSED(caller), char *DYND_UNUSED(data), call_graph &cg,
-                          const ndt::type &dst_tp, size_t DYND_UNUSED(nsrc), const ndt::type *DYND_UNUSED(src_tp),
-                          size_t DYND_UNUSED(nkwd), const array *kwds,
-                          const std::map<std::string, ndt::type> &DYND_UNUSED(tp_vars)) {
-          std::shared_ptr<GeneratorType> g = get_random_device();
-
-          ReturnType a;
-          if (kwds[0].is_na()) {
-            a = 0;
-          } else {
-            a = kwds[0].as<ReturnType>();
-          }
-
-          ReturnType b;
-          if (kwds[1].is_na()) {
-            b = std::numeric_limits<ReturnType>::max();
-          } else {
-            b = kwds[1].as<ReturnType>();
-          }
-
-          cg.emplace_back([g, a, b](kernel_builder &kb, kernel_request_t kernreq, char *DYND_UNUSED(data),
-                                    const char *DYND_UNUSED(dst_arrmeta), size_t DYND_UNUSED(nsrc),
-                                    const char *const *DYND_UNUSED(src_arrmeta)) {
-            kb.emplace_back<uniform_kernel<ReturnType, GeneratorType>>(kernreq, g.get(), a, b);
-          });
-
-          return dst_tp;
-        }
-      };
-
-      template <typename ReturnType, typename GeneratorType>
-      class uniform_callable<ReturnType, ndt::uint_kind_type, GeneratorType>
-          : public uniform_callable<ReturnType, ndt::int_kind_type, GeneratorType> {};
-
-      template <typename ReturnType, typename GeneratorType>
-      class uniform_callable<ReturnType, ndt::float_kind_type, GeneratorType> : public base_callable {
-      public:
-        uniform_callable()
-            : base_callable(ndt::make_type<ndt::callable_type>(
-                  ndt::make_type<ReturnType>(), {},
-                  {{ndt::make_type<ndt::option_type>(ndt::make_type<ReturnType>()), "a"},
-                   {ndt::make_type<ndt::option_type>(ndt::make_type<ReturnType>()), "b"}})) {}
-
-        ndt::type resolve(base_callable *DYND_UNUSED(caller), char *DYND_UNUSED(data), call_graph &cg,
-                          const ndt::type &dst_tp, size_t DYND_UNUSED(nsrc), const ndt::type *DYND_UNUSED(src_tp),
-                          size_t DYND_UNUSED(nkwd), const array *kwds,
-                          const std::map<std::string, ndt::type> &DYND_UNUSED(tp_vars)) {
-          std::shared_ptr<GeneratorType> g = get_random_device();
-
-          ReturnType a;
-          if (kwds[0].is_na()) {
-            a = 0;
-          } else {
-            a = kwds[0].as<ReturnType>();
-          }
-
-          ReturnType b;
-          if (kwds[1].is_na()) {
-            b = 1;
-          } else {
-            b = kwds[1].as<ReturnType>();
-          }
-
-          cg.emplace_back([g, a, b](kernel_builder &kb, kernel_request_t kernreq, char *DYND_UNUSED(data),
-                                    const char *DYND_UNUSED(dst_arrmeta), size_t DYND_UNUSED(nsrc),
-                                    const char *const *DYND_UNUSED(src_arrmeta)) {
-            kb.emplace_back<uniform_kernel<ReturnType, GeneratorType>>(kernreq, g.get(), a, b);
-          });
-
-          return dst_tp;
-        }
-      };
-
-      template <typename ReturnType, typename GeneratorType>
-      class uniform_callable<ReturnType, ndt::complex_kind_type, GeneratorType> : public base_callable {
-      public:
-        uniform_callable()
-            : base_callable(ndt::make_type<ndt::callable_type>(
-                  ndt::make_type<ReturnType>(), {},
-                  {{ndt::make_type<ndt::option_type>(ndt::make_type<ReturnType>()), "a"},
-                   {ndt::make_type<ndt::option_type>(ndt::make_type<ReturnType>()), "b"}})) {}
-
-        ndt::type resolve(base_callable *DYND_UNUSED(caller), char *DYND_UNUSED(data), call_graph &cg,
-                          const ndt::type &dst_tp, size_t DYND_UNUSED(nsrc), const ndt::type *DYND_UNUSED(src_tp),
-                          size_t DYND_UNUSED(nkwd), const array *kwds,
-                          const std::map<std::string, ndt::type> &DYND_UNUSED(tp_vars)) {
-          std::shared_ptr<GeneratorType> g = get_random_device();
-
-          ReturnType a;
-          if (kwds[0].is_na()) {
-            a = ReturnType(0, 0);
-          } else {
-            a = kwds[0].as<ReturnType>();
-          }
-
-          ReturnType b;
-          if (kwds[1].is_na()) {
-            b = ReturnType(1, 1);
-          } else {
-            b = kwds[1].as<ReturnType>();
-          }
-
-          cg.emplace_back([g, a, b](kernel_builder &kb, kernel_request_t kernreq, char *DYND_UNUSED(data),
-                                    const char *DYND_UNUSED(dst_arrmeta), size_t DYND_UNUSED(nsrc),
-                                    const char *const *DYND_UNUSED(src_arrmeta)) {
-            kb.emplace_back<uniform_kernel<ReturnType, GeneratorType>>(kernreq, g.get(), a, b);
-          });
-
-          return dst_tp;
-        }
-      };
-
-    } // namespace dynd::nd::detail
+    template <typename ReturnType, typename GeneratorType, typename Requires = void>
+    class uniform_callable;
 
     template <typename ReturnType, typename GeneratorType>
-    using uniform_callable = detail::uniform_callable<ReturnType, ndt::base_of_t<ReturnType>, GeneratorType>;
+    class uniform_callable<ReturnType, GeneratorType, Requires<is_integral<ReturnType>::value>> : public base_callable {
+    public:
+      uniform_callable()
+          : base_callable(ndt::make_type<ndt::callable_type>(
+                ndt::make_type<ReturnType>(), {},
+                {{ndt::make_type<ndt::option_type>(ndt::make_type<ReturnType>()), "a"},
+                 {ndt::make_type<ndt::option_type>(ndt::make_type<ReturnType>()), "b"}})) {}
+
+      ndt::type resolve(base_callable *DYND_UNUSED(caller), char *DYND_UNUSED(data), call_graph &cg,
+                        const ndt::type &dst_tp, size_t DYND_UNUSED(nsrc), const ndt::type *DYND_UNUSED(src_tp),
+                        size_t DYND_UNUSED(nkwd), const array *kwds,
+                        const std::map<std::string, ndt::type> &DYND_UNUSED(tp_vars)) {
+        std::shared_ptr<GeneratorType> g = get_random_device();
+
+        ReturnType a;
+        if (kwds[0].is_na()) {
+          a = 0;
+        } else {
+          a = kwds[0].as<ReturnType>();
+        }
+
+        ReturnType b;
+        if (kwds[1].is_na()) {
+          b = std::numeric_limits<ReturnType>::max();
+        } else {
+          b = kwds[1].as<ReturnType>();
+        }
+
+        cg.emplace_back([g, a, b](kernel_builder &kb, kernel_request_t kernreq, char *DYND_UNUSED(data),
+                                  const char *DYND_UNUSED(dst_arrmeta), size_t DYND_UNUSED(nsrc),
+                                  const char *const *DYND_UNUSED(src_arrmeta)) {
+          kb.emplace_back<uniform_kernel<ReturnType, GeneratorType>>(kernreq, g.get(), a, b);
+        });
+
+        return dst_tp;
+      }
+    };
+
+    template <typename ReturnType, typename GeneratorType>
+    class uniform_callable<ReturnType, GeneratorType, Requires<is_floating_point<ReturnType>::value>>
+        : public base_callable {
+    public:
+      uniform_callable()
+          : base_callable(ndt::make_type<ndt::callable_type>(
+                ndt::make_type<ReturnType>(), {},
+                {{ndt::make_type<ndt::option_type>(ndt::make_type<ReturnType>()), "a"},
+                 {ndt::make_type<ndt::option_type>(ndt::make_type<ReturnType>()), "b"}})) {}
+
+      ndt::type resolve(base_callable *DYND_UNUSED(caller), char *DYND_UNUSED(data), call_graph &cg,
+                        const ndt::type &dst_tp, size_t DYND_UNUSED(nsrc), const ndt::type *DYND_UNUSED(src_tp),
+                        size_t DYND_UNUSED(nkwd), const array *kwds,
+                        const std::map<std::string, ndt::type> &DYND_UNUSED(tp_vars)) {
+        std::shared_ptr<GeneratorType> g = get_random_device();
+
+        ReturnType a;
+        if (kwds[0].is_na()) {
+          a = 0;
+        } else {
+          a = kwds[0].as<ReturnType>();
+        }
+
+        ReturnType b;
+        if (kwds[1].is_na()) {
+          b = 1;
+        } else {
+          b = kwds[1].as<ReturnType>();
+        }
+
+        cg.emplace_back([g, a, b](kernel_builder &kb, kernel_request_t kernreq, char *DYND_UNUSED(data),
+                                  const char *DYND_UNUSED(dst_arrmeta), size_t DYND_UNUSED(nsrc),
+                                  const char *const *DYND_UNUSED(src_arrmeta)) {
+          kb.emplace_back<uniform_kernel<ReturnType, GeneratorType>>(kernreq, g.get(), a, b);
+        });
+
+        return dst_tp;
+      }
+    };
+
+    template <typename ReturnType, typename GeneratorType>
+    class uniform_callable<ReturnType, GeneratorType, Requires<is_complex<ReturnType>::value>> : public base_callable {
+    public:
+      uniform_callable()
+          : base_callable(ndt::make_type<ndt::callable_type>(
+                ndt::make_type<ReturnType>(), {},
+                {{ndt::make_type<ndt::option_type>(ndt::make_type<ReturnType>()), "a"},
+                 {ndt::make_type<ndt::option_type>(ndt::make_type<ReturnType>()), "b"}})) {}
+
+      ndt::type resolve(base_callable *DYND_UNUSED(caller), char *DYND_UNUSED(data), call_graph &cg,
+                        const ndt::type &dst_tp, size_t DYND_UNUSED(nsrc), const ndt::type *DYND_UNUSED(src_tp),
+                        size_t DYND_UNUSED(nkwd), const array *kwds,
+                        const std::map<std::string, ndt::type> &DYND_UNUSED(tp_vars)) {
+        std::shared_ptr<GeneratorType> g = get_random_device();
+
+        ReturnType a;
+        if (kwds[0].is_na()) {
+          a = ReturnType(0, 0);
+        } else {
+          a = kwds[0].as<ReturnType>();
+        }
+
+        ReturnType b;
+        if (kwds[1].is_na()) {
+          b = ReturnType(1, 1);
+        } else {
+          b = kwds[1].as<ReturnType>();
+        }
+
+        cg.emplace_back([g, a, b](kernel_builder &kb, kernel_request_t kernreq, char *DYND_UNUSED(data),
+                                  const char *DYND_UNUSED(dst_arrmeta), size_t DYND_UNUSED(nsrc),
+                                  const char *const *DYND_UNUSED(src_arrmeta)) {
+          kb.emplace_back<uniform_kernel<ReturnType, GeneratorType>>(kernreq, g.get(), a, b);
+        });
+
+        return dst_tp;
+      }
+    };
 
   } // namespace dynd::nd::random
 } // namespace dynd::nd

--- a/include/dynd/config.hpp
+++ b/include/dynd/config.hpp
@@ -757,6 +757,9 @@ enum assign_error_mode {
   assign_error_default
 };
 
+template <bool Value>
+using Requires = std::enable_if_t<Value>;
+
 struct overflow_check_t {};
 
 inline std::ostream &operator<<(std::ostream &o, assign_error_mode errmode) {

--- a/include/dynd/config.hpp
+++ b/include/dynd/config.hpp
@@ -757,9 +757,6 @@ enum assign_error_mode {
   assign_error_default
 };
 
-template <bool Value>
-using Requires = std::enable_if_t<Value>;
-
 struct overflow_check_t {};
 
 inline std::ostream &operator<<(std::ostream &o, assign_error_mode errmode) {

--- a/include/dynd/kernels/assign_na_kernel.hpp
+++ b/include/dynd/kernels/assign_na_kernel.hpp
@@ -11,152 +11,137 @@
 
 namespace dynd {
 namespace nd {
-  namespace detail {
 
-    template <typename ReturnValueType, typename ReturnValueBaseType>
-    struct assign_na_kernel;
+  template <typename ReturnValueType, typename Enable = void>
+  struct assign_na_kernel;
 
-    template <>
-    struct assign_na_kernel<bool, ndt::bool_kind_type>
-        : base_strided_kernel<assign_na_kernel<bool, ndt::bool_kind_type>, 0> {
-      void single(char *dst, char *const *DYND_UNUSED(src)) { *dst = 2; }
+  template <>
+  struct assign_na_kernel<bool> : base_strided_kernel<assign_na_kernel<bool>, 0> {
+    void single(char *dst, char *const *DYND_UNUSED(src)) { *dst = 2; }
 
-      void strided(char *dst, intptr_t dst_stride, char *const *DYND_UNUSED(src),
-                   const intptr_t *DYND_UNUSED(src_stride), size_t count) {
-        if (dst_stride == 1) {
-          memset(dst, 2, count);
-        } else {
-          for (size_t i = 0; i != count; ++i, dst += dst_stride) {
-            *dst = 2;
-          }
+    void strided(char *dst, intptr_t dst_stride, char *const *DYND_UNUSED(src), const intptr_t *DYND_UNUSED(src_stride),
+                 size_t count) {
+      if (dst_stride == 1) {
+        memset(dst, 2, count);
+      } else {
+        for (size_t i = 0; i != count; ++i, dst += dst_stride) {
+          *dst = 2;
         }
       }
-    };
+    }
+  };
 
-    template <typename ReturnValueType>
-    struct assign_na_kernel<ReturnValueType, ndt::int_kind_type>
-        : base_strided_kernel<assign_na_kernel<ReturnValueType, ndt::int_kind_type>, 0> {
-      void single(char *dst, char *const *DYND_UNUSED(src)) {
+  template <typename ReturnValueType>
+  struct assign_na_kernel<ReturnValueType, std::enable_if_t<is_signed<ReturnValueType>::value>>
+      : base_strided_kernel<assign_na_kernel<ReturnValueType>, 0> {
+    void single(char *dst, char *const *DYND_UNUSED(src)) {
+      *reinterpret_cast<ReturnValueType *>(dst) = std::numeric_limits<ReturnValueType>::min();
+    }
+
+    void strided(char *dst, intptr_t dst_stride, char *const *DYND_UNUSED(src), const intptr_t *DYND_UNUSED(src_stride),
+                 size_t count) {
+      for (size_t i = 0; i != count; ++i, dst += dst_stride) {
         *reinterpret_cast<ReturnValueType *>(dst) = std::numeric_limits<ReturnValueType>::min();
       }
+    }
+  };
 
-      void strided(char *dst, intptr_t dst_stride, char *const *DYND_UNUSED(src),
-                   const intptr_t *DYND_UNUSED(src_stride), size_t count) {
-        for (size_t i = 0; i != count; ++i, dst += dst_stride) {
-          *reinterpret_cast<ReturnValueType *>(dst) = std::numeric_limits<ReturnValueType>::min();
-        }
-      }
-    };
+  template <typename ReturnValueType>
+  struct assign_na_kernel<ReturnValueType, std::enable_if_t<is_unsigned<ReturnValueType>::value>>
+      : base_strided_kernel<assign_na_kernel<ReturnValueType>, 0> {
+    void single(char *dst, char *const *DYND_UNUSED(src)) {
+      *reinterpret_cast<ReturnValueType *>(dst) = std::numeric_limits<ReturnValueType>::max();
+    }
 
-    template <typename ReturnValueType>
-    struct assign_na_kernel<ReturnValueType, ndt::uint_kind_type>
-        : base_strided_kernel<assign_na_kernel<ReturnValueType, ndt::uint_kind_type>, 0> {
-      void single(char *dst, char *const *DYND_UNUSED(src)) {
+    void strided(char *dst, intptr_t dst_stride, char *const *DYND_UNUSED(src), const intptr_t *DYND_UNUSED(src_stride),
+                 size_t count) {
+      for (size_t i = 0; i != count; ++i, dst += dst_stride) {
         *reinterpret_cast<ReturnValueType *>(dst) = std::numeric_limits<ReturnValueType>::max();
       }
+    }
+  };
 
-      void strided(char *dst, intptr_t dst_stride, char *const *DYND_UNUSED(src),
-                   const intptr_t *DYND_UNUSED(src_stride), size_t count) {
-        for (size_t i = 0; i != count; ++i, dst += dst_stride) {
-          *reinterpret_cast<ReturnValueType *>(dst) = std::numeric_limits<ReturnValueType>::max();
-        }
-      }
-    };
+  template <>
+  struct assign_na_kernel<float> : base_strided_kernel<assign_na_kernel<float>, 0> {
+    void single(char *dst, char *const *DYND_UNUSED(src)) {
+      *reinterpret_cast<uint32_t *>(dst) = DYND_FLOAT32_NA_AS_UINT;
+    }
 
-    template <>
-    struct assign_na_kernel<float, ndt::float_kind_type>
-        : base_strided_kernel<assign_na_kernel<float, ndt::float_kind_type>, 0> {
-      void single(char *dst, char *const *DYND_UNUSED(src)) {
+    void strided(char *dst, intptr_t dst_stride, char *const *DYND_UNUSED(src), const intptr_t *DYND_UNUSED(src_stride),
+                 size_t count) {
+      for (size_t i = 0; i != count; ++i, dst += dst_stride) {
         *reinterpret_cast<uint32_t *>(dst) = DYND_FLOAT32_NA_AS_UINT;
       }
+    }
+  };
 
-      void strided(char *dst, intptr_t dst_stride, char *const *DYND_UNUSED(src),
-                   const intptr_t *DYND_UNUSED(src_stride), size_t count) {
-        for (size_t i = 0; i != count; ++i, dst += dst_stride) {
-          *reinterpret_cast<uint32_t *>(dst) = DYND_FLOAT32_NA_AS_UINT;
-        }
-      }
-    };
+  template <>
+  struct assign_na_kernel<double> : base_strided_kernel<assign_na_kernel<double>, 0> {
+    void single(char *dst, char *const *DYND_UNUSED(src)) {
+      *reinterpret_cast<uint64_t *>(dst) = DYND_FLOAT64_NA_AS_UINT;
+    }
 
-    template <>
-    struct assign_na_kernel<double, ndt::float_kind_type>
-        : base_strided_kernel<assign_na_kernel<double, ndt::float_kind_type>, 0> {
-      void single(char *dst, char *const *DYND_UNUSED(src)) {
+    void strided(char *dst, intptr_t dst_stride, char *const *DYND_UNUSED(src), const intptr_t *DYND_UNUSED(src_stride),
+                 size_t count) {
+      for (size_t i = 0; i != count; ++i, dst += dst_stride) {
         *reinterpret_cast<uint64_t *>(dst) = DYND_FLOAT64_NA_AS_UINT;
       }
+    }
+  };
 
-      void strided(char *dst, intptr_t dst_stride, char *const *DYND_UNUSED(src),
-                   const intptr_t *DYND_UNUSED(src_stride), size_t count) {
-        for (size_t i = 0; i != count; ++i, dst += dst_stride) {
-          *reinterpret_cast<uint64_t *>(dst) = DYND_FLOAT64_NA_AS_UINT;
-        }
-      }
-    };
+  template <>
+  struct assign_na_kernel<complex<float>> : base_strided_kernel<assign_na_kernel<complex<float>>, 0> {
+    void single(char *dst, char *const *DYND_UNUSED(src)) {
+      reinterpret_cast<uint32_t *>(dst)[0] = DYND_FLOAT32_NA_AS_UINT;
+      reinterpret_cast<uint32_t *>(dst)[1] = DYND_FLOAT32_NA_AS_UINT;
+    }
 
-    template <>
-    struct assign_na_kernel<complex<float>, ndt::complex_kind_type>
-        : base_strided_kernel<assign_na_kernel<complex<float>, ndt::complex_kind_type>, 0> {
-      void single(char *dst, char *const *DYND_UNUSED(src)) {
+    void strided(char *dst, intptr_t dst_stride, char *const *DYND_UNUSED(src), const intptr_t *DYND_UNUSED(src_stride),
+                 size_t count) {
+      for (size_t i = 0; i != count; ++i, dst += dst_stride) {
         reinterpret_cast<uint32_t *>(dst)[0] = DYND_FLOAT32_NA_AS_UINT;
         reinterpret_cast<uint32_t *>(dst)[1] = DYND_FLOAT32_NA_AS_UINT;
       }
+    }
+  };
 
-      void strided(char *dst, intptr_t dst_stride, char *const *DYND_UNUSED(src),
-                   const intptr_t *DYND_UNUSED(src_stride), size_t count) {
-        for (size_t i = 0; i != count; ++i, dst += dst_stride) {
-          reinterpret_cast<uint32_t *>(dst)[0] = DYND_FLOAT32_NA_AS_UINT;
-          reinterpret_cast<uint32_t *>(dst)[1] = DYND_FLOAT32_NA_AS_UINT;
-        }
-      }
-    };
+  template <>
+  struct assign_na_kernel<complex<double>> : base_strided_kernel<assign_na_kernel<complex<double>>, 0> {
+    void single(char *dst, char *const *DYND_UNUSED(src)) {
+      reinterpret_cast<uint64_t *>(dst)[0] = DYND_FLOAT64_NA_AS_UINT;
+      reinterpret_cast<uint64_t *>(dst)[1] = DYND_FLOAT64_NA_AS_UINT;
+    }
 
-    template <>
-    struct assign_na_kernel<complex<double>, ndt::complex_kind_type>
-        : base_strided_kernel<assign_na_kernel<complex<double>, ndt::complex_kind_type>, 0> {
-      void single(char *dst, char *const *DYND_UNUSED(src)) {
+    void strided(char *dst, intptr_t dst_stride, char *const *DYND_UNUSED(src), const intptr_t *DYND_UNUSED(src_stride),
+                 size_t count) {
+      for (size_t i = 0; i != count; ++i, dst += dst_stride) {
         reinterpret_cast<uint64_t *>(dst)[0] = DYND_FLOAT64_NA_AS_UINT;
         reinterpret_cast<uint64_t *>(dst)[1] = DYND_FLOAT64_NA_AS_UINT;
       }
+    }
+  };
 
-      void strided(char *dst, intptr_t dst_stride, char *const *DYND_UNUSED(src),
-                   const intptr_t *DYND_UNUSED(src_stride), size_t count) {
-        for (size_t i = 0; i != count; ++i, dst += dst_stride) {
-          reinterpret_cast<uint64_t *>(dst)[0] = DYND_FLOAT64_NA_AS_UINT;
-          reinterpret_cast<uint64_t *>(dst)[1] = DYND_FLOAT64_NA_AS_UINT;
-        }
-      }
-    };
+  template <>
+  struct assign_na_kernel<void> : base_strided_kernel<assign_na_kernel<void>, 0> {
+    void single(char *DYND_UNUSED(dst), char *const *DYND_UNUSED(src)) {}
+  };
 
-    template <>
-    struct assign_na_kernel<void, ndt::any_kind_type>
-        : base_strided_kernel<assign_na_kernel<void, ndt::any_kind_type>, 0> {
-      void single(char *DYND_UNUSED(dst), char *const *DYND_UNUSED(src)) {}
-    };
+  template <>
+  struct assign_na_kernel<ndt::pointer_type> : base_strided_kernel<assign_na_kernel<ndt::pointer_type>, 0> {
+    void single(char *DYND_UNUSED(dst), char *const *DYND_UNUSED(src)) {
+      throw std::runtime_error("assign_na for pointers is not yet implemented");
+    }
+  };
 
-    template <>
-    struct assign_na_kernel<ndt::pointer_type, ndt::any_kind_type>
-        : base_strided_kernel<assign_na_kernel<ndt::pointer_type, ndt::any_kind_type>, 0> {
-      void single(char *DYND_UNUSED(dst), char *const *DYND_UNUSED(src)) {
-        throw std::runtime_error("assign_na for pointers is not yet implemented");
-      }
-    };
+  template <>
+  struct assign_na_kernel<bytes> : base_strided_kernel<assign_na_kernel<bytes>, 1> {
+    void single(char *res, char *const *DYND_UNUSED(args)) { reinterpret_cast<bytes *>(res)->clear(); }
+  };
 
-    template <>
-    struct assign_na_kernel<bytes, ndt::bytes_kind_type>
-        : base_strided_kernel<assign_na_kernel<bytes, ndt::bytes_kind_type>, 1> {
-      void single(char *res, char *const *DYND_UNUSED(args)) { reinterpret_cast<bytes *>(res)->clear(); }
-    };
-
-    template <>
-    struct assign_na_kernel<string, ndt::string_kind_type>
-        : base_strided_kernel<assign_na_kernel<string, ndt::string_kind_type>, 1> {
-      void single(char *res, char *const *DYND_UNUSED(args)) { reinterpret_cast<bytes *>(res)->clear(); }
-    };
-
-  } // namespace dynd::nd::detail
-
-  template <typename ReturnValueType>
-  using assign_na_kernel = detail::assign_na_kernel<ReturnValueType, ndt::base_of_t<ReturnValueType>>;
+  template <>
+  struct assign_na_kernel<string> : base_strided_kernel<assign_na_kernel<string>, 1> {
+    void single(char *res, char *const *DYND_UNUSED(args)) { reinterpret_cast<bytes *>(res)->clear(); }
+  };
 
 } // namespace dynd::nd
 } // namespace dynd

--- a/include/dynd/kernels/uniform_kernel.hpp
+++ b/include/dynd/kernels/uniform_kernel.hpp
@@ -39,64 +39,48 @@ inline std::shared_ptr<std::default_random_engine> &get_random_device() {
   return g;
 }
 
-template <typename T>
-constexpr bool is_integral_v = is_integral<T>::value;
-
-template <typename T>
-constexpr bool is_floating_point_v = is_floating_point<T>::value;
-
-template <typename T>
-constexpr bool is_complex_v = is_complex<T>::value;
-
 namespace nd {
   namespace random {
-    namespace detail {
 
-      template <typename ReturnType, typename GeneratorType, typename Enable = void>
-      struct uniform_kernel;
-
-      template <typename ReturnType, typename GeneratorType>
-      struct uniform_kernel<ReturnType, GeneratorType, Requires<is_integral_v<ReturnType>>>
-          : base_strided_kernel<uniform_kernel<ReturnType, GeneratorType, Requires<is_integral_v<ReturnType>>>, 0> {
-        GeneratorType &g;
-        std::uniform_int_distribution<ReturnType> d;
-
-        uniform_kernel(GeneratorType *g, ReturnType a, ReturnType b) : g(*g), d(a, b) {}
-
-        void single(char *dst, char *const *DYND_UNUSED(src)) { *reinterpret_cast<ReturnType *>(dst) = d(g); }
-      };
-
-      template <typename ReturnType, typename GeneratorType>
-      struct uniform_kernel<ReturnType, GeneratorType, Requires<is_floating_point_v<ReturnType>>>
-          : base_strided_kernel<uniform_kernel<ReturnType, GeneratorType, Requires<is_floating_point_v<ReturnType>>>,
-                                0> {
-        GeneratorType &g;
-        std::uniform_real_distribution<ReturnType> d;
-
-        uniform_kernel(GeneratorType *g, ReturnType a, ReturnType b) : g(*g), d(a, b) {}
-
-        void single(char *dst, char *const *DYND_UNUSED(src)) { *reinterpret_cast<ReturnType *>(dst) = d(g); }
-      };
-
-      template <typename ReturnType, typename GeneratorType>
-      struct uniform_kernel<ReturnType, GeneratorType, Requires<is_complex_v<ReturnType>>>
-          : base_strided_kernel<uniform_kernel<ReturnType, GeneratorType, Requires<is_complex_v<ReturnType>>>, 0> {
-        GeneratorType &g;
-        std::uniform_real_distribution<typename ReturnType::value_type> d_real;
-        std::uniform_real_distribution<typename ReturnType::value_type> d_imag;
-
-        uniform_kernel(GeneratorType *g, ReturnType a, ReturnType b)
-            : g(*g), d_real(a.real(), b.real()), d_imag(a.imag(), b.imag()) {}
-
-        void single(char *dst, char *const *DYND_UNUSED(src)) {
-          *reinterpret_cast<ReturnType *>(dst) = ReturnType(d_real(g), d_imag(g));
-        }
-      };
-
-    } // namespace dynd::nd::random::detail
+    template <typename ReturnType, typename GeneratorType, typename Enable = void>
+    struct uniform_kernel;
 
     template <typename ReturnType, typename GeneratorType>
-    using uniform_kernel = detail::uniform_kernel<ReturnType, GeneratorType>;
+    struct uniform_kernel<ReturnType, GeneratorType, Requires<is_integral<ReturnType>::value>>
+        : base_strided_kernel<uniform_kernel<ReturnType, GeneratorType>, 0> {
+      GeneratorType &g;
+      std::uniform_int_distribution<ReturnType> d;
+
+      uniform_kernel(GeneratorType *g, ReturnType a, ReturnType b) : g(*g), d(a, b) {}
+
+      void single(char *dst, char *const *DYND_UNUSED(src)) { *reinterpret_cast<ReturnType *>(dst) = d(g); }
+    };
+
+    template <typename ReturnType, typename GeneratorType>
+    struct uniform_kernel<ReturnType, GeneratorType, Requires<is_floating_point<ReturnType>::value>>
+        : base_strided_kernel<uniform_kernel<ReturnType, GeneratorType>, 0> {
+      GeneratorType &g;
+      std::uniform_real_distribution<ReturnType> d;
+
+      uniform_kernel(GeneratorType *g, ReturnType a, ReturnType b) : g(*g), d(a, b) {}
+
+      void single(char *dst, char *const *DYND_UNUSED(src)) { *reinterpret_cast<ReturnType *>(dst) = d(g); }
+    };
+
+    template <typename ReturnType, typename GeneratorType>
+    struct uniform_kernel<ReturnType, GeneratorType, Requires<is_complex<ReturnType>::value>>
+        : base_strided_kernel<uniform_kernel<ReturnType, GeneratorType>, 0> {
+      GeneratorType &g;
+      std::uniform_real_distribution<typename ReturnType::value_type> d_real;
+      std::uniform_real_distribution<typename ReturnType::value_type> d_imag;
+
+      uniform_kernel(GeneratorType *g, ReturnType a, ReturnType b)
+          : g(*g), d_real(a.real(), b.real()), d_imag(a.imag(), b.imag()) {}
+
+      void single(char *dst, char *const *DYND_UNUSED(src)) {
+        *reinterpret_cast<ReturnType *>(dst) = ReturnType(d_real(g), d_imag(g));
+      }
+    };
 
   } // namespace dynd::nd::random
 } // namespace dynd::nd

--- a/include/dynd/kernels/uniform_kernel.hpp
+++ b/include/dynd/kernels/uniform_kernel.hpp
@@ -13,25 +13,6 @@
 
 namespace dynd {
 
-/*
-template <bool Condition, typename Type = int>
-struct RequiresC_F {
-  using type = Type;
-};
-
-template <typename Type>
-struct RequiresC_F<false, Type> {};
-
-template <bool Condition, typename Type>
-using RequiresC = typename RequiresC_F<Condition, Type>::type;
-
-template <typename Condition, typename Type = int>
-using Requires = RequiresC<Condition::value, Type>;
-*/
-
-template <bool Value>
-using Requires = std::enable_if_t<Value>;
-
 inline std::shared_ptr<std::default_random_engine> &get_random_device() {
   static std::random_device random_device;
   static std::shared_ptr<std::default_random_engine> g(new std::default_random_engine(random_device()));
@@ -42,7 +23,7 @@ inline std::shared_ptr<std::default_random_engine> &get_random_device() {
 namespace nd {
   namespace random {
 
-    template <typename ReturnType, typename GeneratorType, typename Enable = void>
+    template <typename ReturnType, typename GeneratorType, typename Requires = void>
     struct uniform_kernel;
 
     template <typename ReturnType, typename GeneratorType>

--- a/include/dynd/kernels/uniform_kernel.hpp
+++ b/include/dynd/kernels/uniform_kernel.hpp
@@ -23,11 +23,11 @@ inline std::shared_ptr<std::default_random_engine> &get_random_device() {
 namespace nd {
   namespace random {
 
-    template <typename ReturnType, typename GeneratorType, typename Requires = void>
+    template <typename ReturnType, typename GeneratorType, typename Enable = void>
     struct uniform_kernel;
 
     template <typename ReturnType, typename GeneratorType>
-    struct uniform_kernel<ReturnType, GeneratorType, Requires<is_integral<ReturnType>::value>>
+    struct uniform_kernel<ReturnType, GeneratorType, std::enable_if_t<is_integral<ReturnType>::value>>
         : base_strided_kernel<uniform_kernel<ReturnType, GeneratorType>, 0> {
       GeneratorType &g;
       std::uniform_int_distribution<ReturnType> d;
@@ -38,7 +38,7 @@ namespace nd {
     };
 
     template <typename ReturnType, typename GeneratorType>
-    struct uniform_kernel<ReturnType, GeneratorType, Requires<is_floating_point<ReturnType>::value>>
+    struct uniform_kernel<ReturnType, GeneratorType, std::enable_if_t<is_floating_point<ReturnType>::value>>
         : base_strided_kernel<uniform_kernel<ReturnType, GeneratorType>, 0> {
       GeneratorType &g;
       std::uniform_real_distribution<ReturnType> d;
@@ -49,7 +49,7 @@ namespace nd {
     };
 
     template <typename ReturnType, typename GeneratorType>
-    struct uniform_kernel<ReturnType, GeneratorType, Requires<is_complex<ReturnType>::value>>
+    struct uniform_kernel<ReturnType, GeneratorType, std::enable_if_t<is_complex<ReturnType>::value>>
         : base_strided_kernel<uniform_kernel<ReturnType, GeneratorType>, 0> {
       GeneratorType &g;
       std::uniform_real_distribution<typename ReturnType::value_type> d_real;


### PR DESCRIPTION
This is my attempt to allow more finer-grained control of kernel instantiation. It also switches us off using base types as a template enabler, which means we no longer need to know the DyND base of a DyND type at compile time.

Ultimately, this was very easy. Check out uniform_kernel.hpp. We can do exactly what we want with `std::enable_if_t`. However, to make it look more like the syntax we use there, I added a
`template <bool Value> using Requires = std::enable_if_t<Value>;` template alias. Please let me know if you think we should keep `Requires`, or just use `std::enable_if_t` directly.

Pinging @insertinterestingnamehere @mwiebe 