### PR TITLE
Clean up conda recipe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,6 @@ matrix:
       before_script:
         - export CC="gcc-4.9"
         - export CXX="g++-4.9"
-        - export SHORT_COMMIT="$(git rev-parse --short $TRAVIS_COMMIT)"
       script:
         - conda build conda.recipe
     - language: objective-c
@@ -68,7 +67,6 @@ matrix:
       env: CONDA=true
       addons:
       before_script:
-        - export SHORT_COMMIT="$(git rev-parse --short $TRAVIS_COMMIT)"
       before_install:
         - wget https://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-x86_64.sh
         - bash Miniconda-latest-MacOSX-x86_64.sh -b
@@ -85,22 +83,18 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
             - kalakris-cmake
-#            - llvm-toolchain-precise-3.5
+            - llvm-toolchain-precise-3.5
           packages:
-            - gcc-4.9
-            - g++-4.9
-  #          - clang-3.5
+            - clang-3.5
             - cmake
       cache:
       directories:
         - $HOME/.cache/pip
         - $HOME/dynd-python/build
       before_install:
-#        - export CC=clang-3.5
-#        - export CXX=clang++-3.5
-        - export CC=gcc-4.9
-        - export CXX=g++-4.9
-        - travis_retry pip install --install-option="--no-cython-compile" Cython==0.23
+        - export CC=clang-3.5
+        - export CXX=clang++-3.5
+        - travis_retry pip install --install-option="--no-cython-compile" Cython==0.24
       before_script:
         - cd ..
         - travis_retry git clone --depth=1 https://github.com/libdynd/dynd-python.git
@@ -111,7 +105,6 @@ matrix:
         - cd ..
         - python -c "import dynd; dynd.test(verbosity=2, exit=True)"
       after_script:
-        - cd .
     - compiler: gcc
       env: DYND_FFTW=ON DYND_COVERAGE=ON
       addons:
@@ -120,19 +113,19 @@ matrix:
             - ubuntu-toolchain-r-test
             - kalakris-cmake
           packages:
-            - gcc-5
-            - g++-5
+            - gcc-6
+            - g++-6
             - cmake
             - lcov
             - libfftw3-dev
       before_install:
-        - export CC="gcc-5"
-        - export CXX="g++-5"
+        - export CC="gcc-6"
+        - export CXX="g++-6"
         - gem install coveralls-lcov
         - wget https://github.com/linux-test-project/lcov/archive/v1.12.zip
         - unzip v1.12.zip
         - export PATH=${PWD}/lcov-1.12/bin:$PATH
-        - cp /usr/bin/gcov-5 ${PWD}/lcov-1.12/bin/gcov
+        - cp /usr/bin/gcov-6 ${PWD}/lcov-1.12/bin/gcov
       before_script:
         - mkdir build
         - pushd build
@@ -177,7 +170,6 @@ deploy:
 
 notifications:
   email: false
-  flowdock: b08b3ba4fb86fa48121e90b5f67ccb75
   on_success: change
   on_failure: always
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,17 +83,17 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
             - kalakris-cmake
-            - llvm-toolchain-precise-3.5
+            - llvm-toolchain-precise-3.8
           packages:
-            - clang-3.5
+            - clang-3.8
             - cmake
       cache:
       directories:
         - $HOME/.cache/pip
         - $HOME/dynd-python/build
       before_install:
-        - export CC=clang-3.5
-        - export CXX=clang++-3.5
+        - export CC=clang-3.8
+        - export CXX=clang++-3.8
         - travis_retry pip install --install-option="--no-cython-compile" Cython==0.24
       before_script:
         - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,24 +76,24 @@ matrix:
         - conda build conda.recipe
     - language: python
       env: DYND_FFTW=OFF VERBOSE=1
-      compiler: clang
+      compiler: gcc
       python: 3.5
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
             - kalakris-cmake
-            - llvm-toolchain-precise-3.8
+            - ubuntu-toolchain-r-test
           packages:
-            - clang-3.8
+            - gcc-6
+            - g++-6
             - cmake
       cache:
       directories:
         - $HOME/.cache/pip
         - $HOME/dynd-python/build
       before_install:
-        - export CC=clang-3.8
-        - export CXX=clang++-3.8
+        - export CC=gcc-6
+        - export CXX=g++-6
         - travis_retry pip install --install-option="--no-cython-compile" Cython==0.24
       before_script:
         - cd ..

--- a/conda.recipe/bld.bat
+++ b/conda.recipe/bld.bat
@@ -1,6 +1,5 @@
-cd %RECIPE_DIR%
+cd %RECIPE_DIR%/..
 
