### PR TITLE
Fix warnings with gcc 7 and gcc 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -165,7 +165,7 @@ matrix:
         - export CXX="g++-7"
         - mkdir build
         - pushd build
-        - cmake -DCMAKE_CXX_FLAGS="-Wno-error" ..
+        - cmake ..
     - language: objective-c
       os: osx
       osx_image: xcode6.4

--- a/appveyor/clang.bat
+++ b/appveyor/clang.bat
@@ -1,7 +1,8 @@
 @ECHO ON
 
-SET MINICONDA_ROOT=C:\Miniconda3-x64
-SET PATH=%MINICONDA_ROOT%;%MINICONDA_ROOT%\Scripts;%MINICONDA_ROOT%\Library\bin;%PATH%
+Powershell -Command "Start-FileDownload \"https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe\" C:\Miniconda.exe"
+C:\Miniconda.exe /S /D=C:\Py || exit /b 1
+SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
 
 conda config --set always_yes yes || exit /b 1
 

--- a/appveyor/conda.bat
+++ b/appveyor/conda.bat
@@ -1,11 +1,10 @@
 @ECHO ON
 
-IF "%PYTHON_ARCH%"=="x86_64" SET MINICONDA_ROOT=C:\Miniconda3-x64
-IF "%PYTHON_ARCH%"=="x86" SET MINICONDA_ROOT=C:\Miniconda3
-SET PATH=%MINICONDA_ROOT%;%MINICONDA_ROOT%\Scripts;%MINICONDA_ROOT%\Library\bin;%PATH%
+Powershell -Command "Start-FileDownload \"https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-$env:PYTHON_ARCH.exe\" C:\Miniconda.exe"
+C:\Miniconda.exe /S /D=C:\Py
+SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
 
 conda config --set always_yes yes || exit /b 1
-conda update --all || exit /b 1
 
 conda install conda-build || exit /b 1
 if not defined APPVEYOR_PULL_REQUEST_NUMBER conda install anaconda-client || exit /b 1

--- a/include/dynd/complex.hpp
+++ b/include/dynd/complex.hpp
@@ -19,6 +19,8 @@ public:
 
   complex(const T &re = 0.0, const T &im = 0.0) : m_real(re), m_imag(im) {}
 
+  complex(const complex<T> &rhs) = default;
+
   template <typename U>
   complex(const complex<U> &rhs) : m_real(static_cast<T>(rhs.m_real)), m_imag(static_cast<T>(rhs.m_imag)) {}
 
@@ -27,7 +29,10 @@ public:
   T real() const { return m_real; }
   T imag() const { return m_imag; }
 
