### PR TITLE
Switch to refcounted arrays by default in ABI

### DIFF
--- a/include/dynd/abi/array.h
+++ b/include/dynd/abi/array.h
@@ -1,6 +1,7 @@
 #if !defined(DYND_ABI_ARRAY_H)
 #define DYND_ABI_ARRAY_H
 
+#include "dynd/abi/metadata.h"
 #include "dynd/abi/resource.h"
 #include "dynd/abi/version.h"
 
@@ -10,20 +11,30 @@
 #endif
 struct dynd_type;
 
+// Similar to dynd_allocated,
+// but brings in the additional metadata needed
+// to manage type-specific destructors.
+#define dynd_array_header DYND_ABI(array_header)
+struct dynd_array_header {
+  dynd_allocated allocated;
+  void *base;
+  dynd_type *type;
+};
+
 #define dynd_array DYND_ABI(array)
 struct dynd_array {
-  dynd_resource resource;
-  // Note: This may be an owned reference to the
-  // type used here. That's expected to be the
-  // most common case, however whether or not
-  // the reference is owned, the actual in-memory
-  // layout is the same and that's what is specified
-  // here.
+  // This resource encapsulates the allocation
+  // of this particular buffer as well as
+  // any additional custom deallocation required
+  // by the type. Note: the type-specific deallocation
+  // routine will only be called if the base pointer
+  // is null.
   // TODO: the corresponding C++ interface
   // should automatically tie the lifetime of
   // this reference to the lifetime of this
   // metadata buffer.
-  dynd_type *type;
+  dynd_refcounted refcount;
+  dynd_array_header header;
 };
 // Note: the arrmeta specified by this type
 // should be laid out in memory immediately
@@ -31,13 +42,12 @@ struct dynd_array {
 // inside the buffer managed by the resource
 // in the array struct.
 
-// If the array itself
-// is refcounted, the refcount appears
-// in-memory before the resource.
-#define dynd_refcounted_array DYND_ABI(refcounted_array)
-struct dynd_refcounted_array {
-  dynd_refcounted resource;
-  dynd_type *type;
+// Same as previous, but without reference counting.
+// The layout is kept intentionally compatible.
+#define dynd_array_ref DYND_ABI(array)
+struct dynd_array_ref {
+  dynd_resource resource;
+  dynd_array_header header;
 };
 
 #endif // !defined(DYND_ABI_ARRAY_H)


### PR DESCRIPTION
Also make sure there's enough metadata for type-specific destructors to get called if needed.