-cd ..
 mkdir build
 cd build
 
@@ -8,12 +7,14 @@ cd build
 if "%ARCH%" == "32" set CMAKE_GENERATOR=Visual Studio 14
 if "%ARCH%" == "64" set CMAKE_GENERATOR=Visual Studio 14 Win64
 
+:: Do parallel builds everywhere except AppVeyor
+if not "%APPVEYOR%" == "True" (set ADDITIONAL_FLAGS="-MP") else (set ADDITIONAL_FLAGS="")
+
 :: Configure step
-cmake -G "%CMAKE_GENERATOR%" -DCMAKE_BUILD_TYPE=Release -DDYND_INSTALL_LIB=ON -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% -DCMAKE_INSTALL_PREFIX:PATH=%LIBRARY_PREFIX% .. || exit /b 1
+cmake -G "%CMAKE_GENERATOR%" -DCMAKE_BUILD_TYPE=Release -DDYND_INSTALL_LIB=ON -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% -DCMAKE_INSTALL_PREFIX:PATH=%LIBRARY_PREFIX% -DCMAKE_CXX_FLAGS=%ADDITIONAL_FLAGS% .. || exit /b 1
 
 :: Build step
 cmake --build . --config Release || exit /b 1
 
 :: Install step
 cmake --build . --config Release --target install || exit /b 1
-

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -1,42 +1,22 @@
-#!/bin/bash
-set -ex
+#!/usr/bin/env sh
 
-cd $RECIPE_DIR
+cd "$RECIPE_DIR/.."
 
-echo Setting the compiler flags...
-if [ `uname` == Linux ]; then
-    SHARED_LINKER_FLAGS='-static-libstdc++'
-elif [ `uname` == Darwin ]; then
-    SHARED_LINKER_FLAGS=''
-fi
-
-#elif [ `uname` == Darwin ]; then
- #   export CC="$PREFIX/bin/gcc"
-  #  export CXX="$PREFIX/bin/g++"
-#    CPPFLAGS="-stdlib=libc++"
-  #  EXTRAOPTIONS="-DCMAKE_OSX_DEPLOYMENT_TARGET=10.9"
-   # MACOSX_DEPLOYMENT_TARGET=10.9
-#else
- #   CPPFLAGS=
-  #  EXTRAOPTIONS=
-#fi
-
-echo Creating build directory...
-cd ..
 mkdir build
 cd build
-pwd
-echo Configuring build with cmake...
 cmake \
-    $EXTRAOPTIONS \
     -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 \
     -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_SHARED_LINKER_FLAGS=$SHARED_LINKER_FLAGS \
     -DDYND_INSTALL_LIB=ON \
     -DDYND_BUILD_BENCHMARKS=OFF \
-    -DCMAKE_INSTALL_PREFIX=$PREFIX .. || exit 1
-echo Building with make...
-# We should use the CPU_COUNT environment variable set by conda-build, but Travis CI has issues with that.
-make -j4 package || exit 1
-echo Installing the build...
+    -DCMAKE_INSTALL_PREFIX="$PREFIX" .. || exit 1
+
+if [ $TRAVIS = true ]
+then
+    export NBUILDS=4
+else
+    export NBUILDS=$(($CPU_COUNT * 2))
+fi
+
+make -j$NBUILDS package || exit 1
 make install || exit 1

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -5,14 +5,12 @@ package:
 requirements:
   build:
     - cmake
-    - python
+  run:
+    - libgcc >=5.2     # [linux]
 
 build:
   number: {{environ.get('TRAVIS_BUILD_NUMBER', 0)}}    # [unix]
   number: {{environ.get('APPVEYOR_BUILD_NUMBER', 0)}}  # [win]
-  script_env:
-    - CC [linux]
-    - CXX [linux]
 
 test:
   commands:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -11,6 +11,12 @@ requirements:
 build:
   number: {{environ.get('TRAVIS_BUILD_NUMBER', 0)}}    # [unix]
   number: {{environ.get('APPVEYOR_BUILD_NUMBER', 0)}}  # [win]
+  # Make sure the CC and CXX environment variables are forwarded to the build script.
+  script_env:
+    - CC       # [linux]
+    - CXX      # [linux]
+    - TRAVIS   # [unix]
+    - APPVEYOR # [win]
 
 test:
   commands:


### PR DESCRIPTION
Auto-detect the number of processors and use that to build the
conda package in parallel on non-CI systems.
Stop statically linking libstdc++.
Clear out some dead code.