### PR TITLE
Route stderr to stdout in powershell command.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ build_script:
   - conda config --set always_yes yes
   - conda update conda
   - conda install conda-build
-  - ps: if(-not $env:APPVEYOR_PULL_REQUEST_NUMBER) { conda install anaconda-client }
+  - ps: if(-not $env:APPVEYOR_PULL_REQUEST_NUMBER) { conda install anaconda-client 2>&1 }
   - conda-build conda.recipe
 
 on_success:


### PR DESCRIPTION
It appears that at some point conda started writing more of its messages to stderr, which causes false failures when running it from within powershell. This should work around the issues that causes in our appveyor build script.