### PR TITLE
Further cleanup of Appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ build_script:
   - conda config --set always_yes yes
   - conda update conda
   - conda install conda-build
-  - ps: if(-not $env:APPVEYOR_PULL_REQUEST_NUMBER) { cmd /C conda install anaconda-client "2>&1" }
+  - if not defined APPVEYOR_PULL_REQUEST_NUMBER conda install anaconda-client
   - conda-build conda.recipe
 
 on_success:
@@ -42,4 +42,4 @@ on_success:
   # See also http://stackoverflow.com/a/2095623/1935144
   # Route command back through cmd to avoid the powershell bug entirely.
   # See https://connect.microsoft.com/PowerShell/feedback/details/645954
-  - ps: if(-not $env:APPVEYOR_PULL_REQUEST_NUMBER) { cmd /C anaconda --token $env:appveyor_token upload (conda build --output conda.recipe) --user dynd --channel dev "2>&1" }
+  - ps: if(-not $env:APPVEYOR_PULL_REQUEST_NUMBER) { cmd /C anaconda --token $env:appveyor_token upload (cmd /C conda build --output conda.recipe "2>&1") --user dynd --channel dev "2>&1" }


### PR DESCRIPTION
This cleans up the logic for installing anaconda-client only when building on master. It also works around another instance where a command is writing to stderr and making powershell think it failed in spite of completing successfully.