### PR TITLE
Stop using address sanitizer with clang in CI builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,8 @@ matrix:
         - make -j4 || exit 1
         - ./tests/test_libdynd
     - compiler: clang
-      env: -fsanitize=address
       script:
-        - cmake -DCMAKE_CXX_FLAGS="-fsanitize=address" ..
+        - cmake ..
         - make -j4 || exit 1
         - ./tests/test_libdynd
     - compiler: gcc


### PR DESCRIPTION
Local experimentation with a docker container matching the build
environment shows that the failure with the clang address sanitizing
build comes from a configuration issue with the compilers available
in the CI environment. Given that there is already an address sanitizing
build with gcc and that the issue is only exposed when building the
benchmark suite the most sensible solution appears to be just changing
the CI builds that are run.