### PR TITLE
Fixes for Clang on Windows

### DIFF
--- a/include/dynd/kernels/assignment_kernels.hpp
+++ b/include/dynd/kernels/assignment_kernels.hpp
@@ -11,6 +11,7 @@
 #include <dynd/eval/eval_context.hpp>
 #include <dynd/fpstatus.hpp>
 #include <dynd/kernels/base_kernel.hpp>
+#include <dynd/kernels/base_strided_kernel.hpp>
 #include <dynd/kernels/cuda_launch.hpp>
 #include <dynd/kernels/tuple_assignment_kernels.hpp>
 #include <dynd/math.hpp>

--- a/include/dynd/kernels/base_kernel.hpp
+++ b/include/dynd/kernels/base_kernel.hpp
@@ -35,7 +35,13 @@ namespace nd {
     /**
      * Returns the child kernel immediately following this one.
      */
-    kernel_prefix *get_child() { return kernel_prefix::get_child(reinterpret_cast<SelfType *>(this)->size()); }
+    // This needs to be a template to avoid resolving this->size while
+    // SelfType is still an incomplete type, as would the case when SelfType
+    // is built using a CRTP idiom subclassing from base_kernel.
+    template <typename T = SelfType>
+    kernel_prefix *get_child() {
+      return kernel_prefix::get_child(reinterpret_cast<T *>(this)->size());
+    }
 
     template <size_t I>
     std::enable_if_t<I == 0, kernel_prefix *> get_child() {
@@ -48,7 +54,13 @@ namespace nd {
       return kernel_prefix::get_child(offsets[I - 1]);
     }
 
-    constexpr size_t size() const { return sizeof(SelfType); }
+    // This needs to be a template to avoid resolving sizeof(SelfType) while
+    // SelfType is still an incomplete type, as would the case when SelfType
+    // is built using a CRTP idiom subclassing from base_kernel.
+    template <typename T = SelfType>
+    constexpr size_t size() const {
+      return sizeof(T);
+    }
 
     /** Initializes just the kernel_prefix function member. */
     template <typename... ArgTypes>

--- a/include/dynd/type_sequence.hpp
+++ b/include/dynd/type_sequence.hpp
@@ -122,7 +122,7 @@ std::enable_if_t<(S::size() > 1), void> for_each(A &&... a) {
 
 template <typename S, size_t I, typename A0, typename... A>
 std::enable_if_t<S::size() == 1, void> for_each(A0 &&a0, A &&... a) {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
   a0.operator()<typename front<S>::type, I>(std::forward<A>(a)...);
 #else
   a0.template operator()<typename front<S>::type, I>(std::forward<A>(a)...);

--- a/src/dynd/assignment.cpp
+++ b/src/dynd/assignment.cpp
@@ -21,7 +21,7 @@ static std::vector<ndt::type> func_ptr(const ndt::type &dst_tp, size_t DYND_UNUS
 }
 
 template <typename VariadicType, template <typename, typename, VariadicType...> class T>
-struct DYND_API _bind {
+struct _bind {
   template <typename Type0, typename Type1>
   using type = T<Type0, Type1>;
 };

--- a/src/dynd/assignment.cpp
+++ b/src/dynd/assignment.cpp
@@ -21,7 +21,7 @@ static std::vector<ndt::type> func_ptr(const ndt::type &dst_tp, size_t DYND_UNUS
 }
 
 template <typename VariadicType, template <typename, typename, VariadicType...> class T>
-struct _bind {
+struct helper_bind {
   template <typename Type0, typename Type1>
   using type = T<Type0, Type1>;
 };
@@ -36,7 +36,7 @@ nd::callable make_assign() {
       {{ndt::make_type<ndt::option_type>(ndt::make_type<assign_error_mode>()), "error_mode"}});
 
   auto dispatcher =
-      nd::callable::make_all<_bind<assign_error_mode, nd::assign_callable>::type, numeric_types, numeric_types>(
+      nd::callable::make_all<helper_bind<assign_error_mode, nd::assign_callable>::type, numeric_types, numeric_types>(
           func_ptr);
   dispatcher.insert(nd::make_callable<nd::assign_callable<dynd::string, dynd::string>>());
   dispatcher.insert(nd::make_callable<nd::assign_callable<dynd::bytes, dynd::bytes>>());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,7 +14,14 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     # The gtest macro GTEST_SUPPRESS_UNREACHABLE_CODE_WARNING_BELOW_
     # doesn't work to suppress unreachable code warnings with recent versions
     # of clang, so disable that warning for the tests so they compile properly.
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGTEST_USE_OWN_TR1_TUPLE=1 -Wno-unused-value -Wno-ignored-attributes")
+    # Do this except when using clang on windows since the google test
+    # preprocessor defines prevent compiling with clang while using the
+    # MSVC standard library headers.
+    if(WIN32)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGTEST_USE_OWN_TR1_TUPLE=0 -Wno-unused-value -Wno-ignored-attributes")
+    else()
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGTEST_USE_OWN_TR1_TUPLE=1 -Wno-unused-value -Wno-ignored-attributes")
+    endif()
 else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGTEST_USE_OWN_TR1_TUPLE=1")
 endif()


### PR DESCRIPTION
I finally found the special sauce to get things working with clang on windows. This fixes a handful of related bugs. I also updated our vendored copy of googletest while working through the various issues that came up. It didn't end up being necessary, but I left it in since it's a positive move.

This worked for me with a version of clang/llvm built from the latest source (with MSVC 2017) as of a day or two ago, though there are a bunch of warnings that still need to be looked at. A very recent release of clang/llvm would likely work too, but I haven't tested that.

The only way thus far that I've actually been able to get the compiler to work with the CMake build system is to use clang-cl through ninja makefiles generated by CMake. Something like

    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -G "Ninja" ..

can be used to get that to work. This is totally experimental, but hopefully it'll make debugging template issues even easier.