### PR TITLE
Yet another pass at fixing appveyor error.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ build_script:
   - conda config --set always_yes yes
   - conda update conda
   - conda install conda-build
-  - ps: if(-not $env:APPVEYOR_PULL_REQUEST_NUMBER) { conda install anaconda-client 2>&1 | %{ "$_" } }
+  - ps: if(-not $env:APPVEYOR_PULL_REQUEST_NUMBER) { cmd /C conda install anaconda-client "2>&1" }
   - conda-build conda.recipe
 
 on_success:


### PR DESCRIPTION
I haven't been able to reproduce this locally yet, so here's another pass at a fix.
I've temporarily removed the if-statement guard around installing anaconda-client so that (hopefully) the error will show up in this PR instead of requiring a push to master. Once installing anaconda-client is working again I can put the if statement guard back so that the code only runs on a push to master.