### PR TITLE
Update Google Benchmark

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -6,6 +6,7 @@
 cmake_minimum_required(VERSION 2.6)
 project(benchmark_libdynd)
 
+set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL "Enable building the unit tests which depend on gtest.")
 add_subdirectory(${CMAKE_SOURCE_DIR}/thirdparty/benchmark ${CMAKE_CURRENT_BINARY_DIR}/thirdparty/benchmark)
 
 set(benchmarks_SRC

--- a/include/dynd/callables/base_reduction_callable.hpp
+++ b/include/dynd/callables/base_reduction_callable.hpp
@@ -198,13 +198,10 @@ namespace nd {
 
     template <size_t NArg>
     class reduction_callable<var_dim_id, NArg> : public base_reduction_callable {
-      void resolve(call_graph &cg, char *data) {
-        bool inner = reinterpret_cast<node_type *>(data)->inner;
-        bool broadcast = reinterpret_cast<node_type *>(data)->broadcast;
-        bool keepdim = reinterpret_cast<node_type *>(data)->keepdim;
-        cg.emplace_back([inner, broadcast, keepdim](kernel_builder &kb, kernel_request_t kernreq,
-                                                    char *DYND_UNUSED(data), const char *dst_arrmeta, size_t nsrc,
-                                                    const char *const *src_arrmeta) {
+      void resolve(call_graph &cg, char *DYND_UNUSED(data)) {
+        cg.emplace_back([](kernel_builder &kb, kernel_request_t kernreq,
+                           char *DYND_UNUSED(data), const char *dst_arrmeta, size_t nsrc,
+                           const char *const *src_arrmeta) {
           typedef reduction_kernel<ndt::var_dim_type, false, true, NArg> self_type;
           intptr_t root_ckb_offset = kb.size();
           kb.emplace_back<self_type>(


### PR DESCRIPTION
This updates Google benchmark, adds some additional handling of CMake settings related to that update, and also cleans up some unused variables that clang 5.0 was complaining about.