-  complex<T> &operator=(const complex<T> &rhs) {
+  complex<T> &operator=(const complex<T> &rhs) = default;
+
+  template <typename U>
+  complex<T> &operator=(const complex<U> &rhs) {
     m_real = rhs.m_real;
     m_imag = rhs.m_imag;
 

--- a/include/dynd/config.hpp
+++ b/include/dynd/config.hpp
@@ -72,8 +72,18 @@
 
 // Ignore erroneous maybe-uninitizlized
 // warnings on a given line or code block.
-#define DYND_IGNORE_MAYBE_UNINITIALIZED _Pragma("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
+#define DYND_IGNORE_MAYBE_UNINITIALIZED                     \
+_Pragma("GCC diagnostic push")                              \
+_Pragma("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
 #define DYND_END_IGNORE_MAYBE_UNINITIALIZED _Pragma("GCC diagnostic pop")
+
+// Ignore erroneous warnings about unnecessary parentheses.
+#if __GNUC__ >= 8 && !defined(__clang__)
+#define DYND_IGNORE_UNNECESSARY_PARENTHESES         \
+_Pragma("GCC diagnostic push")                      \
+_Pragma("GCC diagnostic ignored \"-Wparentheses\"")
+#define DYND_END_IGNORE_UNNECESSARY_PARENTHESES _Pragma("GCC diagnostic pop")
+#endif
 
 #define DYND_CONSTEXPR constexpr
 
@@ -545,6 +555,11 @@ typedef uintptr_t offset_t;
 #ifndef DYND_IGNORE_MAYBE_UNINITIALIZED
 #define DYND_IGNORE_MAYBE_UNINITIALIZED
 #define DYND_END_IGNORE_MAYBE_UNINITIALIZED
+#endif
+
+#ifndef DYND_IGNORE_UNNECESSARY_PARENTHESES
+#define DYND_IGNORE_UNNECESSARY_PARENTHESES
+#define DYND_END_IGNORE_UNNECESSARY_PARENTHESES
 #endif
 
 // Check endian: define DYND_BIG_ENDIAN if big endian, otherwise assume little

--- a/include/dynd/float128.hpp
+++ b/include/dynd/float128.hpp
@@ -250,9 +250,9 @@ public:
 
   float128 operator-() const { return float128(-static_cast<double>(*this)); }
 
-  bool operator!() const { return ((0x7fffffffffffffffULL | m_hi) == 0) && (m_lo == 0); }
+  bool operator!() const { return ((0x7fffffffffffffffULL & m_hi) | m_lo) == 0; }
 
-  explicit operator bool() const { return (m_lo != 0) || ((0x7fffffffffffffffULL | m_hi) != 0); }
+  explicit operator bool() const { return ((0x7fffffffffffffffULL & m_hi) | m_lo) != 0; }
 };
 
 template <>

--- a/include/dynd/float16.hpp
+++ b/include/dynd/float16.hpp
@@ -92,7 +92,7 @@ public:
 
   explicit operator uint128() const;
 
-  explicit operator float32() const
+  operator float32() const
   {
     DYND_IGNORE_MAYBE_UNINITIALIZED
     return halfbits_to_float(m_bits);

--- a/include/dynd/float16.hpp
+++ b/include/dynd/float16.hpp
@@ -65,7 +65,7 @@ public:
 
   explicit float16(const float128 &value);
 
-  float16(const float16 &rhs) : m_bits(rhs.m_bits) {}
+  float16(const float16 &rhs) = default;
 
   explicit operator int8() const { return static_cast<int8>(halfbits_to_float(m_bits)); }
 
@@ -92,7 +92,7 @@ public:
 
   explicit operator uint128() const;
 
-  operator float32() const
+  explicit operator float32() const
   {
     DYND_IGNORE_MAYBE_UNINITIALIZED
     return halfbits_to_float(m_bits);

--- a/include/dynd/kernels/base_kernel.hpp
+++ b/include/dynd/kernels/base_kernel.hpp
@@ -110,8 +110,11 @@ namespace nd {
     static const volatile char *DYND_USED(ir);
   };
 
+// Ignore a false positive warning from gcc 8 about unnecessary parentheses.
+DYND_IGNORE_UNNECESSARY_PARENTHESES
   template <typename PrefixType, typename SelfType>
   const volatile char *DYND_USED((base_kernel<PrefixType, SelfType>::ir)) = NULL;
+DYND_END_IGNORE_UNNECESSARY_PARENTHESES
 
   template <typename SelfType>
   struct base_kernel<SelfType> : base_kernel<kernel_prefix, SelfType> {};

--- a/include/dynd/math.hpp
+++ b/include/dynd/math.hpp
@@ -224,14 +224,14 @@ complex<T> exp(complex<T> z) {
     if (isfinite(i)) {
       ret = complex<T>(x * c, x * s);
     } else {
-      ret = complex<T>(_nan<T>(NULL), copysign(_nan<T>(NULL), i));
+      ret = complex<T>(std::numeric_limits<T>::quiet_NaN(), copysign(std::numeric_limits<T>::quiet_NaN(), i));
     }
   } else if (isnan(r)) {
     // r is nan
     if (i == 0) {
       ret = complex<T>(r, 0);
     } else {
-      ret = complex<T>(r, copysign(_nan<T>(NULL), i));
+      ret = complex<T>(r, copysign(std::numeric_limits<T>::quiet_NaN(), i));
     }
   } else {
     // r is +- inf
@@ -245,7 +245,7 @@ complex<T> exp(complex<T> z) {
         ret = complex<T>(r * c, r * s);
       } else {
         // x = +inf, y = +-inf | nan
-        ret = complex<T>(r, _nan<T>(NULL));
+        ret = complex<T>(r, std::numeric_limits<T>::quiet_NaN());
       }
     } else {
       if (isfinite(i)) {

--- a/src/dynd/type.cpp
+++ b/src/dynd/type.cpp
@@ -905,8 +905,8 @@ bool dynd::is_lossless_assignment(const ndt::type &dst_tp, const ndt::type &src_
       break;
     case float_kind_id:
       switch (dst_tp.get_base_id()) {
-      case bool_kind_id:
-      case int_kind_id:
+      case bool_kind_id: break;
+      case int_kind_id: break;
       case uint_kind_id:
         return false;
       case float_kind_id:
@@ -918,11 +918,12 @@ bool dynd::is_lossless_assignment(const ndt::type &dst_tp, const ndt::type &src_
       default:
         break;
       }
+      break;
     case complex_kind_id:
       switch (dst_tp.get_base_id()) {
-      case bool_kind_id:
-      case int_kind_id:
-      case uint_kind_id:
+      case bool_kind_id: break;
+      case int_kind_id: break;
+      case uint_kind_id: break;
       case float_kind_id:
         return false;
       case complex_kind_id:
@@ -932,12 +933,13 @@ bool dynd::is_lossless_assignment(const ndt::type &dst_tp, const ndt::type &src_
       default:
         break;
       }
+      break;
     case string_kind_id:
       switch (dst_tp.get_base_id()) {
-      case bool_kind_id:
-      case int_kind_id:
-      case uint_kind_id:
-      case float_kind_id:
+      case bool_kind_id: break;
+      case int_kind_id: break;
+      case uint_kind_id: break;
+      case float_kind_id: break;
       case complex_kind_id:
         return false;
       case bytes_kind_id:
@@ -945,6 +947,7 @@ bool dynd::is_lossless_assignment(const ndt::type &dst_tp, const ndt::type &src_
       default:
         break;
       }
+      break;
     case bytes_kind_id:
       return dst_tp.get_base_id() == bytes_kind_id && dst_tp.get_data_size() == src_tp.get_data_size();
     default:

--- a/src/dynd/type.cpp
+++ b/src/dynd/type.cpp
@@ -905,8 +905,10 @@ bool dynd::is_lossless_assignment(const ndt::type &dst_tp, const ndt::type &src_
       break;
     case float_kind_id:
       switch (dst_tp.get_base_id()) {
-      case bool_kind_id: break;
-      case int_kind_id: break;
+      case bool_kind_id:
+	return false;
+      case int_kind_id:
+	return false;
       case uint_kind_id:
         return false;
       case float_kind_id:
@@ -921,9 +923,12 @@ bool dynd::is_lossless_assignment(const ndt::type &dst_tp, const ndt::type &src_
       break;
     case complex_kind_id:
       switch (dst_tp.get_base_id()) {
-      case bool_kind_id: break;
-      case int_kind_id: break;
-      case uint_kind_id: break;
+      case bool_kind_id:
+	return false;
+      case int_kind_id:
+	return false;
+      case uint_kind_id:
+	return false;
       case float_kind_id:
         return false;
       case complex_kind_id:
@@ -936,10 +941,14 @@ bool dynd::is_lossless_assignment(const ndt::type &dst_tp, const ndt::type &src_
       break;
     case string_kind_id:
       switch (dst_tp.get_base_id()) {
-      case bool_kind_id: break;
-      case int_kind_id: break;
-      case uint_kind_id: break;
-      case float_kind_id: break;
+      case bool_kind_id:
+	return false;
+      case int_kind_id:
+	return false;
+      case uint_kind_id:
+        return false;
+      case float_kind_id:
+        return false;
       case complex_kind_id:
         return false;
       case bytes_kind_id:

--- a/src/dynd/types/substitute_typevars.cpp
+++ b/src/dynd/types/substitute_typevars.cpp
@@ -156,6 +156,9 @@ ndt::type ndt::detail::internal_substitute(const ndt::type &pattern, const std::
           substitute(pattern.extended<typevar_constructed_type>()->get_arg(), typevars, concrete));
     }
 #endif
+    stringstream ss;
+    ss << "No constructed id for dynd type var " << pattern << " was available";
+    throw invalid_argument(ss.str());
   }
   case typevar_id: {
     map<std::string, ndt::type>::const_iterator it = typevars.find(pattern.extended<typevar_type>()->get_name());


### PR DESCRIPTION
This fixes various warnings that show up when using gcc 7 and 8. In particular it closes https://github.com/libdynd/libdynd/issues/1323.