### PR TITLE
Move callable_type fully into libdynd from libdyndt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,6 @@ set(libdyndt_SRC
     src/dynd/types/base_string_type.cpp
     src/dynd/types/bytes_type.cpp
     src/dynd/types/categorical_kind_type.cpp
-    src/dynd/types/callable_type.cpp
     src/dynd/types/char_type.cpp
     src/dynd/types/complex_kind_type.cpp
     src/dynd/types/cuda_device_type.cpp
@@ -216,7 +215,6 @@ set(libdyndt_SRC
     include/dynd/types/base_dim_type.hpp
     include/dynd/types/base_string_type.hpp
     include/dynd/types/bytes_type.hpp
-    include/dynd/types/callable_type.hpp
     include/dynd/types/categorical_kind_type.hpp
     include/dynd/types/char_type.hpp
     include/dynd/types/complex_kind_type.hpp
@@ -287,9 +285,11 @@ set(libdyndt_SRC
 set(libdynd_SRC
     # Types
     src/dynd/types/adapt_type.cpp
+    src/dynd/types/callable_type.cpp
     src/dynd/types/categorical_type.cpp
     src/dynd/types/substitute_shape.cpp
     include/dynd/types/adapt_type.hpp
+    include/dynd/types/callable_type.hpp
     include/dynd/types/categorical_type.hpp
     include/dynd/types/substitute_shape.hpp
     # Callables

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,7 @@ set(libdyndt_SRC
     include/dynd/types/datashape_formatter.hpp
     include/dynd/types/datashape_parser.hpp
     include/dynd/types/dim_kind_type.hpp
+    include/dynd/types/ellipsis_dim_type.hpp
     include/dynd/types/fixed_bytes_type.hpp
     include/dynd/types/fixed_dim_type.hpp
     include/dynd/types/fixed_dim_kind_type.hpp
@@ -294,6 +295,7 @@ set(libdynd_SRC
     include/dynd/types/substitute_shape.hpp
     # Callables
     src/dynd/callables/base_callable.cpp
+    include/dynd/callables/assign_callable.hpp
     include/dynd/callables/base_callable.hpp
     include/dynd/callables/base_dispatch_callable.hpp
     # Kernels

--- a/include/dynd/callables/all_callable.hpp
+++ b/include/dynd/callables/all_callable.hpp
@@ -13,7 +13,9 @@ namespace nd {
 
   class all_callable : public default_instantiable_callable<all_kernel> {
   public:
-    all_callable() : default_instantiable_callable<all_kernel>(ndt::type("(bool) -> bool")) {}
+    all_callable()
+        : default_instantiable_callable<all_kernel>(
+              ndt::make_type<ndt::callable_type>(ndt::make_type<bool>(), {ndt::make_type<bool>()})) {}
   };
 
 } // namespace dynd::nd

--- a/include/dynd/callables/assign_callable.hpp
+++ b/include/dynd/callables/assign_callable.hpp
@@ -828,7 +828,10 @@ namespace nd {
 
   class option_to_value_callable : public base_callable {
   public:
-    option_to_value_callable() : base_callable(ndt::type("(?Any) -> Scalar")) {}
+    option_to_value_callable()
+        : base_callable(ndt::make_type<ndt::callable_type>(
+              ndt::make_type<ndt::scalar_kind_type>(),
+              {ndt::make_type<ndt::option_type>(ndt::make_type<ndt::any_kind_type>())})) {}
 
     ndt::type resolve(base_callable *DYND_UNUSED(caller), char *DYND_UNUSED(data), call_graph &cg,
                       const ndt::type &dst_tp, size_t DYND_UNUSED(nsrc), const ndt::type *src_tp, size_t nkwd,
@@ -860,7 +863,9 @@ namespace nd {
 
   class adapt_assign_from_callable : public base_callable {
   public:
-    adapt_assign_from_callable() : base_callable(ndt::type("(Any) -> Any")) {}
+    adapt_assign_from_callable()
+        : base_callable(ndt::make_type<ndt::callable_type>(ndt::make_type<ndt::any_kind_type>(),
+                                                           {ndt::make_type<ndt::any_kind_type>()})) {}
 
     ndt::type resolve(base_callable *DYND_UNUSED(caller), char *DYND_UNUSED(data), call_graph &DYND_UNUSED(cg),
                       const ndt::type &dst_tp, size_t DYND_UNUSED(nsrc), const ndt::type *DYND_UNUSED(src_tp),
@@ -908,7 +913,9 @@ namespace nd {
 
   class adapt_assign_to_callable : public base_callable {
   public:
-    adapt_assign_to_callable() : base_callable(ndt::type("(Any) -> Any")) {}
+    adapt_assign_to_callable()
+        : base_callable(ndt::make_type<ndt::callable_type>(ndt::make_type<ndt::any_kind_type>(),
+                                                           {ndt::make_type<ndt::any_kind_type>()})) {}
 
     ndt::type resolve(base_callable *DYND_UNUSED(caller), char *DYND_UNUSED(data), call_graph &cg,
                       const ndt::type &dst_tp, size_t nsrc, const ndt::type *DYND_UNUSED(src_tp), size_t nkwd,
@@ -924,7 +931,9 @@ namespace nd {
 
   class assignment_option_callable : public base_callable {
   public:
-    assignment_option_callable() : base_callable(ndt::type("(Scalar) -> ?Any")) {}
+    assignment_option_callable()
+        : base_callable(ndt::make_type<ndt::callable_type>(ndt::make_type<ndt::any_kind_type>(),
+                                                           {ndt::make_type<ndt::scalar_kind_type>()})) {}
 
     ndt::type resolve(base_callable *DYND_UNUSED(caller), char *DYND_UNUSED(data), call_graph &cg,
                       const ndt::type &dst_tp, size_t DYND_UNUSED(nsrc), const ndt::type *src_tp, size_t nkwd,

--- a/include/dynd/callables/byteswap_callable.hpp
+++ b/include/dynd/callables/byteswap_callable.hpp
@@ -13,7 +13,9 @@ namespace nd {
 
   class byteswap_callable : public base_callable {
   public:
-    byteswap_callable() : base_callable(ndt::type("(Any) -> Any")) {}
+    byteswap_callable()
+        : base_callable(ndt::make_type<ndt::callable_type>(ndt::make_type<ndt::any_kind_type>(),
+                                                           {ndt::make_type<ndt::any_kind_type>()})) {}
 
     ndt::type resolve(base_callable *DYND_UNUSED(caller), char *DYND_UNUSED(data), call_graph &cg,
                       const ndt::type &dst_tp, size_t DYND_UNUSED(nsrc), const ndt::type *src_tp,
@@ -32,7 +34,9 @@ namespace nd {
 
   class pairwise_byteswap_callable : public base_callable {
   public:
-    pairwise_byteswap_callable() : base_callable(ndt::type("(Any) -> Any")) {}
+    pairwise_byteswap_callable()
+        : base_callable(ndt::make_type<ndt::callable_type>(ndt::make_type<ndt::any_kind_type>(),
+                                                           {ndt::make_type<ndt::any_kind_type>()})) {}
 
     ndt::type resolve(base_callable *DYND_UNUSED(caller), char *DYND_UNUSED(data), call_graph &cg,
                       const ndt::type &dst_tp, size_t DYND_UNUSED(nsrc), const ndt::type *src_tp,

--- a/include/dynd/callables/copy_callable.hpp
+++ b/include/dynd/callables/copy_callable.hpp
@@ -5,15 +5,19 @@
 
 #pragma once
 
-#include <dynd/callables/base_callable.hpp>
 #include <dynd/assignment.hpp>
+#include <dynd/callables/base_callable.hpp>
+#include <dynd/types/ellipsis_dim_type.hpp>
 
 namespace dynd {
 namespace nd {
 
   class copy_callable : public base_callable {
   public:
-    copy_callable() : base_callable(ndt::type("(A... * S) -> B... * T")) {}
+    copy_callable()
+        : base_callable(ndt::make_type<ndt::callable_type>(
+              ndt::make_type<ndt::ellipsis_dim_type>("B", ndt::make_type<ndt::typevar_type>("T")),
+              {ndt::make_type<ndt::ellipsis_dim_type>("A", ndt::make_type<ndt::typevar_type>("S"))})) {}
 
     ndt::type resolve(base_callable *DYND_UNUSED(caller), char *DYND_UNUSED(data), call_graph &cg,
                       const ndt::type &dst_tp, size_t DYND_UNUSED(nsrc), const ndt::type *src_tp,

--- a/include/dynd/callables/dereference_callable.hpp
+++ b/include/dynd/callables/dereference_callable.hpp
@@ -13,7 +13,10 @@ namespace nd {
 
   class dereference_callable : public base_callable {
   public:
-    dereference_callable() : base_callable(ndt::type("(pointer[Any]) -> Any")) {}
+    dereference_callable()
+        : base_callable(ndt::make_type<ndt::callable_type>(
+              ndt::make_type<ndt::any_kind_type>(),
+              {ndt::make_type<ndt::pointer_type>(ndt::make_type<ndt::any_kind_type>())})) {}
 
     array alloc(const ndt::type *dst_tp) const { return empty(*dst_tp); }
 

--- a/include/dynd/callables/elwise_entry_callable.hpp
+++ b/include/dynd/callables/elwise_entry_callable.hpp
@@ -21,7 +21,10 @@ namespace nd {
       callable m_child;
       bool m_res_ignore;
 
-      elwise_entry_callable(bool res_ignore, const ndt::type tp = ndt::type("(...) -> Any"))
+      elwise_entry_callable(bool res_ignore,
+                            const ndt::type tp = ndt::make_type<ndt::callable_type>(
+                                ndt::make_type<ndt::any_kind_type>(), ndt::make_type<ndt::tuple_type>(true),
+                                ndt::make_type<ndt::struct_type>()))
           : base_callable(tp), m_res_ignore(res_ignore) {}
 
       elwise_entry_callable(const ndt::type &tp, const callable &child, bool res_ignore)

--- a/include/dynd/callables/field_access_callable.hpp
+++ b/include/dynd/callables/field_access_callable.hpp
@@ -13,7 +13,10 @@ namespace nd {
 
   class field_access_callable : public base_callable {
   public:
-    field_access_callable() : base_callable(ndt::type("({...}, field_name : string) -> Any")) {}
+    field_access_callable()
+        : base_callable(ndt::make_type<ndt::callable_type>(ndt::make_type<ndt::any_kind_type>(),
+                                                           {ndt::make_type<ndt::struct_type>(true)},
+                                                           {{ndt::make_type<dynd::string>(), "field_name"}})) {}
 
     ndt::type resolve(base_callable *DYND_UNUSED(caller), char *DYND_UNUSED(data), call_graph &cg,
                       const ndt::type &DYND_UNUSED(res_tp), size_t DYND_UNUSED(narg), const ndt::type *arg_tp,

--- a/include/dynd/callables/index_callable.hpp
+++ b/include/dynd/callables/index_callable.hpp
@@ -30,7 +30,10 @@ namespace nd {
       }
     };
 
-    index_callable() : base_callable(ndt::type("(Any, i: Any) -> Any")) {}
+    index_callable()
+        : base_callable(ndt::make_type<ndt::callable_type>(ndt::make_type<ndt::any_kind_type>(),
+                                                           {ndt::make_type<ndt::any_kind_type>()},
+                                                           {{ndt::make_type<ndt::any_kind_type>(), "i"}})) {}
 
     ndt::type resolve(base_callable *DYND_UNUSED(caller), char *DYND_UNUSED(data), call_graph &DYND_UNUSED(cg),
                       const ndt::type &DYND_UNUSED(dst_tp), size_t DYND_UNUSED(nsrc), const ndt::type *src_tp,
@@ -68,7 +71,10 @@ namespace nd {
       }
     };
 
-    index_callable() : base_callable(ndt::type("(Any, i: Any) -> Any")) {}
+    index_callable()
+        : base_callable(ndt::make_type<ndt::callable_type>(ndt::make_type<ndt::any_kind_type>(),
+                                                           {ndt::make_type<ndt::any_kind_type>()},
+                                                           {{ndt::make_type<ndt::any_kind_type>(), "i"}})) {}
 
     ndt::type resolve(base_callable *DYND_UNUSED(caller), char *DYND_UNUSED(data), call_graph &cg,
                       const ndt::type &dst_tp, size_t nsrc, const ndt::type *src_tp, size_t nkwd, const array *kwds,

--- a/include/dynd/callables/mean_callable.hpp
+++ b/include/dynd/callables/mean_callable.hpp
@@ -15,7 +15,10 @@ namespace nd {
     ndt::type m_tp;
 
   public:
-    mean_callable(const ndt::type &tp) : base_callable(ndt::type("(Any) -> Any")), m_tp(tp) {}
+    mean_callable(const ndt::type &tp)
+        : base_callable(ndt::make_type<ndt::callable_type>(ndt::make_type<ndt::any_kind_type>(),
+                                                           {ndt::make_type<ndt::any_kind_type>()})),
+          m_tp(tp) {}
 
     ndt::type resolve(base_callable *DYND_UNUSED(caller), char *DYND_UNUSED(data), call_graph &DYND_UNUSED(cg),
                       const ndt::type &dst_tp, size_t DYND_UNUSED(nsrc), const ndt::type *DYND_UNUSED(src_tp),

--- a/include/dynd/callables/range_callable.hpp
+++ b/include/dynd/callables/range_callable.hpp
@@ -7,6 +7,7 @@
 
 #include <dynd/callables/base_callable.hpp>
 #include <dynd/kernels/range_kernel.hpp>
+#include <dynd/types/option_type.hpp>
 
 namespace dynd {
 namespace nd {
@@ -18,7 +19,12 @@ namespace nd {
   class range_callable<ReturnElementType, std::enable_if_t<is_signed_integral<ReturnElementType>::value>>
       : public base_callable {
   public:
-    range_callable() : base_callable(ndt::type("(start: ?Scalar, stop: ?Scalar, step: ?Scalar) -> Fixed * Scalar")) {}
+    range_callable()
+        : base_callable(ndt::make_type<ndt::callable_type>(
+              ndt::make_type<ndt::fixed_dim_kind_type>(ndt::make_type<ndt::scalar_kind_type>()), {},
+              {{ndt::make_type<ndt::option_type>(ndt::make_type<ndt::scalar_kind_type>()), "start"},
+               {ndt::make_type<ndt::option_type>(ndt::make_type<ndt::scalar_kind_type>()), "stop"},
+               {ndt::make_type<ndt::option_type>(ndt::make_type<ndt::scalar_kind_type>()), "step"}})) {}
 
     ndt::type resolve(base_callable *DYND_UNUSED(caller), char *DYND_UNUSED(data), call_graph &cg,
                       const ndt::type &DYND_UNUSED(ret_tp), size_t DYND_UNUSED(narg),
@@ -81,7 +87,12 @@ namespace nd {
   class range_callable<ReturnElementType, std::enable_if_t<is_floating_point<ReturnElementType>::value>>
       : public base_callable {
   public:
-    range_callable() : base_callable(ndt::type("(start: ?Scalar, stop: Scalar, step: ?Scalar) -> Fixed * Scalar")) {}
+    range_callable()
+        : base_callable(ndt::make_type<ndt::callable_type>(
+              ndt::make_type<ndt::fixed_dim_kind_type>(ndt::make_type<ndt::scalar_kind_type>()), {},
+              {{ndt::make_type<ndt::option_type>(ndt::make_type<ndt::scalar_kind_type>()), "start"},
+               {ndt::make_type<ndt::option_type>(ndt::make_type<ndt::scalar_kind_type>()), "stop"},
+               {ndt::make_type<ndt::option_type>(ndt::make_type<ndt::scalar_kind_type>()), "step"}})) {}
 
     ndt::type resolve(base_callable *DYND_UNUSED(caller), char *DYND_UNUSED(data), call_graph &cg,
                       const ndt::type &DYND_UNUSED(ret_tp), size_t DYND_UNUSED(narg),
@@ -128,7 +139,11 @@ namespace nd {
   class range_dispatch_callable : public base_callable {
   public:
     range_dispatch_callable()
-        : base_callable(ndt::type("(start: ?Scalar, stop: ?Scalar, step: ?Scalar) -> Fixed * Scalar")) {}
+        : base_callable(ndt::make_type<ndt::callable_type>(
+              ndt::make_type<ndt::fixed_dim_kind_type>(ndt::make_type<ndt::scalar_kind_type>()), {},
+              {{ndt::make_type<ndt::option_type>(ndt::make_type<ndt::scalar_kind_type>()), "start"},
+               {ndt::make_type<ndt::option_type>(ndt::make_type<ndt::scalar_kind_type>()), "stop"},
+               {ndt::make_type<ndt::option_type>(ndt::make_type<ndt::scalar_kind_type>()), "step"}})) {}
 
     ndt::type resolve(base_callable *DYND_UNUSED(caller), char *DYND_UNUSED(data), call_graph &cg,
                       const ndt::type &ret_tp, size_t narg, const ndt::type *arg_tp, size_t nkwd, const array *kwds,

--- a/include/dynd/callables/take_dispatch_callable.hpp
+++ b/include/dynd/callables/take_dispatch_callable.hpp
@@ -7,6 +7,8 @@
 
 #include <dynd/callables/base_callable.hpp>
 #include <dynd/kernels/take_kernel.hpp>
+#include <dynd/types/ellipsis_dim_type.hpp>
+#include <dynd/types/typevar_dim_type.hpp>
 
 namespace dynd {
 namespace nd {
@@ -17,7 +19,11 @@ namespace nd {
   template <>
   class take_callable<bool_id> : public base_callable {
   public:
-    take_callable() : base_callable(ndt::type("(Any, Fixed * bool) -> Any")) {}
+    take_callable()
+        : base_callable(
+              ndt::make_type<ndt::callable_type>(ndt::make_type<ndt::any_kind_type>(),
+                                                 {ndt::make_type<ndt::any_kind_type>(),
+                                                  ndt::make_type<ndt::fixed_dim_kind_type>(ndt::make_type<bool>())})) {}
 
     ndt::type resolve(base_callable *DYND_UNUSED(caller), char *DYND_UNUSED(data), call_graph &cg,
                       const ndt::type &DYND_UNUSED(dst_tp), size_t DYND_UNUSED(nsrc), const ndt::type *src_tp,
@@ -63,7 +69,9 @@ namespace nd {
 
   class indexed_take_callable : public base_callable {
   public:
-    indexed_take_callable() : base_callable(ndt::type("(Any) -> Any")) {}
+    indexed_take_callable()
+        : base_callable(ndt::make_type<ndt::callable_type>(ndt::make_type<ndt::any_kind_type>(),
+                                                           {ndt::make_type<ndt::any_kind_type>()})) {}
 
     ndt::type resolve(base_callable *DYND_UNUSED(caller), char *DYND_UNUSED(data), call_graph &cg,
                       const ndt::type &dst_tp, size_t DYND_UNUSED(nsrc), const ndt::type *src_tp,
@@ -194,7 +202,11 @@ namespace nd {
 
   class take_dispatch_callable : public base_callable {
   public:
-    take_dispatch_callable() : base_callable(ndt::type("(Dims... * T, N * Ix) -> R * T")) {}
+    take_dispatch_callable()
+        : base_callable(ndt::make_type<ndt::callable_type>(
+              ndt::make_type<ndt::typevar_dim_type>("R", ndt::make_type<ndt::typevar_type>("T")),
+              {ndt::make_type<ndt::ellipsis_dim_type>("Dims", ndt::make_type<ndt::typevar_type>("T")),
+               ndt::make_type<ndt::typevar_dim_type>("N", ndt::make_type<ndt::typevar_type>("Ix"))})) {}
 
     ndt::type resolve(base_callable *DYND_UNUSED(caller), char *DYND_UNUSED(data), call_graph &cg,
                       const ndt::type &dst_tp, size_t nsrc, const ndt::type *src_tp, size_t nkwd, const array *kwds,

--- a/include/dynd/callables/view_callable.hpp
+++ b/include/dynd/callables/view_callable.hpp
@@ -13,14 +13,16 @@ namespace nd {
 
   class view_callable : public base_callable {
   public:
-    view_callable() : base_callable(ndt::type("(Any) -> Any")) {}
+    view_callable()
+        : base_callable(ndt::make_type<ndt::callable_type>(ndt::make_type<ndt::any_kind_type>(),
+                                                           {ndt::make_type<ndt::any_kind_type>()})) {}
 
     ndt::type resolve(base_callable *DYND_UNUSED(caller), char *DYND_UNUSED(data), call_graph &cg,
                       const ndt::type &DYND_UNUSED(dst_tp), size_t DYND_UNUSED(nsrc), const ndt::type *src_tp,
                       size_t DYND_UNUSED(nkwd), const array *DYND_UNUSED(kwds),
                       const std::map<std::string, ndt::type> &DYND_UNUSED(tp_vars)) {
-      cg.emplace_back([](kernel_builder &kb, kernel_request_t kernreq, char *DYND_UNUSED(data),const char *DYND_UNUSED(dst_arrmeta),
-                         size_t DYND_UNUSED(nsrc),
+      cg.emplace_back([](kernel_builder &kb, kernel_request_t kernreq, char *DYND_UNUSED(data),
+                         const char *DYND_UNUSED(dst_arrmeta), size_t DYND_UNUSED(nsrc),
                          const char *const *DYND_UNUSED(src_arrmeta)) { kb.emplace_back<view_kernel>(kernreq); });
 
       return src_tp[0];

--- a/include/dynd/compound_arithmetic.hpp
+++ b/include/dynd/compound_arithmetic.hpp
@@ -19,7 +19,11 @@ typedef type_sequence<uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, in
 
 template <template <typename, typename> class KernelType, typename TypeSequence>
 nd::callable make_compound_arithmetic() {
-  const ndt::type &tp = ndt::type("(Any, Any) -> Any");
+  const ndt::type &tp = ndt::make_type<ndt::callable_type>(
+      ndt::make_type<ndt::any_kind_type>(),
+      ndt::make_type<ndt::tuple_type>({ndt::make_type<ndt::any_kind_type>(), ndt::make_type<ndt::any_kind_type>()}),
+      ndt::make_type<ndt::struct_type>());
+
   auto dispatcher = nd::callable::make_all<KernelType, TypeSequence, TypeSequence>(
       [](const ndt::type &dst_tp, size_t DYND_UNUSED(nsrc), const ndt::type *src_tp) -> std::vector<ndt::type> {
         return {dst_tp, src_tp[0]};
@@ -38,9 +42,21 @@ nd::callable make_compound_arithmetic() {
                                                    ndt::make_type<dynd::complex<float>>(),
                                                    ndt::make_type<dynd::complex<double>>()};
 
-  dispatcher.insert(nd::get_elwise(ndt::type("(Scalar, Dim * Any) -> Any")));
-  dispatcher.insert(nd::get_elwise(ndt::type("(Dim * Any, Scalar) -> Any")));
-  dispatcher.insert(nd::get_elwise(ndt::type("(Dim * Any, Dim * Any) -> Any")));
+  dispatcher.insert(nd::get_elwise(ndt::make_type<ndt::callable_type>(
+      ndt::make_type<ndt::any_kind_type>(),
+      ndt::make_type<ndt::tuple_type>({ndt::make_type<ndt::scalar_kind_type>(),
+                                       ndt::make_type<ndt::dim_kind_type>(ndt::make_type<ndt::any_kind_type>())}),
+      ndt::make_type<ndt::struct_type>())));
+  dispatcher.insert(nd::get_elwise(ndt::make_type<ndt::callable_type>(
+      ndt::make_type<ndt::any_kind_type>(),
+      ndt::make_type<ndt::tuple_type>({ndt::make_type<ndt::dim_kind_type>(ndt::make_type<ndt::any_kind_type>()),
+                                       ndt::make_type<ndt::scalar_kind_type>()}),
+      ndt::make_type<ndt::struct_type>())));
+  dispatcher.insert(nd::get_elwise(ndt::make_type<ndt::callable_type>(
+      ndt::make_type<ndt::any_kind_type>(),
+      ndt::make_type<ndt::tuple_type>({ndt::make_type<ndt::dim_kind_type>(ndt::make_type<ndt::any_kind_type>()),
+                                       ndt::make_type<ndt::dim_kind_type>(ndt::make_type<ndt::any_kind_type>())}),
+      ndt::make_type<ndt::struct_type>())));
 
   return nd::make_callable<nd::multidispatch_callable<2>>(tp, dispatcher);
 }

--- a/include/dynd/type_registry.hpp
+++ b/include/dynd/type_registry.hpp
@@ -85,4 +85,12 @@ DYNDT_API type_id_t new_id(const char *name, type_id_t base_id);
  */
 DYNDT_API std::pair<type_id_t, const id_info *> lookup_id_by_name(const std::string &name);
 
+/**
+ * For type ids which are pre-allocated, but whose implementation isn't part of dynd.ndt, this function provides the
+ * mechanism to add the type construction and parsing.
+ */
+DYNDT_API void register_known_type_id_constructor(type_id_t id, ndt::type &&singleton_type,
+                                                  type_constructor_fn_t construct_type,
+                                                  low_level_type_args_parse_fn_t parse_type_args = nullptr);
+
 } // namespace dynd

--- a/include/dynd/types/base_type.hpp
+++ b/include/dynd/types/base_type.hpp
@@ -449,6 +449,13 @@ namespace ndt {
     /** Destructs any references or other state contained in the iterdata */
     virtual size_t iterdata_destruct(iterdata_common *iterdata, intptr_t ndim) const;
 
+    /**
+     * This function returns an nd::buffer with type constructor arguments, exactly as are accepted by the
+     * `construct_type` function which is part of the type registry. The two functions `get_type_constructor_args` and
+     * `construct_type` make DyND's types generically reconstructible.
+     */
+    virtual nd::buffer get_type_constructor_args() const;
+
     virtual bool match(const ndt::type &candidate_tp, std::map<std::string, ndt::type> &tp_vars) const;
 
     /**

--- a/include/dynd/types/callable_type.hpp
+++ b/include/dynd/types/callable_type.hpp
@@ -67,6 +67,9 @@ namespace ndt {
     callable_type(type_id_t new_id, const type &ret, const std::vector<type> &args)
         : callable_type(new_id, ret, args.size(), args.data()) {}
 
+    callable_type(type_id_t new_id, const type &ret, std::initializer_list<type> args)
+        : callable_type(new_id, ret, make_type<tuple_type>(args.size(), args.begin()), ndt::make_type<struct_type>()) {}
+
     callable_type(type_id_t new_id, const type &ret, std::initializer_list<type> args,
                   const std::vector<std::pair<type, std::string>> &kwds)
         : callable_type(new_id, ret, args.size(), args.begin(), kwds) {}

--- a/include/dynd/types/callable_type.hpp
+++ b/include/dynd/types/callable_type.hpp
@@ -12,7 +12,7 @@
 namespace dynd {
 namespace ndt {
 
-  class DYNDT_API callable_type : public base_type {
+  class DYND_API callable_type : public base_type {
     type m_return_type;
     // Always a tuple type containing the types for positional args
     type m_pos_tuple;
@@ -140,6 +140,8 @@ namespace ndt {
     bool match(const type &candidate_tp, std::map<std::string, type> &tp_vars) const;
 
     std::map<std::string, std::pair<ndt::type, const char *>> get_dynamic_type_properties() const;
+
+    static ndt::type construct_type(type_id_t id, const nd::buffer &args, const ndt::type &element_type);
   };
 
   template <typename R>
@@ -176,7 +178,7 @@ namespace ndt {
     static type equivalent() { return make_type<typename funcproto_of<R (T::*)(A...)>::type>(); }
   };
 
-  //  DYNDT_API type make_generic_funcproto(intptr_t nargs);
+  //  DYND_API type make_generic_funcproto(intptr_t nargs);
 
 } // namespace dynd::ndt
 } // namespace dynd

--- a/include/dynd/types/callable_type.hpp
+++ b/include/dynd/types/callable_type.hpp
@@ -144,6 +144,11 @@ namespace ndt {
 
     std::map<std::string, std::pair<ndt::type, const char *>> get_dynamic_type_properties() const;
 
+    /**
+     * This function is just here for now, but it seems useful to make it general. Then `get_type_constructor_args` and
+     * `construct_type` together make DyND's types generically reconstructible.
+     */
+    nd::buffer get_type_constructor_args() const;
     static ndt::type construct_type(type_id_t id, const nd::buffer &args, const ndt::type &element_type);
   };
 

--- a/include/dynd/types/substitute_typevars.hpp
+++ b/include/dynd/types/substitute_typevars.hpp
@@ -26,8 +26,9 @@ namespace ndt {
    */
   inline ndt::type substitute(const ndt::type &pattern, const std::map<std::string, ndt::type> &typevars, bool concrete)
   {
-    // This check for whether ``pattern`` is symbolic is put here in
-    // the inline function to avoid the call overhead in this case
+    // This check for whether ``pattern`` is symbolic is put here in the inline function to avoid the call overhead in
+    // this case. Callables are not symbolic themselves, but may contain symbolic types within them that need
+    // substitution.
     if (!pattern.is_symbolic() && pattern.get_id() != callable_id) {
       return pattern;
     }

--- a/include/dynd/unary_arithmetic.hpp
+++ b/include/dynd/unary_arithmetic.hpp
@@ -27,9 +27,14 @@ template <template <typename> class CallableType, template <typename> class Cond
 nd::callable make_unary_arithmetic() {
   dispatcher<1, nd::callable> dispatcher = nd::callable::make_all_if<CallableType, Condition, TypeSequence>(func_ptr);
 
-  const ndt::type &tp = ndt::type("(Any) -> Any");
-  dispatcher.insert(nd::get_elwise(ndt::type("(Fixed * Any) -> Any")));
-  dispatcher.insert(nd::get_elwise(ndt::type("(var * Any) -> Any")));
+  const ndt::type &tp =
+      ndt::make_type<ndt::callable_type>(ndt::make_type<ndt::any_kind_type>(), {ndt::make_type<ndt::any_kind_type>()});
+  dispatcher.insert(nd::get_elwise(ndt::make_type<ndt::callable_type>(
+      ndt::make_type<ndt::any_kind_type>(),
+      {ndt::make_type<ndt::fixed_dim_kind_type>(ndt::make_type<ndt::any_kind_type>())})));
+  dispatcher.insert(nd::get_elwise(
+      ndt::make_type<ndt::callable_type>(ndt::make_type<ndt::any_kind_type>(),
+                                         {ndt::make_type<ndt::var_dim_type>(ndt::make_type<ndt::any_kind_type>())})));
 
   return nd::make_callable<nd::multidispatch_callable<1>>(tp, dispatcher);
 }

--- a/src/dynd/assignment.cpp
+++ b/src/dynd/assignment.cpp
@@ -100,9 +100,19 @@ nd::callable make_assign() {
   dispatcher.insert(nd::make_callable<nd::assign_callable<double, dynd::string>>());
   dispatcher.insert(nd::make_callable<nd::assign_callable<ndt::tuple_type, ndt::tuple_type>>());
   dispatcher.insert(nd::make_callable<nd::assign_callable<ndt::struct_type, ndt::struct_type>>());
-  dispatcher.insert({nd::get_elwise(ndt::type("(Dim * Any) -> Scalar")),
-                     nd::get_elwise(ndt::type("(Scalar) -> Dim * Any")),
-                     nd::get_elwise(ndt::type("(Dim * Any) -> Dim * Any"))});
+  dispatcher.insert(
+      {nd::get_elwise(ndt::make_type<ndt::callable_type>(
+           ndt::make_type<ndt::scalar_kind_type>(),
+           ndt::make_type<ndt::tuple_type>({ndt::make_type<ndt::dim_kind_type>(ndt::make_type<ndt::any_kind_type>())}),
+           ndt::make_type<ndt::struct_type>())),
+       nd::get_elwise(ndt::make_type<ndt::callable_type>(
+           ndt::make_type<ndt::dim_kind_type>(ndt::make_type<ndt::any_kind_type>()),
+           ndt::make_type<ndt::tuple_type>({ndt::make_type<ndt::scalar_kind_type>()}),
+           ndt::make_type<ndt::struct_type>())),
+       nd::get_elwise(ndt::make_type<ndt::callable_type>(
+           ndt::make_type<ndt::dim_kind_type>(ndt::make_type<ndt::any_kind_type>()),
+           ndt::make_type<ndt::tuple_type>({ndt::make_type<ndt::dim_kind_type>(ndt::make_type<ndt::any_kind_type>())}),
+           ndt::make_type<ndt::struct_type>()))});
 
   return nd::make_callable<nd::multidispatch_callable<2>>(self_tp, dispatcher);
 }

--- a/src/dynd/index.cpp
+++ b/src/dynd/index.cpp
@@ -22,7 +22,8 @@ static std::vector<ndt::type> func_ptr(const ndt::type &DYND_UNUSED(dst_tp), siz
 } // unnamed namespace
 
 DYND_API nd::callable nd::index = nd::make_callable<nd::multidispatch_callable<1>>(
-    ndt::type("(Any, i: Any) -> Any"),
+    ndt::make_type<ndt::callable_type>(ndt::make_type<ndt::any_kind_type>(), {ndt::make_type<ndt::any_kind_type>()},
+                                       {{ndt::make_type<ndt::any_kind_type>(), "i"}}),
     nd::callable::make_all<nd::index_callable, type_sequence<int32_t, ndt::fixed_dim_kind_type>>(func_ptr));
 
 DYND_API nd::callable nd::take = nd::make_callable<nd::take_dispatch_callable>();

--- a/src/dynd/limits.cpp
+++ b/src/dynd/limits.cpp
@@ -17,11 +17,11 @@ static std::vector<ndt::type> func_ptr(const ndt::type &dst_tp, size_t DYND_UNUS
 }
 
 DYND_API nd::callable nd::limits::max = nd::make_callable<nd::multidispatch_callable<1>>(
-    ndt::type("() -> Any"),
+    ndt::make_type<ndt::callable_type>(ndt::make_type<ndt::any_kind_type>(), {}),
     nd::callable::make_all<nd::limits::max_callable, type_sequence<int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t,
                                                                    uint32_t, uint64_t, float, double>>(func_ptr));
 
 DYND_API nd::callable nd::limits::min = nd::make_callable<nd::multidispatch_callable<1>>(
-    ndt::type("() -> Any"),
+    ndt::make_type<ndt::callable_type>(ndt::make_type<ndt::any_kind_type>(), {}),
     nd::callable::make_all<nd::limits::min_callable, type_sequence<int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t,
                                                                    uint32_t, uint64_t, float, double>>(func_ptr));

--- a/src/dynd/math.cpp
+++ b/src/dynd/math.cpp
@@ -29,19 +29,22 @@ DYND_API nd::callable nd::tan = nd::functional::elwise(nd::functional::apply<dou
 DYND_API nd::callable nd::exp = nd::functional::elwise(nd::functional::apply<double (*)(double), &myexp>());
 
 DYND_API nd::callable nd::real = nd::functional::elwise(nd::make_callable<nd::multidispatch_callable<1>>(
-    ndt::type("(Scalar) -> Scalar"),
+    ndt::make_type<ndt::callable_type>(ndt::make_type<ndt::scalar_kind_type>(),
+                                       {ndt::make_type<ndt::scalar_kind_type>()}),
     nd::callable::make_all<nd::real_callable, type_sequence<dynd::complex<float>, dynd::complex<double>>>(
         [](const ndt::type &DYND_UNUSED(dst_tp), size_t DYND_UNUSED(nsrc),
            const ndt::type *src_tp) -> std::vector<ndt::type> { return {src_tp[0]}; })));
 
 DYND_API nd::callable nd::imag = nd::functional::elwise(nd::make_callable<nd::multidispatch_callable<1>>(
-    ndt::type("(Scalar) -> Scalar"),
+    ndt::make_type<ndt::callable_type>(ndt::make_type<ndt::scalar_kind_type>(),
+                                       {ndt::make_type<ndt::scalar_kind_type>()}),
     nd::callable::make_all<nd::imag_callable, type_sequence<dynd::complex<float>, dynd::complex<double>>>(
         [](const ndt::type &DYND_UNUSED(dst_tp), size_t DYND_UNUSED(nsrc),
            const ndt::type *src_tp) -> std::vector<ndt::type> { return {src_tp[0]}; })));
 
 DYND_API nd::callable nd::conj = nd::functional::elwise(nd::make_callable<nd::multidispatch_callable<1>>(
-    ndt::type("(Scalar) -> Scalar"),
+    ndt::make_type<ndt::callable_type>(ndt::make_type<ndt::scalar_kind_type>(),
+                                       {ndt::make_type<ndt::scalar_kind_type>()}),
     nd::callable::make_all<nd::conj_callable, type_sequence<dynd::complex<float>, dynd::complex<double>>>(
         [](const ndt::type &DYND_UNUSED(dst_tp), size_t DYND_UNUSED(nsrc),
            const ndt::type *src_tp) -> std::vector<ndt::type> { return {src_tp[0]}; })));

--- a/src/dynd/option.cpp
+++ b/src/dynd/option.cpp
@@ -30,10 +30,14 @@ nd::callable make_assign_na() {
       type_sequence<bool, int8_t, int16_t, int32_t, int64_t, int128, uint32_t, float, double, dynd::complex<float>,
                     dynd::complex<double>, void, dynd::bytes, dynd::string, ndt::fixed_dim_kind_type>>(
       assign_na_func_ptr);
-  children.insert(nd::get_elwise(ndt::type("() -> Fixed * Any")));
-  children.insert(nd::get_elwise(ndt::type("() -> var * Any")));
+  children.insert(nd::get_elwise(ndt::make_type<ndt::callable_type>(
+      ndt::make_type<ndt::fixed_dim_kind_type>(ndt::make_type<ndt::any_kind_type>()), {})));
+  children.insert(nd::get_elwise(
+      ndt::make_type<ndt::callable_type>(ndt::make_type<ndt::var_dim_type>(ndt::make_type<ndt::any_kind_type>()), {})));
 
-  return nd::make_callable<nd::multidispatch_callable<1>>(ndt::type("() -> ?Any"), children);
+  return nd::make_callable<nd::multidispatch_callable<1>>(
+      ndt::make_type<ndt::callable_type>(ndt::make_type<ndt::option_type>(ndt::make_type<ndt::any_kind_type>()), {}),
+      children);
 }
 
 nd::callable make_is_na() {
@@ -41,10 +45,16 @@ nd::callable make_is_na() {
       nd::is_na_callable,
       type_sequence<bool, int8_t, int16_t, int32_t, int64_t, int128, uint32_t, float, double, dynd::complex<float>,
                     dynd::complex<double>, void, dynd::bytes, dynd::string, ndt::fixed_dim_kind_type>>(is_na_func_ptr);
-  dispatcher.insert(nd::get_elwise(ndt::type("(Fixed * Any) -> Fixed * Any")));
-  dispatcher.insert(nd::get_elwise(ndt::type("(var * Any) -> var * Any")));
+  dispatcher.insert(nd::get_elwise(ndt::make_type<ndt::callable_type>(
+      ndt::make_type<ndt::fixed_dim_kind_type>(ndt::make_type<ndt::any_kind_type>()),
+      {ndt::make_type<ndt::fixed_dim_kind_type>(ndt::make_type<ndt::any_kind_type>())})));
+  dispatcher.insert(nd::get_elwise(
+      ndt::make_type<ndt::callable_type>(ndt::make_type<ndt::var_dim_type>(ndt::make_type<ndt::any_kind_type>()),
+                                         {ndt::make_type<ndt::var_dim_type>(ndt::make_type<ndt::any_kind_type>())})));
 
-  return nd::make_callable<nd::multidispatch_callable<1>>(ndt::type("(Any) -> Any"), dispatcher);
+  return nd::make_callable<nd::multidispatch_callable<1>>(
+      ndt::make_type<ndt::callable_type>(ndt::make_type<ndt::any_kind_type>(), {ndt::make_type<ndt::any_kind_type>()}),
+      dispatcher);
 }
 
 } // unnamed namespace

--- a/src/dynd/random.cpp
+++ b/src/dynd/random.cpp
@@ -9,6 +9,7 @@
 #include <dynd/callables/uniform_callable.hpp>
 #include <dynd/functional.hpp>
 #include <dynd/random.hpp>
+#include <dynd/types/typevar_type.hpp>
 
 using namespace std;
 using namespace dynd;
@@ -29,7 +30,10 @@ struct uniform_callable_alias {
 } // unnamed namespace
 
 DYND_API nd::callable nd::random::uniform = nd::functional::elwise(nd::make_callable<nd::multidispatch_callable<1>>(
-    ndt::type("(a: ?R, b: ?R) -> R"),
+    ndt::make_type<ndt::callable_type>(
+        ndt::make_type<ndt::typevar_type>("R"), {},
+        {{ndt::make_type<ndt::option_type>(ndt::make_type<ndt::typevar_type>("R")), "a"},
+         {ndt::make_type<ndt::option_type>(ndt::make_type<ndt::typevar_type>("R")), "b"}}),
     nd::callable::make_all<uniform_callable_alias<std::default_random_engine>::type,
                            type_sequence<int32_t, int64_t, uint32_t, uint64_t, float, double, dynd::complex<float>,
                                          dynd::complex<double>>>(func_ptr)));

--- a/src/dynd/types/base_type.cpp
+++ b/src/dynd/types/base_type.cpp
@@ -5,6 +5,8 @@
 
 #include <dynd/type.hpp>
 
+#include <dynd/buffer.hpp>
+
 using namespace std;
 using namespace dynd;
 
@@ -182,6 +184,13 @@ size_t ndt::base_type::iterdata_construct(iterdata_common *DYND_UNUSED(iterdata)
 size_t ndt::base_type::iterdata_destruct(iterdata_common *DYND_UNUSED(iterdata), intptr_t DYND_UNUSED(ndim)) const {
   stringstream ss;
   ss << "iterdata_destruct: dynd type " << type(this, true) << " is not uniformly iterable";
+  throw std::runtime_error(ss.str());
+}
+
+nd::buffer ndt::base_type::get_type_constructor_args() const {
+  stringstream ss;
+  ss << "get_type_constructor_args: dynd type " << type(this, true)
+     << " has not yet implemented get_type_constructor_args";
   throw std::runtime_error(ss.str());
 }
 

--- a/src/dynd/types/callable_type.cpp
+++ b/src/dynd/types/callable_type.cpp
@@ -3,6 +3,8 @@
 // BSD 2-Clause License, see LICENSE.txt
 //
 
+#include <dynd/array.hpp>
+#include <dynd/type_registry.hpp>
 #include <dynd/types/callable_type.hpp>
 #include <dynd/types/fixed_dim_type.hpp>
 #include <dynd/types/str_util.hpp>
@@ -207,4 +209,25 @@ std::map<std::string, std::pair<ndt::type, const char *>> ndt::callable_type::ge
   properties["return_type"] = {ndt::make_type<ndt::type_type>(), reinterpret_cast<const char *>(&m_return_type)};
 
   return properties;
+}
+
+ndt::type ndt::callable_type::construct_type(type_id_t DYND_UNUSED(id), const nd::buffer &args0,
+                                             const ndt::type &element_type) {
+  nd::array args = args0;
+  if (args.is_null()) {
+    throw invalid_argument("callable type constructor requires arguments");
+  }
+  if (!element_type.is_null()) {
+    throw invalid_argument("callable type is not a dimension type");
+  }
+
+  return ndt::make_type<ndt::callable_type>(element_type);
+}
+
+namespace {
+// Dynamically register the type constructor for `callable`
+const bool init_callable_type = []() -> bool {
+  dynd::register_known_type_id_constructor(callable_id, ndt::type(), &ndt::callable_type::construct_type);
+  return true;
+}();
 }

--- a/src/dynd/types/substitute_typevars.cpp
+++ b/src/dynd/types/substitute_typevars.cpp
@@ -3,7 +3,6 @@
 // BSD 2-Clause License, see LICENSE.txt
 //
 
-#include <dynd/types/callable_type.hpp>
 #include <dynd/types/cuda_device_type.hpp>
 #include <dynd/types/dim_fragment_type.hpp>
 #include <dynd/types/ellipsis_dim_type.hpp>
@@ -78,10 +77,13 @@ ndt::type ndt::detail::internal_substitute(const ndt::type &pattern, const std::
     return ndt::make_type<ndt::option_type>(
         ndt::substitute(pattern.extended<option_type>()->get_value_type(), typevars, concrete));
   case callable_id:
-    return ndt::make_type<ndt::callable_type>(
-        substitute(pattern.extended<callable_type>()->get_return_type(), typevars, concrete),
-        substitute(pattern.extended<callable_type>()->get_pos_tuple(), typevars, concrete),
-        substitute(pattern.extended<callable_type>()->get_kwd_struct(), typevars, concrete));
+    throw std::runtime_error("TODO: substitute type vars in callable");
+  /*
+  return ndt::make_type<ndt::callable_type>(
+      substitute(pattern.extended<callable_type>()->get_return_type(), typevars, concrete),
+      substitute(pattern.extended<callable_type>()->get_pos_tuple(), typevars, concrete),
+      substitute(pattern.extended<callable_type>()->get_kwd_struct(), typevars, concrete));
+      */
   case typevar_constructed_id: {
     map<std::string, ndt::type>::const_iterator it =
         typevars.find(pattern.extended<typevar_constructed_type>()->get_name());


### PR DESCRIPTION
The callable_type now registers itself into the type registry at initialization time. Some notes:

* The type registry is incomplete - construction from nd::buffer type constructor arguments is not implemented in general
* A mechanism for reconstructing types via these generic type constructor arguments is in place, but only used by the callable type. It functions within type variable substitution via this mechanism now, for example.
* Due to initialization order issues (registration of the callable type vs parsing), all creation of callable types in libdynd at startup time have been replaced with calls to ndt::make_type<ndt::callable_type>(...).