### PR TITLE
Address anaconda-client upload issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -115,9 +115,9 @@ matrix:
     - compiler: gcc
       env: CONDA=true
       before_install:
-        - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh
-        - bash Miniconda-latest-Linux-x86_64.sh -b
-        - export PATH=$HOME/miniconda2/bin:$PATH
+        - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+        - bash Miniconda3-latest-Linux-x86_64.sh -b
+        - export PATH=$HOME/miniconda3/bin:$PATH
         - conda install --yes conda-build jinja2 cmake
       before_script:
         - export CC="gcc-4.9"


### PR DESCRIPTION
For some reason uploading the libdynd conda package fails because a piece of setuptools isn't getting found properly. I'm investigating solutions here and will go ahead and merge when that's fixed.